### PR TITLE
[autotuner] Rewrite reduction sizing around live resources

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -31,11 +31,8 @@ from .triton import TritonH100MultiMatmulHeuristic
 from .triton import TritonMatmulReductionEpilogueHeuristic
 from .triton import TritonNarrowReductionHeuristic
 from .triton import TritonPointwiseSeedHeuristic
+from .triton import TritonReductionHeuristic
 from .triton import TritonSkinnyGemmHeuristic
-from .triton import TritonStandardReductionHeuristicSM90
-from .triton import TritonStandardReductionHeuristicSM100
-from .triton import TritonUserTiledReductionHeuristicSM90
-from .triton import TritonUserTiledReductionHeuristicSM100
 
 if TYPE_CHECKING:
     import torch
@@ -78,10 +75,7 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
         TritonB200FormulaMatmulHeuristic,
         TritonB200MultiMatmulHeuristic,
         TritonMatmulReductionEpilogueHeuristic,
-        TritonStandardReductionHeuristicSM90,
-        TritonStandardReductionHeuristicSM100,
-        TritonUserTiledReductionHeuristicSM90,
-        TritonUserTiledReductionHeuristicSM100,
+        TritonReductionHeuristic,
         TritonNarrowReductionHeuristic,
         TritonPointwiseSeedHeuristic,
     ),

--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import logging
+import math
 from operator import itemgetter
 from typing import TYPE_CHECKING
 from typing import Any
@@ -41,13 +41,10 @@ if TYPE_CHECKING:
     from ...autotuner.config_spec import MatmulFact
     from ...autotuner.config_spec import PointwiseElementwiseFact
     from ...autotuner.config_spec import ReductionDescriptor
-    from ...autotuner.config_spec import ReductionKernelFact
     from ..compile_environment import CompileEnvironment
     from ..device_ir import DeviceIR
     from .common import HardwareTarget
 
-
-log = logging.getLogger(__name__)
 
 # Stand-in ceiling for an arch with no TMEM (sm90): makes a TMEM fit-check vacuously true.
 _INF = float("inf")
@@ -866,7 +863,10 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
 
     @classmethod
     def _full_block_map(
-        cls, env: CompileEnvironment, block_sizes: list[int]
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        overrides: Mapping[int, int] | None = None,
     ) -> dict[int, int]:
         """``{block_id: per-program extent}`` for EVERY block id, under the config whose
         ``block_sizes`` list is ``block_sizes``.
@@ -879,6 +879,9 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         * an ``hl.grid`` axis is a fixed source of 1 -- one row per program -- even though
           the axis's *extent* is the whole grid;
         * a specialized axis is fixed at its full extent.
+
+        ``overrides`` supplies candidate-owned widths, such as compiler-rolled reductions,
+        that must take precedence over their fixed source.
 
         Inferring these from "does it have a ``block_sizes`` entry" gets the middle case
         backwards, and the error is not small: reading a pinned outer grid axis at its full
@@ -903,6 +906,8 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         for slot in range(len(spec.block_sizes)):
             bs = cast("BlockSizeSpec", spec.block_sizes[slot])
             out[bs.block_id] = block_sizes[slot]
+        if overrides is not None:
+            out.update(overrides)
         # Everything else is fixed by its source: an ``hl.grid`` axis is one row per program
         # even though its extent is the whole grid, and a specialized / persistent-reduction
         # axis is its full extent.
@@ -4383,241 +4388,141 @@ def _primary_descriptor_selected(env: CompileEnvironment) -> ReductionDescriptor
 def _is_standard_reduction(pd: ReductionDescriptor) -> bool:
     """Standard vs user-tiled discriminator, keyed on the primary reduction's category: standard
     iff FULL_SLICE (a rolled rdim or a materialized full-width rdim the roller declined) or
-    FULL_GRID; user-tiled is the USER_TILE case (the rdim is a ``block_sizes`` entry).
+    FULL_GRID. USER_TILE and FIXED_TILE are sequential user-written tiles; the former emits a
+    ``block_sizes`` value while the latter has no reduction-size knob to emit.
     """
     return pd.category in FULL_EXTENT_CATEGORIES
 
 
-class _TileAllocation(NamedTuple):
-    """The result of :meth:`_TritonReductionSeedBase.size_reduction_tiles` — the single
-    per-co-residency-group budget allocation that produces every tile size the seed emits.
+@dataclass(frozen=True)
+class _ReductionCandidate:
+    """One complete temporary reduction seed state."""
 
-    Per co-residency group the allocator forms a register/byte capacity, then seats axes in
-    priority order (full-extent reductions → user-tile reductions → grid-tile reductions → the
-    grid-M rows), each taking first crack then floored by the budget remaining after everything
-    already seated. Earlier groups' assignments are held fixed as inputs to later groups; the
-    non-reduction loops are sized last against the remaining headroom. Floor-vs-resident and
-    collapse-vs-widen are budget outcomes, not separate branches.
+    block_sizes: tuple[int, ...]
+    reduction_widths: tuple[tuple[int, int], ...]
 
-    - ``block_sizes``: the full ``Config.block_sizes`` vector — every tunable axis sized.
-    - ``block_sizes_red_values``: ``{block_id -> r_block}`` for every tunable sized reduction that
-      rides a ``block_sizes`` slot (the user-tiled track's reductions, including its primary). The
-      standard track's rolled primary rides ``reduction_loops`` instead, surfaced via
-      ``primary_r_block``/``persistent`` — so the name is about the emission target (block_sizes
-      slot), not "secondary". Emission routing is the only standard-vs-user difference; every
-      reduction gets a size from the same budget.
-    - ``primary_r_block`` / ``persistent``: the primary reduction's chunk + persistence verdict
-      (the byte budget admits the full extent AND the row is re-read).
-    - ``rolled_loop_sizes``: ``{block_id -> (r_block, persistent)}`` for every rolled reduction axis
-      OTHER than the primary (a kernel that rolls >1 reduction into separate ``reduction_loops``
-      subgraphs). Empty unless a kernel rolls more than one reduction.
-    """
+    def reduction_width(self, block_id: int) -> int:
+        for candidate_block_id, width in self.reduction_widths:
+            if candidate_block_id == block_id:
+                return width
+        raise KeyError(block_id)
+
+
+class _ReductionResources(NamedTuple):
+    """Independent inputs for candidate-resolved resource calculations."""
+
+    peak_live_bytes: int
+    num_warps: int
+    launch_waves: tuple[float | None, ...]
+
+
+class _LivenessTileAllocation(NamedTuple):
+    """Final liveness-based allocation and its kernel-wide warp count."""
 
     block_sizes: list[int]
-    block_sizes_red_values: dict[int, int]
     primary_r_block: int
-    persistent: bool
-    rolled_loop_sizes: dict[int, tuple[int, bool]]
+    rolled_loop_sizes: dict[int, int]
+    num_warps: int
 
 
-class _TritonReductionSeedBase(AutotunerHeuristic):
-    """Shared base for the two Triton inner-reduction seed heuristics. Both consume the Stage-1
-    ``ReductionKernelFact`` through ONE budget allocator (:meth:`size_reduction_tiles`); the
-    subclasses differ ONLY in how they map the allocation onto knobs (EMISSION routing):
+class TritonReductionHeuristic(AutotunerHeuristic):
+    """Candidate-resolved Triton reduction seed for H100 and B200.
 
-    - **standard** (:class:`TritonStandardReductionHeuristicSM90`): Helion rolls the rdim into a
-      ``reduction_loops`` loop, so the primary reduction's size lands on that knob.
-    - **user-tiled** (:class:`TritonUserTiledReductionHeuristicSM90`): the user hand-writes the
-      ``hl.tile`` loop, so each reduction axis is a ``block_sizes`` entry.
+    One allocator resolves every sized reduction and ordinary block axis against the kernel's
+    live-step timeline. The primary reduction category affects only final config routing:
+    compiler-rolled reductions emit through ``reduction_loops``, while user-written mutable
+    ``hl.tile`` reductions emit through ``block_sizes`` and fixed tiles emit no size knob.
 
-    Each track has a sm90/H100 class (``*SM90``) and a sm100/B200 subclass (``*SM100``); the
-    conservative upstream fallback for unclaimed hardware lives in the standalone
-    :class:`TritonNarrowReductionHeuristic`. Every concrete class gates its own hardware in
-    ``is_eligible`` (via ``cls.HARDWARE_TARGETS``), so ``get_seed_config`` never declines for the
-    wrong GPU. Not registered; only the concrete subclasses are.
+    The conservative fallback for other hardware remains the standalone
+    :class:`TritonNarrowReductionHeuristic`.
     """
 
+    name = "triton_reduction"
     backend = "triton"
     CACHE_SPECIALIZATION_FACTS = frozenset({"device_num_sm"})
-    # Widen the declared type so the sm100 subclass can retarget it (the base is sm90-only).
-    HARDWARE_TARGETS: ClassVar[tuple[HardwareTarget, ...]] = (("cuda", "sm90"),)
-    # Promote the reduction seed to the compiler default (autotune off) for every tuned track
-    # that derives from this base -- sm90/H100 AND sm100/B200. The narrow fallback
-    # (TritonNarrowReductionHeuristic) does NOT derive from this base, so it stays unpromoted.
+    HARDWARE_TARGETS: ClassVar[tuple[HardwareTarget, ...]] = (
+        ("cuda", "sm90"),
+        ("cuda", "sm100"),
+    )
+    # Promote the tuned reduction seed to the compiler default (autotune off) on H100 and B200.
+    # The narrow fallback is a separate class and stays unpromoted.
     # This is safe because the seed only emits valid configs: it materializes through
     # ``_materialize_config`` (an illegal ``pid_type`` is repaired to a legal persistent type),
     # ``ReductionLoopSpec._normalize`` floors a degenerate looped chunk of 1, and the reduction
     # roller refuses to roll a scan-containing reduction (which would drop the scan's chunk carry).
     promote_seed_to_default = True
 
-    # ----- THE BUDGET (a register/byte capacity; everything else is a per-axis desire) -----
-    # Per-program persistent byte ceiling: the group's resident working set — the sum over its live
-    # tiles of ``itemsize × ∏(tile dims)`` — must fit this, else a tile floors. ~240 KiB, just over
-    # H100 SMEM.
-    ROW_PERSIST_MAX_BYTES = 245760
-    # The tighter byte ceiling for a CARRIED reduction (an accumulator whose last dim is the rdim,
-    # e.g. kl_div/jsd's ``[grid_M, R]``): that tile is held resident across the whole inner loop
-    # rather than streamed-and-released, a heavier steady-state pressure, so the chunk sharing SRAM
-    # with it wants a smaller extent. Half of ROW_PERSIST. This is the only place the
-    # carried-vs-streamed distinction lives.
-    CARRIED_PERSIST_MAX_BYTES = 245760 // 2
-    # The PERSISTENCE-HOLD ceiling — the byte watermark under which a re-read row may hold its FULL
-    # extent (vs the chunk budget, which sizes a streamed/looped tile). Only ``row_reread AND
-    # carried_2d_count == 0`` reductions reach the hold, so a carried tile never loosens. The true
-    # cutoff is not a single faithful byte budget (e.g. softmax flips at ~128-160 KiB, cross_entropy
-    # at ~256-384 KiB with the same footprint), so these are two calibrated buckets selected by
-    # ``_has_store_only_row_reread`` — a coarse proxy for whether persist's avoided HBM re-read lives
-    # in the small L2 working set (tighter ceiling) or the large register file (looser ceiling):
-    #  - no store-only re-read (cross_entropy/sum): reuse is register-resident, so holding a high
-    #    watermark wins far out. 3x ROW.
-    #  - a store-only re-reading pass exists (softmax/rms/layer_norm/welford): the row is re-swept
-    #    from L2, so past ~a few KiB/row streaming beats holding it. ~1.2x ROW.
-    PERSIST_HOLD_MAX_BYTES = 3 * 245760
-    USER_TILE_PERSIST_HOLD_MAX_BYTES = 294912
-    # Looped-fallback reduction chunk (pow2) for a row that does not fit the persistent budget.
-    LOOPED_CHUNK = 16384
-    # Occupancy floor for the grid-M widen: keep the post-tile grid >= num_sm * MIN_WAVES so
-    # collapsing a fan-out sibling never under-occupies (mirrors the pointwise seed's MIN_WAVES).
-    MIN_WAVES = 8
-    # Diminishing-returns ceiling on the grid-M widen (rows/program): a memory-bound reduction does
-    # not amortize past a handful of batched rows, and widening only trades away grid parallelism.
-    # Bounds the widen the byte/occupancy caps alone would permit on a small-row huge-M kernel. Does
-    # NOT bound the grad-param COLLAPSE branch (which intentionally batches rows to cut the
-    # cross-grid finalize) nor a raised autotuner_min floor (max(floor, ...) still wins).
-    WIDEN_MAX_ROWS = 8
+    # Candidate capacity, occupancy, and work-exchange policy.
+    NORMAL_LIVE_BUDGET = 240 * 1024
+    PERSISTENCE_BUDGET_MULTIPLIER = 1.5
+    COALESCING_SENSITIVE_FLOOR = 128
+    MIN_NUM_WARPS = 1
+    MAX_NUM_WARPS = 32
+    REGISTER_OVERHEAD_PER_THREAD = 10
+    REGISTER_ALLOCATION_GRANULARITY_PER_THREAD = 8
+    WARP_DESCENT_REGISTER_ESTIMATE_SCALE = 0.70
+    MAX_REGISTERS_PER_THREAD = 255
+    SPILL_PRESSURE_THRESHOLD = 1.0
+    WARP_DESCENT_MIN_LIVE_BYTES = 8 * 1024
+    WARP_DESCENT_CALIBRATION_MAX_SPILL = 0.50
+    REGISTER_FILE_REGISTERS_PER_SM = 65536
+    MAX_THREADS_PER_SM = 2048
+    MAX_CTAS_PER_SM = 32
+    GRID_RESIDENCY_GAIN_THRESHOLD = 1.5
+    FULL_GRID_SPLIT_GAIN_THRESHOLD = 2.0
+    SERIAL_LOOP_COST_ALPHA = 1.1
+    MAX_BLOCK_ADJUSTMENT_PASSES = 20
 
-    # num_warps ramp: keyed on the primary reduction extent (see ``_num_warps``).
-
-    # =============================== Stage-1 fact accessors ================================= #
+    # Structural fact accessors.
     @classmethod
-    def _non_reduction_loop_ids(cls, spec: ConfigSpec) -> tuple[int, ...]:
-        """The non-reduction user-tiled loops (welford's normalize pass) -- sized as a separate
-        apply pass, NOT reduction-sized. Read off ``ReductionKernelFact.non_reduction_loop_block_ids``.
-        """
+    def _has_floor_batched_nonresident_grid(
+        cls,
+        env: CompileEnvironment,
+    ) -> bool:
+        """Whether a nonresident grid axis is already batched at its legal floor."""
+        spec = env.config_spec
         kf = spec.reduction_kernel_fact
         assert kf is not None
-        return kf.non_reduction_loop_block_ids
-
-    @classmethod
-    def _resident_block_ids(cls, spec: ConfigSpec) -> set[int]:
-        """The union of block_ids that appear (as a resolved dim) in some co-residency group's
-        live-tile set — the "is this axis register-resident?" test. The single definition of
-        residency, shared by the grid-M widen (a resident grid axis widens into the byte budget; a
-        non-resident one is reduced away -> collapses) and ``_has_reduced_away_grid``. Empty if no
-        kernel fact (a bare-spec unit test)."""
-        kf = spec.reduction_kernel_fact
-        if kf is None:
-            return set()
-        resident: set[int] = set()
-        for g in kf.coresidency_groups:
-            for tile in g.live_tiles:
-                resident.update(d for d in tile if d is not None)
-        return resident
-
-    @classmethod
-    def _has_reduced_away_grid(cls, spec: ConfigSpec) -> bool:
-        """True iff some grid axis is REDUCED AWAY — in no live tile, and batching more than one
-        row per program — i.e. a sequential cross-grid reduction finalized by a later ``.sum(0)``
-        (the grad-parameter M-collapse idiom). False if no kernel fact.
-
-        Both clauses are needed: non-residency alone also covers a ``block_size=1`` axis used as a
-        scalar index, which batches nothing, so consumers get neither cross-warp work to spread nor
-        a row that reloads from L2. A kernel property, not a target one, so both arches share it
-        and tune the RESPONSE instead.
-        """
-        kf = spec.reduction_kernel_fact
-        if kf is None:
-            return False
-        resident = cls._resident_block_ids(spec)
-        return any(
-            g not in resident and cls._m_axis_block_size(spec, g) > 1
-            for g in kf.grid_axis_block_ids
-        )
-
-    @staticmethod
-    def _max_group_footprint(
-        kf: ReductionKernelFact,
-        axis: int,
-        footprint_terms: Callable[
-            [tuple[tuple[int | None, ...], ...], int], tuple[int, int]
-        ],
-        default_tiles: tuple[tuple[int | None, ...], ...],
-    ) -> tuple[int, int]:
-        """The ``(scale, flat)`` footprint for sizing ``axis``, taken from the heaviest co-residency
-        group that spans it (largest ``scale``). A reduction axis is tiled the same width
-        everywhere, so it must fit the worst group that uses it. ``flat`` comes from that same max
-        group (mixing scale/flat across groups breaks the chunk solve). If the axis spans no group's
-        tiles (a bare-spec / degenerate case), fall back to ``default_tiles`` (this descriptor's own
-        group)."""
-        best = None
-        for g in kf.coresidency_groups:
-            if not any(axis in t for t in g.live_tiles):
-                continue
-            scale, flat = footprint_terms(g.live_tiles, axis)
-            if best is None or scale > best[0]:
-                best = (scale, flat)
-        return best if best is not None else footprint_terms(default_tiles, axis)
-
-    @classmethod
-    def _has_store_only_row_reread(
-        cls, spec: ConfigSpec, pd: ReductionDescriptor
-    ) -> bool:
-        """True iff the primary reduction's row tensor is ALSO loaded by a store-only pass — a load
-        of that tensor that feeds a store and no reduction (``stores_fed and not reductions_fed``).
-
-        This selects the persist-hold ceiling. The physical question it stands in for is whether
-        persistence's benefit (avoiding the row's HBM re-read) is served from the small L2 working
-        set (tighter ceiling) or the large register file (looser ceiling). That quantity is not
-        cleanly recoverable from any seed-time signal — kernels with the same byte footprint, load
-        count, and output width can flip persist->chunk at ~2x-different points — so this is an
-        ADMITTED PROXY: it classifies the tested kernels correctly but is not a faithful measure of
-        the underlying cache-tier question and can be fooled (e.g. a 2-pass kernel whose 2nd pass
-        reduces instead of storing re-reads the row identically but reads as False). If a kernel
-        regresses on the persist ceiling, this proxy is the first suspect.
-
-        Detected from the walker ``MemoryOpFact`` list (no re-walk). Not the same as
-        ``non_reduction_loop_block_ids`` (a 2nd pass that reduces over the same axis leaves that set
-        empty). Empty facts / no kernel fact -> False."""
-        facts = spec.memory_op_facts
-        if not facts:
-            return False
-        red_tensors = {
-            f.tensor_name
-            for f in facts
-            if f.kind == "load"
-            and f.tensor_name is not None
-            and any(ax == pd.block_id for ax, _ in f.reductions_fed)
+        resident = {
+            block_id
+            for step in kf.live_tile_steps
+            for tile in step
+            if tile.kind != "global"
+            for block_id in tile.dim_block_ids
+            if block_id is not None
         }
-        if not red_tensors:
-            return False
-        return any(
-            f.kind == "load"
-            and f.tensor_name in red_tensors
-            and f.stores_fed
-            and not f.reductions_fed
-            for f in facts
-        )
+        tunable = spec.block_sizes.valid_block_ids()
+        default = spec._base_default_config()
+        for block_id in kf.grid_axis_block_ids:
+            if block_id in resident:
+                continue
+            if block_id in tunable:
+                block = cast(
+                    "BlockSizeSpec",
+                    spec.block_sizes[spec.block_sizes.block_id_to_index(block_id)],
+                )
+                if cls._block_floor(block) > 1:
+                    return True
+                continue
+            info = env.block_sizes[block_id]
+            value = info.block_size_source.from_config(default, info)
+            if isinstance(value, torch.SymInt):
+                expression = env.config_value_expressions.get(_symint_sympy_expr(value))
+                if expression is not None:
+                    value = expression.evaluate(default)
+            if isinstance(value, (int, torch.SymInt)) and env.size_hint(value) > 1:
+                return True
+        return False
 
-    @classmethod
-    def non_reduction_loop_block_cap(
-        cls, spec: ConfigSpec, pd: ReductionDescriptor
-    ) -> int | None:
-        """Optional element cap for a non-reduction apply loop. ``None`` = no extra cap beyond the
-        shared ``loop_budget`` (sm90/H100 unchanged); a subclass may return a smaller budget."""
-        return None
-
-    # =============================== scalar levers (outside the budget) ===================== #
-    @classmethod
-    def _num_warps(cls, pd: ReductionDescriptor) -> int:
-        """Scale num_warps with the reduction extent (pow2): rnumel <= 1024 -> 4, <= 4096 -> 8,
-        <= 16384 -> 16, > 16384 -> 32."""
-        rnumel = pd.size_hint
-        warps32_min_elems = 16384
-        if rnumel > warps32_min_elems:
+    # Scalar levers.
+    @staticmethod
+    def _num_warps_for_reduction_width(width: int) -> int:
+        """Draft warps for useful lane-parallel reduction work."""
+        if width > 16384:
             return 32
-        if rnumel <= 1024:
+        if width <= 1024:
             return 4
-        if rnumel <= 4096:
+        if width <= 4096:
             return 8
         return 16
 
@@ -4627,463 +4532,618 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
         large-M shapes rather than emitting an invalid ``block_size=1``)."""
         return max(1, bs_spec.min_size, bs_spec.autotuner_min)
 
-    @classmethod
-    def _m_axis_block_size(cls, spec: ConfigSpec, mbid: int) -> int:
-        """Seed block size (rows/program) for one M-axis (grid) block_id, whether or not it is a
-        tunable ``block_sizes`` entry. A grid-PINNED axis (``hl.tile(M, block_size=1)``) has no
-        tunable slot and lives solely on the program grid -- read its FIXED value off
-        ``env.block_sizes`` (the grid-pinned-M idiom every vLLM quant kernel uses)."""
-        if mbid in spec.block_sizes.valid_block_ids():
-            m_idx = spec.block_sizes.block_id_to_index(mbid)
-            return cls._block_floor(cast("BlockSizeSpec", spec.block_sizes[m_idx]))
-        from ...runtime.config import Config as _Config
-        from ..compile_environment import CompileEnvironment
+    @staticmethod
+    def _reread_eviction_policies(
+        env: CompileEnvironment,
+        reread_slot: int | None,
+    ) -> list[str] | None:
+        """Keep one re-read input in L2 and evict the other load slots first."""
+        n = env.config_spec.load_eviction_policies.length
+        if reread_slot is None or not 0 <= reread_slot < n:
+            return None
+        policy = ["first"] * n
+        policy[reread_slot] = "last"
+        return policy
 
-        env = CompileEnvironment.current()
-        value = env.block_sizes[mbid].from_config(_Config(block_sizes=[]))
-        if isinstance(value, (int, torch.SymInt)):
-            return max(1, int(value))
-        log.warning(
-            "reduction seed: M-axis block_id=%s resolved to a non-static block size %r; "
-            "falling back to block_size=1 (this should not happen for a pinned grid axis)",
-            mbid,
-            value,
-        )
-        return 1
-
+    # ======================= candidate-resolved liveness allocator ====================== #
     @classmethod
-    def _eviction_policies(
+    def _reduction_candidate_block_map(
         cls,
         env: CompileEnvironment,
-        kind: str,
-        reread_slot: int | None = None,
-    ) -> list[str] | None:
-        """``load_eviction_policies`` list (spec length); None leaves the autotuner default.
-        - ``"stream"`` — single streamed input (read once): every load -> ``'first'`` (frees L2).
-        - ``"reread"`` — the row is re-read across passes: its first load -> ``'last'``
-          (L2-resident), rest -> ``'first'``. ``reread_slot`` from ``reread_eviction_index``."""
-        n = env.config_spec.load_eviction_policies.length
-        if n <= 0:
-            return None
-        if kind == "stream":
-            return ["first"] * n
-        if kind == "reread":
-            if reread_slot is None or not 0 <= reread_slot < n:
-                return None
-            policy = ["first"] * n
-            policy[reread_slot] = "last"
-            return policy
-        return None
+        candidate: _ReductionCandidate,
+    ) -> dict[int, int]:
+        """Resolve every block axis under one complete reduction candidate."""
+        return TritonH100MatmulHeuristic._full_block_map(
+            env,
+            list(candidate.block_sizes),
+            dict(candidate.reduction_widths),
+        )
 
-    # ================================ THE BUDGET ALLOCATOR ============================== #
     @classmethod
-    def size_reduction_tiles(
+    def _reduction_peak_live_bytes(
+        cls,
+        env: CompileEnvironment,
+        candidate: _ReductionCandidate,
+    ) -> int:
+        """Return peak register-live bytes across the complete timeline."""
+        kf = env.config_spec.reduction_kernel_fact
+        assert kf is not None
+        block_of = cls._reduction_candidate_block_map(env, candidate)
+        peak_bytes = 0
+        for step in kf.live_tile_steps:
+            step_bytes = 0
+            for tile in step:
+                if tile.kind == "global":
+                    continue
+                tile_bytes = TritonH100MatmulHeuristic._resolve_tile_bytes(
+                    tile,
+                    block_of,
+                )
+                step_bytes += tile_bytes
+            peak_bytes = max(peak_bytes, step_bytes)
+        return peak_bytes
+
+    @classmethod
+    def _reduction_launch_waves(
+        cls,
+        env: CompileEnvironment,
+        candidate: _ReductionCandidate,
+        num_sm: int,
+    ) -> tuple[float | None, ...]:
+        """Fractional launch supply for each independently executing root."""
+        spec = env.config_spec
+        grid_fact = spec.kernel_grid_fact
+        roots = grid_fact.grid_groups if grid_fact is not None else ()
+        if not roots:
+            roots = (tuple(spec.grid_block_ids),)
+        block_of = cls._reduction_candidate_block_map(env, candidate)
+        waves: list[float | None] = []
+        for root in roots:
+            ctas = 1
+            known = True
+            for block_id in root:
+                extent = TritonH100MatmulHeuristic._axis_extent(env, block_id)
+                if extent is None:
+                    known = False
+                    break
+                ctas *= max(1, -(-extent // max(1, block_of[block_id])))
+            waves.append(ctas / max(1, num_sm) if known else None)
+        return tuple(waves) or (None,)
+
+    @classmethod
+    def _reduction_resources(
+        cls,
+        env: CompileEnvironment,
+        candidate: _ReductionCandidate,
+        num_warps: int,
+        num_sm: int,
+    ) -> _ReductionResources:
+        """Resolve the independent resource inputs for one candidate."""
+        peak_bytes = cls._reduction_peak_live_bytes(env, candidate)
+        warps = max(cls.MIN_NUM_WARPS, min(cls.MAX_NUM_WARPS, num_warps))
+        return _ReductionResources(
+            peak_live_bytes=peak_bytes,
+            num_warps=warps,
+            launch_waves=cls._reduction_launch_waves(env, candidate, num_sm),
+        )
+
+    @classmethod
+    def _reduction_estimated_registers_per_thread(
+        cls,
+        resources: _ReductionResources,
+    ) -> int:
+        """Estimate logical registers/thread from peak liveness and warps."""
+        threads = 32 * resources.num_warps
+        bytes_per_register_file_lane = max(1, threads * 4)
+        logical_registers_per_thread = (
+            resources.peak_live_bytes + bytes_per_register_file_lane - 1
+        ) // bytes_per_register_file_lane
+        return logical_registers_per_thread + cls.REGISTER_OVERHEAD_PER_THREAD
+
+    @classmethod
+    def _reduction_spill_pressure(
+        cls,
+        resources: _ReductionResources,
+    ) -> float:
+        """Return the uncapped register estimate relative to the hardware limit."""
+        return (
+            cls._reduction_estimated_registers_per_thread(resources)
+            / cls.MAX_REGISTERS_PER_THREAD
+        )
+
+    @classmethod
+    def _reduction_resource_resident_ctas_per_sm(
+        cls,
+        resources: _ReductionResources,
+        *,
+        register_estimate_scale: float = 1.0,
+    ) -> int:
+        """Return CTA residency from registers, threads, and architecture limits."""
+        threads = 32 * resources.num_warps
+        estimated_registers = math.ceil(
+            cls._reduction_estimated_registers_per_thread(resources)
+            * register_estimate_scale
+        )
+        granularity = cls.REGISTER_ALLOCATION_GRANULARITY_PER_THREAD
+        allocated_registers = min(
+            cls.MAX_REGISTERS_PER_THREAD,
+            max(
+                granularity,
+                -(-estimated_registers // granularity) * granularity,
+            ),
+        )
+        allocated_register_bytes = allocated_registers * threads * 4
+        register_limit = max(
+            1,
+            (cls.REGISTER_FILE_REGISTERS_PER_SM * 4)
+            // max(1, allocated_register_bytes),
+        )
+        return max(
+            1,
+            min(
+                cls.MAX_CTAS_PER_SM,
+                cls.MAX_THREADS_PER_SM // threads,
+                register_limit,
+            ),
+        )
+
+    @classmethod
+    def _reduction_effective_resident_ctas_per_sm(
+        cls,
+        resources: _ReductionResources,
+        *,
+        register_estimate_scale: float = 1.0,
+    ) -> tuple[float, ...]:
+        """Cap resource residency by each root's available launch work."""
+        resource_residency = cls._reduction_resource_resident_ctas_per_sm(
+            resources,
+            register_estimate_scale=register_estimate_scale,
+        )
+        return tuple(
+            float(resource_residency)
+            if waves is None
+            else min(float(resource_residency), waves)
+            for waves in resources.launch_waves
+        )
+
+    @classmethod
+    def _choose_reduction_num_warps(
+        cls,
+        env: CompileEnvironment,
+        candidate: _ReductionCandidate,
+        pd: ReductionDescriptor,
+        num_sm: int,
+        *,
+        allow_descent: bool = True,
+    ) -> int:
+        """Draft warps from reduction width, relieve spills, then retain only useful warps."""
+        parallel_width = max(width for _, width in candidate.reduction_widths)
+        requested_warps = cls._num_warps_for_reduction_width(parallel_width)
+        if pd.size_hint > 16384 and parallel_width >= 8192:
+            requested_warps = cls.MAX_NUM_WARPS
+        ladder = (1, 2, 4, 8, 16, 32)
+        warps = next(
+            (
+                value
+                for value in ladder
+                if value >= requested_warps and value >= cls.MIN_NUM_WARPS
+            ),
+            cls.MAX_NUM_WARPS,
+        )
+        warps = min(warps, cls.MAX_NUM_WARPS)
+        while warps < cls.MAX_NUM_WARPS:
+            resources = cls._reduction_resources(env, candidate, warps, num_sm)
+            if cls._reduction_spill_pressure(resources) <= cls.SPILL_PRESSURE_THRESHOLD:
+                break
+            warps = min(cls.MAX_NUM_WARPS, warps * 2)
+        if not allow_descent:
+            return warps
+
+        draft_resources = cls._reduction_resources(env, candidate, warps, num_sm)
+        draft_warp_score = cls._reduction_effective_warp_score(draft_resources)
+        target_warps = (
+            min(32.0, draft_warp_score)
+            if draft_resources.peak_live_bytes >= cls.WARP_DESCENT_MIN_LIVE_BYTES
+            else draft_warp_score
+        )
+        descent_register_scale = (
+            cls.WARP_DESCENT_REGISTER_ESTIMATE_SCALE
+            if warps >= 16 and parallel_width <= 8192
+            else 1.0
+        )
+        for trial_warps in ladder:
+            if trial_warps >= warps:
+                break
+            trial_resources = cls._reduction_resources(
+                env, candidate, trial_warps, num_sm
+            )
+            trial_spill = cls._reduction_spill_pressure(trial_resources)
+            if trial_spill > cls.SPILL_PRESSURE_THRESHOLD:
+                continue
+            trial_register_scale = (
+                descent_register_scale
+                if trial_spill <= cls.WARP_DESCENT_CALIBRATION_MAX_SPILL
+                else 1.0
+            )
+            if (
+                cls._reduction_effective_warp_score(
+                    trial_resources,
+                    register_estimate_scale=trial_register_scale,
+                )
+                + 1e-9
+                >= target_warps
+            ):
+                return trial_warps
+        return warps
+
+    @classmethod
+    def _reduction_effective_cta_score(
+        cls,
+        resources: _ReductionResources,
+    ) -> float:
+        """Conservative useful-concurrency score across independent roots."""
+        return min(cls._reduction_effective_resident_ctas_per_sm(resources))
+
+    @classmethod
+    def _reduction_effective_warp_score(
+        cls,
+        resources: _ReductionResources,
+        *,
+        register_estimate_scale: float = 1.0,
+    ) -> float:
+        """Conservative resident-warp score across independently executing roots."""
+        hardware_warp_slots = cls.MAX_THREADS_PER_SM // 32
+        return min(
+            min(float(hardware_warp_slots), value * resources.num_warps)
+            for value in cls._reduction_effective_resident_ctas_per_sm(
+                resources,
+                register_estimate_scale=register_estimate_scale,
+            )
+        )
+
+    @classmethod
+    def size_reduction_tiles_liveness(
         cls,
         env: CompileEnvironment,
         spec: ConfigSpec,
-        device_ir: DeviceIR,
         pd: ReductionDescriptor,
-    ) -> _TileAllocation:
-        """THE allocator: a per-co-residency-group BUDGET over the group's ACTUAL resident live
-        tiles (``CoResidencyGroup.live_tiles``) assigns every tile size, in TWO passes.
-
-        The footprint is faithful: ``resident_bytes = itemsize × Σ over the group's live tiles of
-        ∏(tile dim widths)``. Sizing an axis A splits that sum into ``(scale, flat)`` — tiles
-        CONTAINING A scale with ``block(A)``, tiles WITHOUT A are constant — and the budget test is
-        ``itemsize × (scale × block(A) + flat) <= budget`` (the constant term SUBTRACTED, never
-        divided). No ``num_live`` multiplier, no separate accumulator sum, no feature-extent
-        reconstruction: the live tiles ARE the resident set (accumulators captured inline at real
-        shape, scalar carries as rank-1 constant tiles).
-
-        For each co-residency group:
-
-          PASS 1 — seat the reductions with the grid axes pinned at their FLOOR (full-extent ->
-            user-tile -> grid-tile). A re-read full-slice raises its floor to the full extent
-            (PERSISTENCE) iff its resident tile fits the budget; else it chunks to
-            ``min(LOOPED_CHUNK, byte budget, extent)``. A carried reduction (kl_div/norm-bwd) sizes
-            against the tighter ``CARRIED_PERSIST`` budget.
-
-          PASS 2 — the grid-M rows take the REMAINDER. A grid axis that is RESIDENT (appears in some
-            live tile -> its row co-occupies the working set) WIDENS into the byte remainder (capped
-            by occupancy + WIDEN_MAX_ROWS + extent) and FLOORS when the budget is spent. A grid axis
-            in NO live tile is REDUCED AWAY (a sequential cross-grid ``.sum(0)`` finalize, holds no
-            bytes) -> its floor raises to ``grid_rows / num_sm`` (collapse the finalize to ~1 SM
-            wave). Both are pure per-axis MEMBERSHIP outcomes — no ``cdiv`` branch, no recognizer.
-
-        Then the non-reduction loops LAST (welford's normalize, rms_norm_per_block's groups_per_row)
-        — a separate pass co-resident with nothing in the group, sized against its own headroom.
-
-        EMISSION is the ONLY standard-vs-user difference: a reduction's computed size is WRITTEN to
-        ``reduction_loops`` (rolled/standard) or a ``block_sizes`` slot (user-tiled). Every
-        reduction gets a size from the SAME budget; the split is codegen routing, not a different
-        way to compute.
-        """
+    ) -> _LivenessTileAllocation:
+        """Size every reduction-kernel axis from complete candidate liveness."""
         from ..._utils import next_power_of_2 as _np2
-        from ..._utils import prev_power_of_2 as _pp2
         from ...runtime import get_num_sm
 
-        num_sm = max(1, get_num_sm(env.device))
-        occ_floor = num_sm * cls.MIN_WAVES
-        itemsize = max(1, pd.itemsize)
-        valid = set(spec.block_sizes.valid_block_ids())
         kf = spec.reduction_kernel_fact
         assert kf is not None
-        grid_ids = set(kf.grid_axis_block_ids)
-        non_reduction_loop_ids = set(cls._non_reduction_loop_ids(spec))
-        reduction_ids = {d.block_id for d in kf.reductions}
+        assert kf.live_tile_steps, "reduction sizing requires a complete live timeline"
 
-        # Extent (pow2-padded) per block_id, read from STORED hints. The reason these maps exist at
-        # all is TESTING: the reduction unit tests call ``get_seed_config`` on a bare spec OUTSIDE an
-        # active CompileEnvironment, where ``env.block_sizes[bid]`` is unavailable — so extents must
-        # come from data already persisted on the spec/fact. A reduction's extent is its descriptor
-        # ``size_hint``; a tunable axis's is its ``BlockSizeSpec.size_hint``. The third fallback
-        # (``env.block_sizes`` — a non-tunable pinned grid / materialized feature) is LIVE-PATH ONLY:
-        # in the no-env test path every axis is in ``_spec_extent`` or ``_desc_extent`` by
-        # construction, so that branch never executes (and would raise NoCurrentEnvironment if it did).
-        _desc_extent = {d.block_id: d.size_hint for d in kf.reductions}
-        _spec_extent = {
-            cast("BlockSizeSpec", spec.block_sizes[i]).block_id: cast(
-                "BlockSizeSpec", spec.block_sizes[i]
-            ).size_hint
-            for i in range(len(spec.block_sizes))
+        num_sm = max(1, get_num_sm(env.device))
+        specs = [
+            cast("BlockSizeSpec", spec.block_sizes[index])
+            for index in range(len(spec.block_sizes))
+        ]
+        slot_of = {block.block_id: index for index, block in enumerate(specs)}
+        floors = {block.block_id: cls._block_floor(block) for block in specs}
+        maximums = {block.block_id: _np2(max(1, block.size_hint)) for block in specs}
+        blocks = [floors[block.block_id] for block in specs]
+
+        descriptors_by_block: dict[int, list[ReductionDescriptor]] = {}
+        for descriptor in kf.reductions:
+            if descriptor.category in SIZED_REDUCTION_CATEGORIES:
+                descriptors_by_block.setdefault(descriptor.block_id, []).append(
+                    descriptor
+                )
+        rolled_ids = {
+            reduction_loop.block_ids[0] for reduction_loop in spec.reduction_loops
         }
+        raw_reduction_extents = {
+            block_id: max(descriptor.size_hint for descriptor in descriptors)
+            for block_id, descriptors in descriptors_by_block.items()
+        }
+        reduction_widths: dict[int, int] = {}
+        reduction_floors: dict[int, int] = {}
+        reduction_maximums: dict[int, int] = {}
+        fixed_reduction_ids: set[int] = set()
 
-        def extent_of(bid: int) -> int:
-            if bid in _spec_extent:
-                return _np2(_spec_extent[bid])
-            if bid in _desc_extent:
-                return _np2(_desc_extent[bid])
-            return _np2(env.block_sizes[bid].size_hint())
-
-        # The persistence/chunk budget a reduction sizes against — the only place the regime enters
-        # (the footprint formula is identical everywhere; only this number changes). Two budgets,
-        # keyed PER-REDUCTION on whether THIS reduction carries a >=2-D tile:
-        #  - CARRIED (``carried_2d_count > 0``): the reduction's own ``[grid_M, R]`` accumulator is
-        #    held resident across the whole inner loop, a heavier steady-state pressure than a
-        #    streamed row -> the tighter budget -> smaller chunk.
-        #  - STREAMED (``carried_2d_count == 0``): the ROW budget. Per-reduction, not kernel-wide: a
-        #    grad-parameter norm-bwd carries its N accumulator on the materialized N axis, but the
-        #    co-resident inner tile it sizes is itself non-carried and wants the looser ROW budget.
-        #    A per-row scalar carry (e.g. welford mean/M2 ``[grid_M]``) has c2d=0, so it stays STREAMED.
-        def persist_budget_for(d: ReductionDescriptor) -> int:
-            return (
-                cls.CARRIED_PERSIST_MAX_BYTES
-                if d.carried_2d_count > 0
-                else cls.ROW_PERSIST_MAX_BYTES
-            )
-
-        # The static grid-row count (program count before any widen), the occupancy numerator.
-        from ..compile_environment import NoCurrentEnvironment
-
-        grid_rows = 1
-        # The try/except is NECESSARY (not defensive noise): this block dereferences the live
-        # ``env`` (``env.block_sizes[gbid].size``, ``env.size_hint``), which the no-env unit-test
-        # path (see ``extent_of`` above) cannot provide -> ``NoCurrentEnvironment``; a dynamic/None
-        # grid size raises ``AttributeError``/``TypeError``. All three collapse to the SAME defined
-        # fallback ``grid_rows = 0`` = "no compile-time occupancy", which the pass-2 occupancy widen
-        # already handles (it simply does not fire). Scoped tightly to the env-touching loop so it
-        # cannot mask an unrelated bug.
-        try:
-            for gbid in grid_ids:
-                size = env.block_sizes[gbid].size
-                if isinstance(size, (int, torch.SymInt)):
-                    grid_rows *= env.size_hint(size)
-                else:
-                    grid_rows = 0  # dynamic grid -> no compile-time occupancy
-                    break
-        except (NoCurrentEnvironment, AttributeError, TypeError):
-            grid_rows = 0
-
-        # ``seated`` holds every tile assigned so far (held fixed for later sizing); ``sizes`` is
-        # the subset that lands in tunable ``block_sizes`` slots. PASS 1 seats every grid axis at
-        # its FLOOR; the reductions are sized against that floored grid, then PASS 2 widens the grid
-        # into whatever budget the seated reductions left (the two-pass structure — reductions
-        # first with the grid pinned low, then the grid).
-        seated: dict[int, int] = {}
-        for gbid in sorted(grid_ids):
-            seated[gbid] = cls._m_axis_block_size(spec, gbid)
-        sizes: dict[int, int] = {}
-        block_sizes_red_values: dict[int, int] = {}
-        rolled_loop_sizes: dict[int, tuple[int, bool]] = {}
-        primary_r_block = 1
-        persistent = False
-
-        # Which axes are register-resident (see ``_resident_block_ids``). A grid axis in a live tile
-        # widens into the byte budget; a grid axis in no live tile is reduced away by a later
-        # ``.sum(0)``, holds no bytes, and collapses to ~1 SM wave instead.
-        resident_block_ids = cls._resident_block_ids(spec)
-
-        # A kernel with a loop-carried >=2-D accumulator (``carried_2d_count >= 1`` on any reduction)
-        # pins that ``[grid_M, R]`` state in registers across the whole inner loop, so widening the
-        # resident grid is risky (it multiplies the pinned register footprint and trips the
-        # CTA-per-SM occupancy cliff). Such a kernel keeps its resident grid at FLOOR (no widen).
-        carried_kernel = any(d.carried_2d_count > 0 for d in kf.reductions)
-
-        def footprint_terms(
-            tiles: tuple[tuple[int | None, ...], ...],
-            axis: int,
-        ) -> tuple[int, int]:
-            """The group footprint as ``(scale, flat)``: resident bytes while sizing ``axis`` =
-            ``itemsize × (scale × block(axis) + flat)`` — an axis-scaling term plus a constant term,
-            kept separate (they ADD; folding the constant into a per-element coefficient over-counts
-            it and wrongly denies persistence). Sum ``∏(dim widths)`` over the group's live tiles: a
-            tile containing ``axis`` scales with it (its ``∏(other dims)`` adds to ``scale``), a tile
-            without ``axis`` is constant (adds to ``flat``). A ``None`` dim is a size-1 broadcast.
-            The tiles already ARE the resident set (loop-carried accumulators captured inline at
-            real shape), so no separate accumulator sum is needed."""
-            scale = 0
-            flat = 0
-            for tile in tiles:
-                contains_axis = axis in tile
-                prod = 1
-                for d in tile:
-                    if d is None or d == axis:
-                        continue
-                    prod *= conservatively_large_tile_width(d)
-                if contains_axis:
-                    scale += prod
-                else:
-                    flat += prod
-            return max(1, scale), flat
-
-        def conservatively_large_tile_width(bid: int) -> int:
-            """One resident dim's width for the footprint bound: its SEATED width if already chosen,
-            else its full extent. The full-extent fallback is safe BY SEATING ORDER, not a blind
-            assumption — grid axes are seated first (the pass-1 preamble above), and a not-yet-seated
-            *reduction* dim is later in the sizing ``order`` below, so over-approximating it at full
-            extent only makes the footprint LARGER, keeping the axis currently being sized
-            conservative (it can only end up smaller/safer, never over-sized into a spill). NB: the
-            footprint is therefore ORDER-DEPENDENT (a later-sized reduction sees an earlier one at its
-            seated width, but not vice-versa) — the ``order`` sort below is load-bearing for
-            correctness, not cosmetic."""
-            return max(1, seated.get(bid, extent_of(bid)))
-
-        # The persistence-hold ceiling (used once, at ``expand_to_persist`` in the loop below; kept
-        # here as it is loop-invariant — keyed on the primary ``pd``). Selects the SMALL vs BIG
-        # bucket via ``_has_store_only_row_reread`` (an admitted proxy — see that method and
-        # PERSIST_HOLD_MAX_BYTES).
-        hold_ceiling = (
-            cls.USER_TILE_PERSIST_HOLD_MAX_BYTES
-            if cls._has_store_only_row_reread(spec, pd)
-            else cls.PERSIST_HOLD_MAX_BYTES
-        )
-
-        for g in kf.coresidency_groups:
-            descs = [kf.reductions[i] for i in g.descriptor_indices]
-            sized = [d for d in descs if d.category in SIZED_REDUCTION_CATEGORIES]
-            if not sized:
-                continue
-            tiles = g.live_tiles
-
-            # ---- PASS 1: seat the reductions (full-extent -> user-tile -> grid-tile) against the
-            # group's live-tile footprint with the grid axes at their floor. ----
-            order = sorted(
-                sized,
-                key=lambda d: (
-                    0
-                    if d.category in FULL_EXTENT_CATEGORIES
-                    else (1 if d.category is ReductionCategory.USER_TILE else 2),
-                    -d.size_hint,
+        for block_id, descriptors in descriptors_by_block.items():
+            raw_extent = raw_reduction_extents[block_id]
+            fixed = next(
+                (
+                    descriptor
+                    for descriptor in descriptors
+                    if descriptor.category is ReductionCategory.FIXED_TILE
                 ),
+                None,
             )
-            # ``order`` is ``sized`` (SIZED_REDUCTION_CATEGORIES only): FULL_SLICE / FULL_GRID /
-            # USER_TILE. A GRID_TILE reduction (jsd's grid amax) is NOT sized here — it is a grid
-            # axis, seated at its floor in the grid loop above and widened in PASS 2 like any grid
-            # row. So this loop never sees a GRID_TILE.
-            for d in order:
-                raw_ext = d.size_hint  # the true reduction extent (NOT pow2-padded)
-                ext = extent_of(d.block_id)  # pow2-padded — the seated tile width
-                materialized_full_width = (
-                    d.category is ReductionCategory.FULL_SLICE
-                    and d.block_id not in valid
-                    and d.block_id not in spec.reduction_loops.valid_block_ids()
-                )
-                if d.category is ReductionCategory.FULL_GRID or materialized_full_width:
-                    # FULL_GRID (cdiv == 1) or a materialized full-width FULL_SLICE (the roller
-                    # declined to roll it and it has no tunable block_sizes slot — e.g. a
-                    # grad-parameter ``grad_weight[N]`` accumulator axis, or a specialized
-                    # ``group_size``): the whole axis is one program's tile, full-extent resident by
-                    # definition. Seat at the full extent, never chunk it through the byte budget — it
-                    # cannot be split across programs and has nowhere to emit a chunk. Seating it
-                    # full-width (not chunked to 1) is what lets the co-resident inner tile see the
-                    # real N (else the inner tile reads N as 1 and grows to full extent — a spill).
-                    seated[d.block_id] = ext
-                    if d.block_id == pd.block_id:
-                        primary_r_block = ext
-                        # Seated at its full extent (r == ext), so it is persistent under the same
-                        # ``persistent = (r >= ext)`` rule the normal sizing path uses.
-                        persistent = True
-                    if d.block_id in valid:
-                        block_sizes_red_values[d.block_id] = ext
-                    continue
-                # Resident bytes(R) = itemsize × (scale × R + flat) over the live tiles. A reduction
-                # axis is tiled the same width everywhere it appears, so it must fit the heaviest
-                # co-residency group that spans it — take the footprint from the max-``scale`` group
-                # over ``d.block_id``, not just this descriptor's own group. ``flat`` is taken from
-                # that same max group (mixing terms across groups breaks the chunk arithmetic).
-                scale, flat = cls._max_group_footprint(
-                    kf, d.block_id, footprint_terms, default_tiles=tiles
-                )
-                # Size a streamed/chunked R from the byte budget first: the largest pow2 R whose
-                # resident bytes fit, solving ``itemsize × (scale × R + flat) <= budget`` for R (the
-                # constant term is subtracted, not divided), capped by LOOPED_CHUNK and the extent. A
-                # carried reduction sizes against the tighter carried budget; a non-carried inner tile
-                # against ROW.
-                avail = persist_budget_for(d) // itemsize - flat
-                byte_budget = _pp2(max(1, avail // scale))
-                r = max(1, min(cls.LOOPED_CHUNK, byte_budget, ext))
-                # THEN EXPAND TO PERSISTENT: lift R to the full extent iff the row is re-read (a
-                # persistent pass fuses reduce+apply to one HBM load) AND there is no carried 2-D
-                # tile (a carried tile is held resident the whole loop — it chunks, never persists)
-                # AND the extent clears the per-program element limit AND the single resident tile
-                # fits the persist ``hold_ceiling`` (apply-reread-keyed, computed above). The byte
-                # test uses the RAW extent (true resident element count, not pow2-padded).
-                element_cap = env.backend.max_tensor_numel
-                expand_to_persist = (
-                    d.row_reread
-                    and d.carried_2d_count == 0
-                    and (element_cap is None or raw_ext <= element_cap)
-                    and itemsize * (scale * raw_ext + flat) <= hold_ceiling
-                )
-                if expand_to_persist:
-                    r = ext
-                seated[d.block_id] = r
-                # THREE independent routing checks (the block_sizes and reduction_loops namespaces
-                # are DISJOINT — an axis is a ``block_sizes`` tile XOR a rolled ``reduction_loops``
-                # axis, never both — so these are plain ``if``s, not an if/elif chain):
-                # (A) the PRIMARY's scalar levers (num_warps ramp + standard-track reduction_loops).
-                if d.block_id == pd.block_id:
-                    primary_r_block = r
-                    persistent = r >= ext and d.category in FULL_EXTENT_CATEGORIES
-                # (B) a tunable ``block_sizes`` reduction (user-tiled) -> its block_sizes slot.
-                if d.block_id in valid:
-                    block_sizes_red_values[d.block_id] = r
-                # (C) a ROLLED NON-primary reduction -> surface its size for the standard track's
-                # reduction_loops emission. ``!= pd.block_id`` excludes the ROLLED PRIMARY (whose
-                # size is emitted via ``primary_r_block`` in (A) instead — it would otherwise be
-                # double-routed here). Only reached by a kernel that rolls >1 reduction.
-                if (
-                    d.block_id != pd.block_id
-                    and d.block_id in spec.reduction_loops.valid_block_ids()
-                ):
-                    rolled_loop_sizes[d.block_id] = (
-                        r,
-                        r >= ext and d.category in FULL_EXTENT_CATEGORIES,
-                    )
-
-            # ---- PASS 2: the grid-M rows take the remainder (widen / floor / collapse). ----
-            for mbid in sorted(grid_ids):
-                if mbid not in valid:
-                    continue  # a grid-PINNED axis (FixedBlockSizeSource) -> fixed, not sized.
-                ext = extent_of(mbid)
-                floor = cls._block_floor(
-                    cast(
-                        "BlockSizeSpec",
-                        spec.block_sizes[spec.block_sizes.block_id_to_index(mbid)],
-                    )
-                )
-                if mbid not in resident_block_ids:
-                    # a sequential cross-grid reduction loop (grad-param .sum(0)): in NO live tile ->
-                    # NOT resident, holds no bytes. The byte budget cannot size it; raise the floor
-                    # to ~1 SM wave to collapse the cross-grid finalize.
-                    collapse = _np2(max(1, grid_rows // num_sm)) if grid_rows > 0 else 1
-                    blk = max(floor, min(collapse, ext))
-                elif carried_kernel:
-                    # Register-occupancy guard (see ``carried_kernel`` above): the pinned
-                    # ``[grid_M, R]`` accumulator makes widening the grid trip the CTA-per-SM
-                    # occupancy cliff, which the leftover-byte widen and program-count ``occ_widen``
-                    # cannot see. So a carried kernel keeps its resident grid at FLOOR.
-                    blk = floor
-                else:
-                    # resident parallel rows: widen into the byte remainder (same faithful
-                    # ``scale × block + flat`` footprint over the live tiles — a wider grid row
-                    # scales every tile CONTAINING the grid axis), capped by occupancy (keep the
-                    # post-widen grid >= num_sm·MIN_WAVES), a diminishing-returns ROWS ceiling, and
-                    # the extent; floors when the budget is full.
-                    scale_w, flat_w = footprint_terms(tiles, mbid)
-                    avail_w = persist_budget_for(pd) // itemsize - flat_w
-                    byte_widen = _pp2(max(1, avail_w // scale_w))
-                    if grid_rows > 0:
-                        occ_widen = _pp2(max(1, grid_rows // occ_floor))
-                    else:
-                        occ_widen = (
-                            1  # dynamic grid -> no compile-time occupancy -> no widen
-                        )
-                    # ROWS ceiling: batching more than WIDEN_MAX_ROWS reduction ROWS/program only
-                    # trades away grid parallelism for a resident-row reduction (softmax/rms_norm:
-                    # memory-bound, does not amortize past ~8 rows). Does NOT apply when the primary
-                    # is FULL_GRID (the grid axis batches tiny grid-resident per-group reductions —
-                    # per_token_group's groups_per_row — which wants the wide occupancy-bound widen).
-                    rows_ceiling = (
-                        ext
-                        if pd.category is ReductionCategory.FULL_GRID
-                        else cls.WIDEN_MAX_ROWS
-                    )
-                    blk = max(floor, min(byte_widen, occ_widen, rows_ceiling, ext))
-                seated[mbid] = blk
-                sizes[mbid] = blk
-
-        # ---- the non-reduction / independent loops LAST (own budget vs the headroom) ----
-        # welford's normalize loop / rms_norm_per_block's groups_per_row. Co-resident with nothing
-        # in a group's reduction tile (a separate sequential pass), so each gets a FRESH budget
-        # against its own extent capped by the streamed ROW budget.
-        loop_budget = _pp2(max(1, cls.ROW_PERSIST_MAX_BYTES // itemsize))
-        # Optional tighter cap for a non-reduction apply loop (None on the base; set by sm100).
-        loop_cap = cls.non_reduction_loop_block_cap(spec, pd)
-        for i in range(len(spec.block_sizes)):
-            bs_spec = cast("BlockSizeSpec", spec.block_sizes[i])
-            bid = bs_spec.block_id
-            if bid in block_sizes_red_values or bid in grid_ids or bid in reduction_ids:
-                continue
-            if bid in non_reduction_loop_ids or bid not in seated:
-                # a non-reduction apply loop OR an independent standalone tiled loop: size it to
-                # its own extent capped by the headroom (flooring it to 1 would serialize the pass).
-                budget = loop_budget
-                if loop_cap is not None and bid in non_reduction_loop_ids:
-                    budget = min(budget, loop_cap)
-                sizes[bid] = max(1, min(extent_of(bid), budget))
-
-        # ---- assemble the full block_sizes vector ----
-        block_sizes: list[int] = []
-        for i in range(len(spec.block_sizes)):
-            bs_spec = cast("BlockSizeSpec", spec.block_sizes[i])
-            bid = bs_spec.block_id
-            if bid in sizes:
-                block_sizes.append(sizes[bid])
-            elif bid in block_sizes_red_values:
-                block_sizes.append(block_sizes_red_values[bid])
+            if fixed is not None:
+                assert fixed.fixed_tile_size_hint is not None
+                width = _np2(max(1, fixed.fixed_tile_size_hint))
+                reduction_widths[block_id] = width
+                reduction_floors[block_id] = width
+                reduction_maximums[block_id] = width
+                fixed_reduction_ids.add(block_id)
+            elif block_id in slot_of:
+                width = blocks[slot_of[block_id]]
+                reduction_widths[block_id] = width
+                reduction_floors[block_id] = floors[block_id]
+                reduction_maximums[block_id] = maximums[block_id]
+            elif block_id in rolled_ids:
+                full_width = _np2(max(1, raw_extent))
+                width = min(8, full_width)
+                reduction_widths[block_id] = width
+                reduction_floors[block_id] = width
+                reduction_maximums[block_id] = full_width
             else:
-                block_sizes.append(cls._block_floor(bs_spec))
+                width = _np2(max(1, raw_extent))
+                reduction_widths[block_id] = width
+                reduction_floors[block_id] = width
+                reduction_maximums[block_id] = width
+                fixed_reduction_ids.add(block_id)
 
-        return _TileAllocation(
-            block_sizes=block_sizes,
-            block_sizes_red_values=block_sizes_red_values,
-            primary_r_block=primary_r_block,
-            persistent=persistent,
-            rolled_loop_sizes=rolled_loop_sizes,
+        def make_candidate(
+            candidate_blocks: list[int],
+            widths: dict[int, int],
+        ) -> _ReductionCandidate:
+            return _ReductionCandidate(
+                tuple(candidate_blocks),
+                tuple(sorted(widths.items())),
+            )
+
+        candidate = make_candidate(blocks, reduction_widths)
+
+        def with_axis(
+            current: _ReductionCandidate,
+            block_id: int,
+            value: int,
+        ) -> _ReductionCandidate:
+            candidate_blocks = list(current.block_sizes)
+            widths = dict(current.reduction_widths)
+            slot = slot_of.get(block_id)
+            if slot is not None:
+                candidate_blocks[slot] = value
+            if block_id in widths:
+                widths[block_id] = value
+            return make_candidate(candidate_blocks, widths)
+
+        def grow(
+            block_id: int,
+            maximum: int,
+        ) -> None:
+            nonlocal candidate
+            current = (
+                candidate.reduction_width(block_id)
+                if block_id in reduction_widths
+                else candidate.block_sizes[slot_of[block_id]]
+            )
+            while current < maximum:
+                value = min(maximum, current * 2)
+                trial = with_axis(candidate, block_id, value)
+                current_peak = cls._reduction_peak_live_bytes(env, candidate)
+                trial_peak = cls._reduction_peak_live_bytes(env, trial)
+                if not (
+                    trial_peak <= cls.NORMAL_LIVE_BUDGET
+                    or (
+                        current_peak > cls.NORMAL_LIVE_BUDGET
+                        and trial_peak <= current_peak
+                    )
+                ):
+                    break
+                candidate = trial
+                current = value
+
+        def reduction_order_key(block_id: int) -> tuple[int, int, int]:
+            descriptors = descriptors_by_block[block_id]
+            categories = {descriptor.category for descriptor in descriptors}
+            if ReductionCategory.FIXED_TILE in categories:
+                tier = 0
+            elif categories & FULL_EXTENT_CATEGORIES:
+                tier = 1
+            else:
+                tier = 2
+            return tier, -raw_reduction_extents[block_id], block_id
+
+        for block_id in sorted(descriptors_by_block, key=reduction_order_key):
+            if block_id not in fixed_reduction_ids:
+                grow(block_id, reduction_maximums[block_id])
+
+        grid_ids = tuple(
+            block_id
+            for block_id in sorted(kf.grid_axis_block_ids)
+            if block_id in slot_of and block_id not in descriptors_by_block
+        )
+        for block_id in grid_ids:
+            grow(block_id, maximums[block_id])
+
+        non_reduction_ids = tuple(
+            block_id
+            for block_id in sorted(kf.non_reduction_loop_block_ids)
+            if block_id in slot_of and block_id not in descriptors_by_block
+        )
+        for block_id in non_reduction_ids:
+            grow(block_id, maximums[block_id])
+
+        classified = set(descriptors_by_block) | set(grid_ids) | set(non_reduction_ids)
+        for block_id in sorted(set(slot_of) - classified):
+            grow(block_id, maximums[block_id])
+
+        axis_floors = dict(floors)
+        axis_floors.update(reduction_floors)
+        axis_maximums = dict(maximums)
+        axis_maximums.update(reduction_maximums)
+        full_reduction_ids = {
+            block_id
+            for block_id in descriptors_by_block
+            if candidate.reduction_width(block_id) == reduction_maximums[block_id]
+        }
+        adjustable_ids = {
+            *(
+                block_id
+                for block_id in descriptors_by_block
+                if block_id not in fixed_reduction_ids
+                and block_id not in full_reduction_ids
+            ),
+            *grid_ids,
+            *non_reduction_ids,
+            *(set(slot_of) - classified),
+        }
+        coalescing = set(kf.coalescing_sensitive_block_ids)
+        non_grid_noncoalescing = sorted(adjustable_ids - set(grid_ids) - coalescing)
+        coalescing_ids = sorted(adjustable_ids & coalescing)
+        adjustment_order = (
+            *grid_ids,
+            *non_grid_noncoalescing,
+            *coalescing_ids,
         )
 
+        def axis_value(current: _ReductionCandidate, block_id: int) -> int:
+            if block_id in reduction_widths:
+                return current.reduction_width(block_id)
+            return current.block_sizes[slot_of[block_id]]
 
-class TritonStandardReductionHeuristicSM90(_TritonReductionSeedBase):
-    """standard (Helion-rolled rdim) inner-reduction seed for sm90/H100: Helion rolls the
-    reduction axis into a ``reduction_loops`` loop from a single ``.sum(-1)``-style op — sum,
-    long_sum, rms_norm, layer_norm, softmax-row, cross_entropy. Triton analog of
-    ``CuteReductionTileHeuristic`` (keeps its registry name), deepening the original
-    one-row/persistent/``['last']`` seed with the num_warps ramp, persistent-vs-looped,
-    and per-slot eviction.
+        def adjustment_floor(block_id: int) -> int:
+            floor = axis_floors[block_id]
+            if block_id in coalescing and block_id not in grid_ids:
+                floor = max(
+                    floor,
+                    min(axis_maximums[block_id], cls.COALESCING_SENSITIVE_FLOOR),
+                )
+            return floor
 
-    Gated by ``_triton_reduction_eligible`` (standard track) — broader than upstream
-    ``is_canonical_row_reduction`` (also multi-axis rollable rows and raised-``autotuner_min``
-    large-M shapes) — AND the sm90 hardware target. sm100 routes to
-    :class:`TritonStandardReductionHeuristicSM100`; unclaimed hardware routes to
-    :class:`TritonNarrowReductionHeuristic`.
-    """
+        def resources_for(
+            current: _ReductionCandidate,
+        ) -> tuple[int, _ReductionResources]:
+            warps = cls._choose_reduction_num_warps(
+                env,
+                current,
+                pd,
+                num_sm,
+                allow_descent=False,
+            )
+            return warps, cls._reduction_resources(env, current, warps, num_sm)
 
-    name = "triton_reduction_tile"
+        for _ in range(cls.MAX_BLOCK_ADJUSTMENT_PASSES):
+            changed = False
+            warps, resources = resources_for(candidate)
+            for block_id in adjustment_order:
+                current_value = axis_value(candidate, block_id)
+                floor = adjustment_floor(block_id)
+                if current_value <= floor:
+                    continue
+                raw_extent = (
+                    raw_reduction_extents[block_id]
+                    if block_id in raw_reduction_extents
+                    else specs[slot_of[block_id]].size_hint
+                )
+                current_steps = max(1, -(-raw_extent // current_value))
+                current_padded_work = current_steps * current_value
+                trial_value = max(floor, current_value // 2)
+                if block_id not in grid_ids and current_value > raw_extent:
+                    while (
+                        trial_value > floor
+                        and -(-raw_extent // trial_value) * trial_value
+                        >= current_padded_work
+                    ):
+                        trial_value = max(floor, trial_value // 2)
+                trial = with_axis(candidate, block_id, trial_value)
+                trial_warps, trial_resources = resources_for(trial)
+                current_ctas = cls._reduction_effective_cta_score(resources)
+                trial_ctas = cls._reduction_effective_cta_score(trial_resources)
+                current_warps_score = cls._reduction_effective_warp_score(resources)
+                trial_warps_score = cls._reduction_effective_warp_score(trial_resources)
+                current_spill = cls._reduction_spill_pressure(resources)
+                trial_spill = cls._reduction_spill_pressure(trial_resources)
+                relieves_spill = (
+                    current_spill > cls.SPILL_PRESSURE_THRESHOLD
+                    and trial_spill <= cls.SPILL_PRESSURE_THRESHOLD
+                    and trial_warps_score + 1e-9 >= current_warps_score
+                )
+                if block_id in grid_ids:
+                    required_gain = (
+                        cls.FULL_GRID_SPLIT_GAIN_THRESHOLD
+                        if current_value == axis_maximums[block_id]
+                        else cls.GRID_RESIDENCY_GAIN_THRESHOLD
+                    )
+                    worthwhile = (
+                        trial_ctas / max(current_ctas, 1e-9) + 1e-9 >= required_gain
+                    )
+                else:
+                    trial_steps = max(
+                        1,
+                        -(-raw_extent // max(1, trial_value)),
+                    )
+                    serial_cost = 1.0 + cls.SERIAL_LOOP_COST_ALPHA * (
+                        trial_steps / current_steps - 1.0
+                    )
+                    relieves_padding = (
+                        current_value > raw_extent
+                        and trial_steps * trial_value < current_padded_work
+                        and trial_warps_score + 1e-9 >= current_warps_score
+                    )
+                    worthwhile = relieves_padding or (
+                        trial_warps_score > current_warps_score
+                        and trial_warps_score / max(current_warps_score, 1e-9) + 1e-9
+                        >= serial_cost
+                    )
+                if relieves_spill or worthwhile:
+                    candidate = trial
+                    resources = trial_resources
+                    changed = True
+            if not changed:
+                break
 
-    # Warp floor when a grid axis is reduced away: the batched rows give cross-warp work to
-    # spread. Per-arch, since it trades occupancy against that parallelism.
-    M_COLLAPSE_MIN_NUM_WARPS = 8
+        # Probe full-row persistence only after the normal candidate is stable.
+        primary_block_id = pd.block_id
+        primary_full_width = _np2(max(1, pd.size_hint))
+        persistence_tunable = primary_block_id in rolled_ids or (
+            primary_block_id in slot_of and pd.category is ReductionCategory.USER_TILE
+        )
+        if (
+            pd.row_reread
+            and persistence_tunable
+            and candidate.reduction_width(primary_block_id) < primary_full_width
+        ):
+            persistent_trial = with_axis(
+                candidate,
+                primary_block_id,
+                primary_full_width,
+            )
+            _, normal_resources = resources_for(candidate)
+            _, persistent_resources = resources_for(persistent_trial)
+            normal_effective_ctas = cls._reduction_effective_resident_ctas_per_sm(
+                normal_resources
+            )
+            persistent_effective_ctas = cls._reduction_effective_resident_ctas_per_sm(
+                persistent_resources
+            )
+            occupancy_not_hurt = all(
+                persistent + 1e-9 >= normal
+                for persistent, normal in zip(
+                    persistent_effective_ctas,
+                    normal_effective_ctas,
+                    strict=True,
+                )
+            )
+            if (
+                persistent_resources.peak_live_bytes
+                <= cls.NORMAL_LIVE_BUDGET * cls.PERSISTENCE_BUDGET_MULTIPLIER
+                and cls._reduction_spill_pressure(persistent_resources)
+                <= cls.SPILL_PRESSURE_THRESHOLD
+                and occupancy_not_hurt
+            ):
+                candidate = persistent_trial
+
+        final_warps = cls._choose_reduction_num_warps(env, candidate, pd, num_sm)
+        final_widths = dict(candidate.reduction_widths)
+        rolled_loop_sizes = {
+            block_id: final_widths[block_id]
+            for block_id in rolled_ids
+            if block_id != primary_block_id
+        }
+        return _LivenessTileAllocation(
+            block_sizes=list(candidate.block_sizes),
+            primary_r_block=final_widths[primary_block_id],
+            rolled_loop_sizes=rolled_loop_sizes,
+            num_warps=final_warps,
+        )
 
     @classmethod
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
@@ -5091,8 +5151,7 @@ class TritonStandardReductionHeuristicSM90(_TritonReductionSeedBase):
             return False
         if not _triton_reduction_eligible(env, device_ir):
             return False
-        pd = _primary_descriptor_selected(env)
-        return pd is not None and _is_standard_reduction(pd)
+        return _primary_descriptor_selected(env) is not None
 
     @classmethod
     def get_seed_config(
@@ -5102,269 +5161,55 @@ class TritonStandardReductionHeuristicSM90(_TritonReductionSeedBase):
         pd = _primary_descriptor_selected(env)
         if pd is None:
             return None
-        # The allocator sizes every axis from the per-co-residency-group budget: the reduction
-        # chunk(s), the grid M (the remainder — widen / floor / collapse), and the apply/independent
-        # loops, in one pass. The standard track maps that sizing onto the rolled ``reduction_loops``
-        # knob + the num_warps ramp + eviction below (emission routing only).
-        alloc = cls.size_reduction_tiles(env, spec, device_ir, pd)
-        block_sizes = alloc.block_sizes
-        r_block, persistent = alloc.primary_r_block, alloc.persistent
-        num_warps = cls._num_warps(pd)
-        # Grad-parameter M-collapse warp floor: a kernel that reduces its grid-M axis away (finalized
-        # by a later ``.sum(0)`` — a grid block_id in no live tile) batches many M-rows per program
-        # and accumulates a wide ``[inner, N]`` gradient. That cross-warp-parallelizable work wants
-        # >=8 warps even when the primary reduction's extent is small. A floor, so it never lowers a
-        # large-rdim ramp. Independent of co-residency, so not gated on a co-resident sibling.
-        if cls._has_reduced_away_grid(spec):
-            num_warps = max(cls.M_COLLAPSE_MIN_NUM_WARPS, num_warps)
+        kf = spec.reduction_kernel_fact
+        assert kf is not None
+        alloc = cls.size_reduction_tiles_liveness(env, spec, pd)
 
-        # standard rides persistent-vs-looped on the rolled ``reduction_loops`` knob (the primary
-        # rdim is NOT a block_sizes entry). MATERIALIZED rdim (rms/ln/instance bwd, the roller
-        # declined to roll it): emit an EMPTY reduction_loops -- already full-width persistent, and
-        # a length-1 list would fail normalize against the 0-length spec.
-        is_materialized = pd.block_id not in spec.reduction_loops.valid_block_ids()
-        reduction_loops: list[int | None]
-        if is_materialized:
-            reduction_loops = []
-        elif len(spec.reduction_loops) <= 1:
-            # Single rolled reduction (the common case).
-            reduction_loops = [None] if persistent else [r_block]
-        else:
-            # Multiple rolled reductions (e.g. two sequential rolled reductions in separate graphs).
-            # One ``reduction_loops`` entry per spec in spec order: the primary spec uses
-            # (r_block, persistent); the other rolled specs use ``alloc.rolled_loop_sizes`` (each
-            # sized against its own extent — a rolled axis has no block_sizes slot, so the allocator
-            # surfaces it here rather than in block_sizes_red_values).
-            reduction_loops = []
-            for rl_spec in spec.reduction_loops:
-                bid = rl_spec.block_ids[0]
-                if bid == pd.block_id:
-                    reduction_loops.append(None if persistent else r_block)
-                else:
-                    rb, pers = alloc.rolled_loop_sizes[bid]
-                    reduction_loops.append(None if pers else rb)
         seed: dict[str, Any] = {
-            "block_sizes": block_sizes,
-            "reduction_loops": reduction_loops,
-            "num_warps": num_warps,
+            "block_sizes": alloc.block_sizes,
+            "num_warps": alloc.num_warps,
             "num_stages": 1,
-            # 'flat': these reductions are grid-saturated at the M-grid.
             "pid_type": "flat",
         }
-        # Eviction: a streamed input -> 'first' everywhere; a re-read row reloaded across a
-        # grid-COLLAPSE loop -> pin it 'last' (first load), rest 'first'. Gated on
-        # ``_has_reduced_away_grid`` (the grad-parameter ``.sum(0)`` M-collapse idiom: the program
-        # batches many M-rows and re-fetches the row from L2 each row, so pinning it pays), not on
-        # ``not persistent`` — a single fused persistent row does not reload from L2, so pinning
-        # there only oversubscribes L2 and evicts store lines. Whether the row reloads is a
-        # structural property, not a byte threshold, so ``_has_reduced_away_grid`` is the
-        # discriminator. (A ``num_load == 1`` kernel hits the stream branch first.)
-        evict = None
-        if pd.num_load == 1:
-            evict = cls._eviction_policies(env, "stream")
-        elif pd.row_reread and cls._has_reduced_away_grid(spec):
-            # Re-read row's eviction slot read directly from the descriptor (its load's
-            # MemoryOpFact.eviction_index), not a per-config codegen re-walk.
-            evict = cls._eviction_policies(env, "reread", pd.reread_eviction_index)
-        if evict is not None:
-            seed["load_eviction_policies"] = evict
-        # Materialize through the shared guard so an emitted config value that is
-        # illegal for this kernel is repaired rather than shipped raw: a hardcoded
-        # ``pid_type='flat'`` is replaced with a legal persistent type when 'flat' is
-        # disallowed (barrier / data-dependent grid bound), matching the matmul seed path.
+        if _is_standard_reduction(pd):
+            # Compiler-rolled reductions have no block_sizes slot. Full width is encoded as
+            # ``None``; a materialized full reduction has no reduction_loops knob at all.
+            if pd.block_id not in spec.reduction_loops.valid_block_ids():
+                reduction_loops: list[int | None] = []
+            elif len(spec.reduction_loops) <= 1:
+                reduction_loops = [
+                    None
+                    if alloc.primary_r_block >= pd.size_hint
+                    else alloc.primary_r_block
+                ]
+            else:
+                reduction_loops = []
+                for rl_spec in spec.reduction_loops:
+                    block_id = rl_spec.block_ids[0]
+                    width = (
+                        alloc.primary_r_block
+                        if block_id == pd.block_id
+                        else alloc.rolled_loop_sizes[block_id]
+                    )
+                    reduction_loops.append(
+                        None if width >= rl_spec.size_hint else width
+                    )
+            seed["reduction_loops"] = reduction_loops
+            if pd.row_reread and cls._has_floor_batched_nonresident_grid(env):
+                evict = cls._reread_eviction_policies(env, pd.reread_eviction_index)
+                if evict is not None:
+                    seed["load_eviction_policies"] = evict
+        elif kf.non_reduction_loop_block_ids or pd.row_reread:
+            # A user-written reduction already emits its mutable width through block_sizes.
+            evict = cls._reread_eviction_policies(env, pd.reread_eviction_index)
+            if evict is not None:
+                seed["load_eviction_policies"] = evict
+
         return _materialize_config(seed, config_spec=spec)
-
-
-class TritonUserTiledReductionHeuristicSM90(_TritonReductionSeedBase):
-    """user-tiled inner-reduction seed for sm90/H100: fires when the user hand-writes the
-    ``hl.tile`` loop over the reduction axis (so the rdim is an ordinary ``block_sizes`` entry,
-    e.g. ``hl.tile(n, block_size=R_BLOCK)``), which the upstream gate rejects entirely.
-
-    Every axis (the reduction r_block(s), the grid rows, the apply loops) is sized by the shared
-    :meth:`size_reduction_tiles` ONE budget allocator — there are NO per-band branches. The kernel
-    families this track covers (plain user-tiled softmax, carried-2-D kl_div/jsd, reduce-then-apply
-    welford, grad-parameter bias_grad/dyt) differ only in their Stage-1 facts (carried accumulators,
-    non-reduction loops, materialized features), which the budget consumes uniformly; the
-    floor-vs-resident and chunk-vs-persistent decisions are budget OUTCOMES. This track maps the
-    allocation onto its knobs (every reduction axis is a ``block_sizes`` entry; no
-    ``reduction_loops``) + num_warps + reread eviction below.
-    """
-
-    name = "triton_reduction_user_tile"
-
-    @classmethod
-    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
-        if not matches_hardware(env, cls.HARDWARE_TARGETS):
-            return False
-        if not _triton_reduction_eligible(env, device_ir):
-            return False
-        pd = _primary_descriptor_selected(env)
-        return pd is not None and not _is_standard_reduction(pd)
-
-    @classmethod
-    def get_seed_config(
-        cls, env: CompileEnvironment, device_ir: DeviceIR
-    ) -> Config | None:
-        spec = env.config_spec
-        pd = _primary_descriptor_selected(env)
-        if pd is None:
-            return None
-        # The allocator sizes every axis from the per-co-residency-group budget: the user-tiled
-        # reduction chunk(s) on their block_sizes slots, the grid M (the remainder), and the apply
-        # loops, in one pass. The user-tiled track maps that sizing onto num_warps + eviction below
-        # (no reduction_loops knob; the rdim rides a block_sizes entry).
-        alloc = cls.size_reduction_tiles(env, spec, device_ir, pd)
-        block_sizes = alloc.block_sizes
-        num_warps = cls._num_warps(pd)
-        non_reduction_loop_ids = set(cls._non_reduction_loop_ids(spec))
-        seed: dict[str, Any] = {
-            "block_sizes": block_sizes,
-            "num_warps": num_warps,
-            "num_stages": 1,
-            "pid_type": "flat",  # see the standard branch.
-        }
-        # Reread eviction: keep the re-read row L2-resident ('last' on its load slot) whenever
-        # it is re-read — welford (reduce-then-apply across combine + normalize) AND plain
-        # user-tiled (softmax_two_pass loads x twice). Applies even when PERSISTENT: the second
-        # pass still re-fetches x from HBM (profiler-confirmed), so 'last' cuts that re-read
-        # traffic. kl_div/jsd (row_reread=False) unaffected.
-        if non_reduction_loop_ids or pd.row_reread:
-            # Re-read row's eviction slot read directly from the descriptor (its load's
-            # MemoryOpFact.eviction_index), not a per-config codegen re-walk.
-            ev = cls._eviction_policies(env, "reread", pd.reread_eviction_index)
-            if ev is not None:
-                seed["load_eviction_policies"] = ev
-        # See the standard branch: materialize through the shared guard so an illegal
-        # ``pid_type='flat'`` (disallowed under a barrier / data-dependent bound) is
-        # repaired to a legal persistent type instead of shipping the raw seed.
-        return _materialize_config(seed, config_spec=spec)
-
-
-def _config_with_num_warps(cfg: Config, num_warps: int) -> Config:
-    """Return a copy of ``cfg`` with ``num_warps`` overridden (the reduction seeds always set
-    num_warps, so this replaces the existing value)."""
-    merged: dict[str, Any] = {**cfg.config, "num_warps": num_warps}
-    return Config(**merged)
-
-
-# ============================ sm100 (B200) dedicated subclasses ============================ #
-# Re-target the sm90 reduction seeds at sm100 via a subclass that overrides only the hardware target +
-# B200 constants; the sm90/H100 emit is a separate class + gate, so it stays frozen.
-class _TritonReductionSeedSM100(_TritonReductionSeedBase):
-    """sm100 (B200) constant/gate carrier for the two reduction seed tracks. Overrides the hardware
-    target and re-tunes constants (as class attributes) only where a B200 measurement demands it. The
-    concrete subclasses inherit ``is_eligible`` from their sm90 track class, which gates on
-    ``cls.HARDWARE_TARGETS`` (sm100 here) — so hardware selection lives in ``is_eligible``, not in
-    this ``get_seed_config``. Not registered; the two concrete subclasses below are.
-
-    ``promote_seed_to_default`` is inherited from :class:`_TritonReductionSeedBase` (``True`` for
-    every tuned track, sm90 and sm100 alike)."""
-
-    HARDWARE_TARGETS = (("cuda", "sm100"),)
-    # --- B200 constant overrides (re-tuned during the climb; unset = direct port of H100) ---
-    # Load-traffic ceiling (bytes) below which a light streamed row drops to nw8 (see _b200_num_warps).
-    NW8_MAX_ROW_TRAFFIC = 64 * 1024
-    # Element cap for a non-reduction apply loop (see non_reduction_loop_block_cap).
-    NON_REDUCTION_LOOP_MAX_ELEMS = 4096
-    # Row extent at or below which there is too little parallelism to fill 4 warps.
-    NARROW_ROW_MAX_ELEMS = 1024
-    NARROW_ROW_NUM_WARPS = 2
-    # Warp count for a light-traffic row above the narrow cap (was an always-8 split).
-    WIDE_ROW_NUM_WARPS = 4
-    # Heavy-traffic rows up to this extent cap here instead of taking the base ramp's 16/32.
-    HEAVY_ROW_MAX_ELEMS = 16384
-    HEAVY_ROW_NUM_WARPS = 8
-    # M-collapse floor (see TritonStandardReductionHeuristicSM90); 8 overshoots on B200.
-    M_COLLAPSE_MIN_NUM_WARPS = 4
-
-    @classmethod
-    def non_reduction_loop_block_cap(
-        cls, spec: ConfigSpec, pd: ReductionDescriptor
-    ) -> int | None:
-        # Cap EVERY non-reduction apply loop (relieves register pressure on B200).
-        return cls.NON_REDUCTION_LOOP_MAX_ELEMS
-
-    @classmethod
-    def get_seed_config(
-        cls, env: CompileEnvironment, device_ir: DeviceIR
-    ) -> Config | None:
-        # Build the inherited sm90-track seed (is_eligible already confirmed sm100), then re-tune.
-        cfg = super().get_seed_config(env, device_ir)
-        if cfg is None:
-            return None
-        # Re-tune num_warps by the load-traffic key (both tracks, one place); see _b200_num_warps.
-        pd = _primary_descriptor_selected(env)
-        if pd is not None:
-            nw = cls._b200_num_warps(env.config_spec, pd, cfg)
-            if nw is not None:
-                cfg = _config_with_num_warps(cfg, nw)
-        return cfg
-
-    @classmethod
-    def _b200_num_warps(
-        cls, spec: ConfigSpec, pd: ReductionDescriptor, cfg: Config
-    ) -> int | None:
-        """The B200 warp count for a light-traffic PERSISTENT streamed row (8, or 4 at small extent),
-        or None to leave the base ramp untouched. Purely additive: only lowers, never raises."""
-        # Skip M-collapse (grad-parameter .sum(0)): a cross-warp accumulate, not a streamed row.
-        if cls._has_reduced_away_grid(spec):
-            return None
-        # Skip reduce-then-apply (welford / rms_norm_per_block): its reread lives on the non-reduction
-        # loop, not in ``num_load``, so the traffic key can't see it.
-        if cls._non_reduction_loop_ids(spec):
-            return None
-        # Restrict to a single sized reduction: a second one adds cross-warp compute the traffic key
-        # can't see, with a non-monotonic warp optimum.
-        kf = spec.reduction_kernel_fact
-        if (
-            kf is None
-            or sum(1 for d in kf.reductions if d.category in SIZED_REDUCTION_CATEGORIES)
-            != 1
-        ):
-            return None
-        # Skip LOOPED reductions (positive ``reduction_loops`` chunk): they keep the base ramp.
-        loops = cfg.config.get("reduction_loops")
-        if isinstance(loops, (list, tuple)) and any(isinstance(x, int) for x in loops):
-            return None
-        # Load traffic per row = elems × load-width × #loads.
-        traffic = pd.size_hint * max(1, pd.input_load_itemsize) * max(1, pd.num_load)
-        if traffic <= cls.NW8_MAX_ROW_TRAFFIC:
-            # Warps past the useful ones idle while still holding registers and scheduler slots.
-            if pd.size_hint <= cls.NARROW_ROW_MAX_ELEMS:
-                return cls.NARROW_ROW_NUM_WARPS
-            return cls.WIDE_ROW_NUM_WARPS
-        # Heavy traffic: the base ramp's 16/32 is an H100 port that overshoots here up to
-        # HEAVY_ROW_MAX_ELEMS. Genuinely huge rows keep the base ramp.
-        if pd.size_hint <= cls.HEAVY_ROW_MAX_ELEMS:
-            return cls.HEAVY_ROW_NUM_WARPS
-        return None
-
-
-class TritonStandardReductionHeuristicSM100(
-    _TritonReductionSeedSM100, TritonStandardReductionHeuristicSM90
-):
-    """standard (Helion-rolled rdim) inner-reduction seed for sm100/B200: the rich
-    :class:`TritonStandardReductionHeuristicSM90` allocator with B200 constants from
-    :class:`_TritonReductionSeedSM100`."""
-
-    name = "triton_reduction_tile_sm100"
-
-
-class TritonUserTiledReductionHeuristicSM100(
-    _TritonReductionSeedSM100, TritonUserTiledReductionHeuristicSM90
-):
-    """user-tiled inner-reduction seed for sm100/B200: the rich
-    :class:`TritonUserTiledReductionHeuristicSM90` allocator with B200 constants from
-    :class:`_TritonReductionSeedSM100`."""
-
-    name = "triton_reduction_user_tile_sm100"
 
 
 # Hardware the tuned reduction seeds own; the narrow fallback yields to these targets.
-_TUNED_REDUCTION_TARGETS: tuple[HardwareTarget, ...] = (
-    ("cuda", "sm90"),
-    ("cuda", "sm100"),
-)
+_TUNED_REDUCTION_TARGETS = TritonReductionHeuristic.HARDWARE_TARGETS
 
 
 class TritonNarrowReductionHeuristic(AutotunerHeuristic):

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -33,7 +33,6 @@ from .. import exc
 from .. import language as hl
 from ..autotuner.config_spec import FULL_EXTENT_CATEGORIES
 from ..autotuner.config_spec import SIZED_REDUCTION_CATEGORIES
-from ..autotuner.config_spec import CoResidencyGroup
 from ..autotuner.config_spec import CuteLaneLayoutSpec
 from ..autotuner.config_spec import CuteReductionReloadSpec
 from ..autotuner.config_spec import CuteVectorWidthSpec
@@ -1133,6 +1132,7 @@ class DeviceIR:
         - no static extent -> DECLINED (jagged).
         - on the grid + fully resident (cdiv==1) -> FULL_GRID; on the grid + partial -> GRID_TILE.
         - a tunable ``block_sizes`` entry, not on the grid -> USER_TILE.
+        - an off-grid fixed block different from the full extent -> FIXED_TILE.
         - otherwise (rolled ``reduction_loops`` OR materialized full-width) -> FULL_SLICE.
         """
         env = CompileEnvironment.current()
@@ -1145,20 +1145,30 @@ class DeviceIR:
             return ReductionCategory.GRID_TILE
         if block_id in env.config_spec.block_sizes.valid_block_ids():
             return ReductionCategory.USER_TILE
+        from .compile_environment import FixedBlockSizeSource as _Fixed
+
+        source = info.block_size_source
+        if isinstance(source, _Fixed):
+            block = source.value
+            if isinstance(block, (int, torch.SymInt)) and not env.known_equal(
+                block, info.size
+            ):
+                return ReductionCategory.FIXED_TILE
         # FULL_SLICE is reached by elimination, so guard the structural invariant it relies on:
         # a genuine full-slice reduction is one the compiler allocated a reduction dimension for,
         # either ROLLED into reduction_loops (``ReductionLoopBlockSizeSource``) or MATERIALIZED
-        # full-width after the roller declined; a fully-resident specialized axis reduced over in
-        # one program is a ``FixedBlockSizeSource`` (rms_norm_per_block_quant's group_size=128 in a
-        # sequential graph -- on the grid only via a shared hl.tile, so absent from grid_ids here).
+        # full-width after the roller declined. A fully-resident specialized axis reduced over in
+        # one program is a ``FixedBlockSizeSource`` whose block equals its extent
+        # (rms_norm_per_block_quant's group_size=128 in a sequential graph -- on the grid only via
+        # a shared hl.tile, so absent from grid_ids here). A smaller fixed block returned above as
+        # FIXED_TILE rather than falling through to this full-width case.
         # ANY OTHER source landing here (e.g. a plain ``LoopSpecBlockSizeSource`` that should have
         # been USER_TILE) means the kernel fell through for the WRONG reason and may be mis-sized.
         # Debug-level (this fires on real corpus cells -- rms_norm_per_block_quant -- so it is not
         # an anomaly, just an inspection hook), never crash.
-        from .compile_environment import FixedBlockSizeSource as _Fixed
         from .compile_environment import ReductionLoopBlockSizeSource as _RedLoop
 
-        if not isinstance(info.block_size_source, (_RedLoop, _Fixed)):
+        if not isinstance(source, (_RedLoop, _Fixed)):
             log.debug(
                 "reduction block_id %s classified FULL_SLICE by fallthrough but carries "
                 "%s, not ReductionLoopBlockSizeSource or FixedBlockSizeSource -- the full-slice "
@@ -1171,29 +1181,17 @@ class DeviceIR:
     def build_reduction_kernel_fact(
         self,
         memory_op_facts: list[MemoryOpFact],
-        accumulator_facts: list[AccumulatorFact],
         analysis: DeviceIRAnalysis,
     ) -> None:
-        """Build the categorizing ``ReductionKernelFact`` — the list of reduction descriptors +
-        their ``graph_id`` co-residency groups + the non-reduction loops + the parallel grid axes.
-        The reduction seed + the Stage-2 allocator consume this fact directly.
+        """Build reduction descriptors, loop/grid axes, and complete liveness facts.
+
+        The reduction seed resolves every candidate against the full live-step timeline.
         """
         env = CompileEnvironment.current()
         spec = env.config_spec
         grid_ids = {b for bids in self.grid_block_ids for b in bids}
 
         occurrences = analysis.original_reductions()
-        # carried-2D tiles: count of accumulators whose last dim is the rdim (per block_id,
-        # kernel-wide -- an accumulator is carried across the whole inner loop, so it is not
-        # graph-scoped). A count (not a bool) is load-bearing: the carried byte cap divides the
-        # budget by it, so the descriptor must carry the multiplicity.
-        carried_2d_by_bid: dict[int, int] = {}
-        for a in accumulator_facts:
-            if len(a.dim_block_ids) >= 2 and a.dim_block_ids[-1] is not None:
-                carried_2d_by_bid[a.dim_block_ids[-1]] = (
-                    carried_2d_by_bid.get(a.dim_block_ids[-1], 0) + 1
-                )
-
         descriptors: list[ReductionDescriptor] = []
         for gid, bid in occurrences:
             category = self._categorize_reduction(bid, grid_ids)
@@ -1201,85 +1199,83 @@ class DeviceIR:
             size_hint = (
                 info.size_hint() if isinstance(info.size, (int, torch.SymInt)) else 0
             )
-            per = self._per_reduction_memory_fields(bid, gid, memory_op_facts)
+            fixed_tile_size_hint = None
+            if category is ReductionCategory.FIXED_TILE:
+                from .compile_environment import FixedBlockSizeSource
+
+                source = info.block_size_source
+                assert isinstance(source, FixedBlockSizeSource)
+                fixed_tile_size_hint = env.size_hint(source.value)
+            per = self._per_reduction_memory_fields(bid, memory_op_facts)
             descriptors.append(
                 ReductionDescriptor(
                     category=category,
                     block_id=bid,
                     graph_id=gid,
                     size_hint=size_hint,
-                    itemsize=analysis.reduction_input_itemsize(bid),
                     input_load_itemsize=per["input_load_itemsize"],
-                    carried_2d_count=carried_2d_by_bid.get(bid, 0),
                     row_reread=per["row_reread"],
                     reread_eviction_index=per["reread_eviction_index"],
-                    num_load=per["num_load"],
+                    fixed_tile_size_hint=fixed_tile_size_hint,
                 )
             )
 
-        # Co-residency groups = original graph_id equivalence classes. The materialized-feature
-        # footprint a group byte-caps against is not stored here — the Stage-2 allocator derives it
-        # at the comparison site (each group can materialize different feature axes, so a kernel-wide
-        # value would be wrong for a multi-group kernel).
-        groups_by_gid: dict[int, list[int]] = {}
-        for idx, d in enumerate(descriptors):
-            groups_by_gid.setdefault(d.graph_id, []).append(idx)
-        # The per-group resident tile set: each group's peak live tiles, attributed home +
-        # driven-loop-bodies, max'd across If/Else. Consumed by the Stage-2 footprint (which sums
-        # ∏(dims) per actual tile).
-        #
-        # Preserve the legacy best-effort fallback: incomplete graph metadata
-        # yields an extent-based footprint rather than failing fact construction.
-        # The focused reduction corpus keeps this liveness-derived field pinned.
-        try:
-            group_live = analysis.group_live_tiles(sorted(groups_by_gid))
-        except (KeyError, AttributeError, TypeError):
-            group_live = {}
-        coresidency_groups = tuple(
-            CoResidencyGroup(
-                graph_id=gid,
-                descriptor_indices=tuple(idxs),
-                live_tiles=tuple(group_live.get(gid, [])),
-            )
-            for gid, idxs in sorted(groups_by_gid.items())
-        )
-
-        # non-reduction loops + parallel grid axes. The non-reduction loops are the union over the
-        # sized reductions' apply/normalize candidates; the grid axes are grid block_ids with no
-        # reduction sized over them.
+        # Non-reduction loops + parallel grid axes. Every tunable off-grid loop that is not itself
+        # a reduction receives the same policy; extent equality with a reduction is not a useful
+        # distinction (an apply pass may legitimately have a different logical extent).
         sized_bids = {
             d.block_id for d in descriptors if d.category in SIZED_REDUCTION_CATEGORIES
         }
-        non_reduction_loops: set[int] = set()
-        for bid in sized_bids:
-            non_reduction_loops.update(
-                self._non_reduction_loop_candidates(bid, grid_ids)
-            )
-        non_reduction_loops -= sized_bids
+        reduction_bids = {d.block_id for d in descriptors}
+        non_reduction_loops = set(spec.block_sizes.valid_block_ids()) - (
+            grid_ids | reduction_bids
+        )
         grid_axis_block_ids = tuple(sorted(grid_ids - sized_bids))
+
+        coalescing_sensitive: set[int] = set()
+        for memory in memory_op_facts:
+            axis_ids = (
+                memory.subscript_affine_block_ids
+                or memory.subscript_block_ids
+                or memory.indexed_block_ids
+            )
+            fed_reduction_ids = tuple(axis for axis, _ in memory.reductions_fed)
+            for index, block_id in enumerate(axis_ids):
+                stride = (
+                    memory.subscript_strides[index]
+                    if index < len(memory.subscript_strides)
+                    else 0
+                )
+                gather_scale = (
+                    memory.subscript_index_scales[index]
+                    if index < len(memory.subscript_index_scales)
+                    else 1
+                )
+                if stride != 1 or gather_scale != 1:
+                    continue
+                if block_id is not None:
+                    coalescing_sensitive.add(block_id)
+                elif len(fed_reduction_ids) == 1:
+                    # A plain ``:`` slice has no tile-index block id even
+                    # though the compiler later rolls that contiguous axis as
+                    # a reduction. The dataflow attribution supplies the
+                    # otherwise missing identity without guessing by extent.
+                    coalescing_sensitive.add(fed_reduction_ids[0])
 
         spec.reduction_kernel_fact = ReductionKernelFact(
             reductions=tuple(descriptors),
-            coresidency_groups=coresidency_groups,
             non_reduction_loop_block_ids=tuple(sorted(non_reduction_loops)),
             grid_axis_block_ids=grid_axis_block_ids,
+            live_tile_steps=analysis.kernel_live_tile_steps(),
+            coalescing_sensitive_block_ids=tuple(sorted(coalescing_sensitive)),
         )
 
     def _per_reduction_memory_fields(
         self,
         red_block_id: int,
-        graph_id: int,
         memory_op_facts: list[MemoryOpFact],
     ) -> dict:
-        """The memory-op-derived per-reduction fields, computed exactly as
-        ``_assemble_reduction_fact`` does (so a descriptor is field-equal to the legacy fact),
-        but SCOPED to this reduction's original graph for ``num_load`` (a co-resident pass loads
-        in its own graph). ``row_reread`` / ``input_load_itemsize`` are axis-keyed and
-        graph-agnostic (a re-read is global to the axis), matching the legacy computation.
-        """
-        num_load = sum(
-            1 for f in memory_op_facts if f.kind == "load" and f.graph_id == graph_id
-        )
+        """Derive the reduction's row reread and input-width memory signals."""
         row_reread = False
         reread_eviction_index: int | None = None
         for f in memory_op_facts:
@@ -1315,7 +1311,6 @@ class DeviceIR:
             ]
             input_load_itemsize = min(row_sizes) if row_sizes else 0
         return {
-            "num_load": num_load,
             "row_reread": row_reread,
             "reread_eviction_index": reread_eviction_index,
             "input_load_itemsize": input_load_itemsize,
@@ -1332,48 +1327,27 @@ class DeviceIR:
     def build_matmul_reduction_epilogue_facts(self) -> None:
         """Phase 4: compose a ``MatmulWithReductionEpilogueFact`` for a fused matmul +
         reduction-over-output-axis epilogue. Fires iff exactly one ``MatmulFact`` AND exactly
-        one SIZED full-extent reduction descriptor in a singleton co-residency group (the
-        epilogue reduction over the specialized output N); holds the matmul fact plus the
+        one sized full-extent reduction descriptor in its original graph (the epilogue
+        reduction over specialized output N); holds the matmul fact plus the
         N-extent the seed keys on. Pure-matmul kernels have no epilogue reduction and
         pure-reduction kernels no MatmulFact, so the composed fact fires ONLY on the fused
         family.
 
-        CONSTRAINT (PROMPT §2.9 — must NOT inherit the relaxed reduction gate): the epilogue
-        seed is tuned for ONE specific reduction shape (a single full-extent reduction over the
-        specialized output N, no other reduction co-resident). Expressed in the Stage-1
-        vocabulary: exactly ONE sized reduction, FULL_SLICE/FULL_GRID, in a singleton
-        co-residency group. A MULTI-reduction matmul kernel must NOT compose this fact (its
-        bare ``reduction.size_hint`` would no longer be unambiguously the epilogue's N).
+        The epilogue seed is tuned for one full-extent reduction over specialized output N.
+        Another reduction in the same original graph makes that N attribution ambiguous.
         """
         env = CompileEnvironment.current()
         spec = env.config_spec
 
         if len(spec.matmul_facts) != 1:
             return
-        # §2.9 guard (Stage-1 vocabulary): the kernel's SIZED reductions must be exactly ONE
-        # full-extent reduction in a singleton co-residency group — a single epilogue reduction
-        # over the specialized output N, no other reduction co-resident. A MULTI-reduction matmul
-        # kernel must NOT compose this fact (its epilogue N would be ambiguous). This is the sole
-        # reduction gate (the legacy ``len(reduction_facts)==1`` check it replaced was strictly
-        # looser — this also rejects a co-resident second sized reduction).
         kf = spec.reduction_kernel_fact
         if kf is None:
             return
         sized = [d for d in kf.reductions if d.category in SIZED_REDUCTION_CATEGORIES]
         if len(sized) != 1 or sized[0].category not in FULL_EXTENT_CATEGORIES:
             return
-        group = next(
-            (
-                g
-                for g in kf.coresidency_groups
-                if any(
-                    kf.reductions[i].block_id == sized[0].block_id
-                    for i in g.descriptor_indices
-                )
-            ),
-            None,
-        )
-        if group is not None and len(group.descriptor_indices) != 1:
+        if sum(d.graph_id == sized[0].graph_id for d in kf.reductions) != 1:
             return
         matmul = spec.matmul_facts[0]
         # N-extent = the epilogue reduction's extent (the specialized, hl.specialize'd output N).
@@ -1434,42 +1408,6 @@ class DeviceIR:
         if not isinstance(block, (int, torch.SymInt)):
             return False
         return bool(env.known_equal(block, info.size))
-
-    def _non_reduction_loop_candidates(
-        self, red_block_id: int, grid_ids: set[int]
-    ) -> tuple[int, ...]:
-        """Identify non-reduction loop tiles for ``red_block_id`` -- non-grid
-        ``block_sizes`` loops that are NOT the reduction axis. Shared by the standard
-        and user-tiled fact builders.
-
-        Returns ``qualifying`` (block_sizes order): candidate loops spanning the
-        reduction extent with a resolvable static size -- the seed widens these to
-        ``next_pow2``. A non-qualifying candidate (extent unresolvable or != the
-        reduction extent) is left out and floored by the caller.
-        """
-        try:
-            red_info = CompileEnvironment.current().block_sizes[red_block_id]
-        except (IndexError, KeyError):
-            return ()
-        if not isinstance(red_info.size, (int, torch.SymInt)):
-            return ()
-        red_size_hint = red_info.size_hint()
-
-        env = CompileEnvironment.current()
-        qualifying: list[int] = []
-        for bid in env.config_spec.block_sizes.valid_block_ids():
-            if bid in grid_ids or bid == red_block_id:
-                continue
-            try:
-                info = env.block_sizes[bid]
-            except (IndexError, KeyError):
-                continue
-            if not isinstance(info.size, (int, torch.SymInt)) or (
-                info.size_hint() != red_size_hint
-            ):
-                continue
-            qualifying.append(bid)
-        return tuple(qualifying)
 
     def build_codegen_graphs(self, config: Config) -> list[GraphInfo]:
         """Build and return graph copies with reduction rolling and epilogue subtiling applied.
@@ -3395,11 +3333,9 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
         # may read them), so build them independently of the reduction facts. Must run
         # after the rolling (it walks the rolled loop subgraphs).
         config_spec.accumulator_facts = device_ir.build_accumulator_facts(analysis)
-        # Phase 3 (PROMPT §2.1/§2.2): build the categorizing ReductionKernelFact — the first-class
-        # reduction-descriptor list + co-residency groups the reduction seed + allocator consume.
+        # Build the reduction descriptors and candidate-resolved liveness facts.
         device_ir.build_reduction_kernel_fact(
             memory_op_facts,
-            config_spec.accumulator_facts,
             analysis,
         )
         # Phase 3b: compose the whole-kernel contraction fact for ANY kernel with a matmul,

--- a/helion/_compiler/device_ir_analysis.py
+++ b/helion/_compiler/device_ir_analysis.py
@@ -377,25 +377,14 @@ def tile_rank(dims: tuple[int | None, ...]) -> int:
     return sum(dim is not None for dim in dims)
 
 
-def tile_set_rank_profile(
-    tiles: Iterable[tuple[int | None, ...]],
-    max_rank: int,
-) -> tuple[int, ...]:
-    """Block-size-free lexicographic footprint key, highest rank first."""
-    by_rank: dict[int, int] = {}
-    for tile in tiles:
-        rank = tile_rank(tile)
-        if rank:
-            by_rank[rank] = by_rank.get(rank, 0) + 1
-    return tuple(by_rank.get(rank, 0) for rank in range(max_rank, 0, -1))
-
-
 def _live_tile_kind(node: torch.fx.Node, dot_targets: frozenset[object]) -> str:
     from ..language import memory_ops
 
     if node.op == "placeholder":
         return "carry"
     if node.op == "call_function":
+        if node.target is _tracing_ops._host_tensor:
+            return "global"
         if node.target in dot_targets:
             return "dot_out"
         if node.target is memory_ops.load:
@@ -524,13 +513,11 @@ class GraphAnalysis:
     block_ids: frozenset[int]
     block_id_order: tuple[int, ...]
     live_tile_steps: tuple[tuple[LiveTile, ...], ...]
-    peak_live_tiles: tuple[LiveTile, ...]
     peak_dot_output_tiles: tuple[LiveTile, ...]
     peak_promoted_lhs_tiles: tuple[LiveTile, ...]
     dot_nodes: tuple[torch.fx.Node, ...]
     reduction_occurrences: tuple[int, ...]
     reduction_axis_by_node_id: dict[int, int]
-    reduction_input_itemsizes: tuple[tuple[int, int], ...]
     memory_tiles: tuple[tuple[torch.fx.Node, LiveTile], ...]
     _memory_tiles_by_loop_axes: dict[frozenset[int], tuple[LiveTile, ...]] = (
         dataclasses.field(
@@ -562,7 +549,6 @@ class GraphAnalysis:
         reduction_occurrences: list[int] = []
         seen_reductions: set[int] = set()
         reduction_axis_by_node_id: dict[int, int] = {}
-        reduction_input_itemsizes: list[tuple[int, int]] = []
         memory_tiles: list[tuple[torch.fx.Node, LiveTile]] = []
         operand_positions = matmul_operand_positions()
         promoted_lhs_nodes: set[torch.fx.Node] = set()
@@ -585,7 +571,10 @@ class GraphAnalysis:
             for input_node in node.all_input_nodes:
                 last_use[input_node] = index
 
-            kind = _live_tile_kind(node, dot_targets)
+            kind_node = resolve_placeholder(node) if node.op == "placeholder" else node
+            kind = _live_tile_kind(kind_node, dot_targets)
+            if node.op == "placeholder" and kind != "global":
+                kind = "carry"
             tile = _tile_from_tensor(node.meta.get("val"), env, kind=kind)
             if tile is not None and kind == "dot_out":
                 dot_details[node] = tile
@@ -608,13 +597,6 @@ class GraphAnalysis:
                     if block_id not in seen_reductions:
                         seen_reductions.add(block_id)
                         reduction_occurrences.append(block_id)
-                    for input_node in node.all_input_nodes:
-                        input_value = input_node.meta.get("val")
-                        if isinstance(input_value, torch.Tensor):
-                            reduction_input_itemsizes.append(
-                                (block_id, input_value.element_size())
-                            )
-                            break
 
             if node.op != "call_function":
                 continue
@@ -639,12 +621,6 @@ class GraphAnalysis:
 
         live_tile_steps: list[tuple[LiveTile, ...]] = []
         seen_steps: set[frozenset[int]] = set()
-        max_rank = max(
-            (tile_rank(tile.dim_block_ids) for tile in tile_details.values()),
-            default=0,
-        )
-        best_key: tuple[int, ...] = ()
-        peak_live_tiles: tuple[LiveTile, ...] = ()
         for live in _live_node_steps(nodes, tile_details, last_use):
             if live:
                 step_key = frozenset(id(value) for value in live)
@@ -652,13 +628,6 @@ class GraphAnalysis:
                 if step_key not in seen_steps:
                     seen_steps.add(step_key)
                     live_tile_steps.append(step)
-                key = tile_set_rank_profile(
-                    (tile_details[value].dim_block_ids for value in live),
-                    max_rank,
-                )
-                if key > best_key:
-                    best_key = key
-                    peak_live_tiles = step
 
         def peak_role_tiles(
             details: dict[torch.fx.Node, LiveTile],
@@ -696,13 +665,11 @@ class GraphAnalysis:
             block_ids=frozenset(getattr(graph_info, "block_ids", ()) or ()),
             block_id_order=tuple(getattr(graph_info, "block_ids", ()) or ()),
             live_tile_steps=tuple(live_tile_steps),
-            peak_live_tiles=peak_live_tiles,
             peak_dot_output_tiles=peak_dot_output_tiles,
             peak_promoted_lhs_tiles=peak_promoted_lhs_tiles,
             dot_nodes=tuple(dot_nodes),
             reduction_occurrences=tuple(reduction_occurrences),
             reduction_axis_by_node_id=reduction_axis_by_node_id,
-            reduction_input_itemsizes=tuple(reduction_input_itemsizes),
             memory_tiles=tuple(memory_tiles),
         )
 
@@ -768,6 +735,7 @@ class DeviceIRAnalysis:
         env: CompileEnvironment,
     ) -> DeviceIRAnalysis:
         from .device_ir import ForLoopGraphInfo
+        from .device_ir import HelperFunctionGraphInfo
         from .device_ir import NodeArgsGraphInfo
         from .device_ir import ReductionLoopGraphInfo
 
@@ -781,7 +749,9 @@ class DeviceIRAnalysis:
             while node.op == "placeholder" and node not in seen:
                 seen.add(node)
                 graph_info = graph_info_by_graph.get(node.graph)
-                if not isinstance(graph_info, NodeArgsGraphInfo):
+                if not isinstance(graph_info, NodeArgsGraphInfo) or isinstance(
+                    graph_info, HelperFunctionGraphInfo
+                ):
                     break
                 try:
                     node = graph_info.placeholder_to_outer_arg(node)
@@ -892,16 +862,14 @@ class DeviceIRAnalysis:
             for block_id in graph.reduction_occurrences
         )
 
-    def reduction_input_itemsize(self, block_id: int) -> int:
-        """Legacy last-occurrence input width for one reduction axis."""
-        itemsize = 0
-        for graph in self.graphs:
-            for axis, width in graph.reduction_input_itemsizes:
-                if axis == block_id:
-                    itemsize = width
-        return itemsize
-
     def kernel_live_tile_steps(self) -> tuple[tuple[LiveTile, ...], ...]:
+        """Every original graph step, kept separate across sequential regions.
+
+        Loop-body placeholders already represent the values carried into that
+        body, including enclosing-loop carries. Flattening the graph-local
+        timelines therefore preserves complete body residency without summing
+        state from sequential graphs or mutually exclusive branches.
+        """
         return tuple(
             step
             for graph in self.non_reduction_graphs
@@ -940,51 +908,6 @@ class DeviceIRAnalysis:
     def kernel_peak_promoted_lhs(self) -> tuple[LiveTile, ...]:
         """Peak transformed-LHS set after adding ancestor loop graphs."""
         return self._kernel_peak_role_tiles("peak_promoted_lhs_tiles")
-
-    def group_live_tiles(
-        self,
-        group_graph_ids: list[int],
-    ) -> dict[int, list[tuple[int | None, ...]]]:
-        """Resident peak-live tiles attributed to reduction co-residency groups."""
-        group_axes = {
-            graph_id: set(self.by_id[graph_id].reduction_occurrences)
-            for graph_id in group_graph_ids
-        }
-        peak_of = {
-            graph.graph_id: [tile.dim_block_ids for tile in graph.peak_live_tiles]
-            for graph in self.non_reduction_graphs
-        }
-
-        def max_by_profile(
-            lhs: list[tuple[int | None, ...]],
-            rhs: list[tuple[int | None, ...]],
-        ) -> list[tuple[int | None, ...]]:
-            max_rank = max(
-                (tile_rank(tile) for tile in lhs + rhs),
-                default=0,
-            )
-            lhs_key = tile_set_rank_profile(lhs, max_rank)
-            rhs_key = tile_set_rank_profile(rhs, max_rank)
-            return lhs if lhs_key >= rhs_key else rhs
-
-        group_keys = set(group_graph_ids)
-        result: dict[int, list[tuple[int | None, ...]]] = {}
-        for graph_id in group_graph_ids:
-            axes = group_axes[graph_id]
-            tiles = list(peak_of.get(graph_id, ()))
-            seen_bodies = {graph_id}
-            frontier = [graph_id]
-            while frontier:
-                current = frontier.pop()
-                for body_id, block_ids in self.child_loops.get(current, ()):
-                    if body_id in seen_bodies or body_id in group_keys:
-                        continue
-                    if not axes or (block_ids & axes):
-                        seen_bodies.add(body_id)
-                        tiles = max_by_profile(tiles, peak_of.get(body_id, []))
-                        frontier.append(body_id)
-            result[graph_id] = tiles
-        return result
 
     def accumulator_facts(
         self,

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -255,7 +255,7 @@ class DotAxes(NamedTuple):
 
 
 class LiveTile(NamedTuple):
-    """One simultaneously-live tensor tile at a graph's peak-live step.
+    """One simultaneously-live tensor tile at one graph step.
 
     Extends the bare ``dim_block_ids`` liveness view with the two things a resource
     estimate cannot be written without: how WIDE an element is, and WHO produced
@@ -268,7 +268,9 @@ class LiveTile(NamedTuple):
     - ``static_dims`` — the extent at each ``None`` position, so a footprint can be
       computed without re-resolving shapes (``None`` where unresolvable).
     - ``itemsize`` — element width in bytes.
-    - ``kind`` — ``"dot_out"`` | ``"load"`` | ``"carry"`` | ``"other"``.
+    - ``kind`` — ``"dot_out"`` | ``"load"`` | ``"carry"`` | ``"other"`` |
+      ``"global"``. A global tensor handle is retained in the structural
+      timeline but is not register-resident.
     - ``stageable`` — for a loop-body load, whether its index is proven to
       vary with the enclosing loop. ``None`` means uncertain and is charged
       conservatively as stageable.
@@ -498,7 +500,9 @@ class ReductionCategory(enum.Enum):
     - ``FULL_GRID`` — a full-extent axis on the grid, block == extent (fully resident per program).
     - ``GRID_TILE`` — a grid axis reduced over but NOT full-extent: the grid parallelizes the
       reduction across programs, so the whole-axis size is not a per-program extent.
-    - ``USER_TILE`` — an inner sequential ``hl.tile`` the user wrote over the reduction axis.
+    - ``USER_TILE`` — a tunable inner sequential ``hl.tile`` over the reduction axis.
+    - ``FIXED_TILE`` — an inner sequential ``hl.tile`` whose explicit fixed block differs from
+      the full iteration extent.
     - ``DECLINED`` — no static extent (e.g. jagged / data-dependent); recorded but never sized.
     """
 
@@ -506,17 +510,19 @@ class ReductionCategory(enum.Enum):
     FULL_GRID = "full_grid"
     GRID_TILE = "grid_tile"
     USER_TILE = "user_tile"
+    FIXED_TILE = "fixed_tile"
     DECLINED = "declined"
 
 
-# Categories the seed sizes a per-program reduction extent for. GRID_TILE (grid-parallelized
-# partial) stays a grid row and DECLINED (no static extent) falls back to the default, so neither
-# is sized as a reduction.
+# Categories for which the seed has a statically modelable per-program reduction width.
+# FIXED_TILE is already fixed rather than chosen by the seed. GRID_TILE (grid-parallelized
+# partial) stays a grid row and DECLINED (no static extent) falls back to the default.
 SIZED_REDUCTION_CATEGORIES = frozenset(
     {
         ReductionCategory.FULL_SLICE,
         ReductionCategory.FULL_GRID,
         ReductionCategory.USER_TILE,
+        ReductionCategory.FIXED_TILE,
     }
 )
 # Categories that occupy the full reduction extent within one program.
@@ -527,71 +533,49 @@ FULL_EXTENT_CATEGORIES = frozenset(
 
 class ReductionDescriptor(NamedTuple):
     """One reduction OCCURRENCE: a (``graph_id``, ``block_id``) reduction on the ORIGINAL
-    (pre-roll) device graphs. Stage 1 emits a list of these; the Stage-2 allocator consumes them.
+    (pre-roll) device graphs. Stage 1 emits a list of these; the allocator consumes them.
 
     A reduction axis may occur in more than one original graph (e.g. a kernel that reduces the
     same axis in two separate passes) — each occurrence is its own descriptor, so sequential
     passes over one axis are NOT collapsed.
 
-    Descriptors with the same ``graph_id`` are co-resident (the compiler fused them into one graph
-    -> shared resident working set). ``graph_id`` is read off the ORIGINAL graphs only (rolled
-    ``ReductionLoopGraphInfo`` subgraphs excluded), so it is invariant to the autotuner flipping a
+    ``graph_id`` is read off the ORIGINAL graphs only (rolled ``ReductionLoopGraphInfo``
+    subgraphs excluded), so it is invariant to the autotuner flipping a
     ``reduction_loops`` knob.
 
     Fields:
     - ``category``: the :class:`ReductionCategory`.
-    - ``block_id`` / ``graph_id``: the reduction axis + its original-graph co-residency key.
-    - ``size_hint`` / ``itemsize`` / ``input_load_itemsize``: extent (element count), the
-      fp32-promoted accumulator itemsize, and the HBM-load element width feeding it.
-    - ``carried_2d_count``: the NUMBER of >=2-D ``[M_BLOCK, R_BLOCK]`` loop-carried accumulators
-      whose last dim is this rdim (e.g. kl_div=1, jsd=2); those tiles stay resident the whole loop.
-      A count (not a bool) because the carried byte cap divides the budget by it. 0 = none here.
-    - ``row_reread`` / ``reread_eviction_index`` / ``num_load``: per-reduction memory-op signals.
+    - ``block_id`` / ``graph_id``: the reduction axis and original graph.
+    - ``size_hint`` / ``input_load_itemsize``: logical extent and the HBM-load element width
+      feeding it.
+    - ``fixed_tile_size_hint``: fixed per-iteration width for ``FIXED_TILE``; ``None`` otherwise.
+    - ``row_reread`` / ``reread_eviction_index``: per-reduction memory-op signals.
     """
 
     category: ReductionCategory
     block_id: int
     graph_id: int
     size_hint: int
-    itemsize: int
     input_load_itemsize: int = 0
-    carried_2d_count: int = 0
     row_reread: bool = False
     reread_eviction_index: int | None = None
-    num_load: int = 0
-
-
-class CoResidencyGroup(NamedTuple):
-    """A ``graph_id`` equivalence class of reductions whose working tiles are live at the same
-    time, so ONE budget must fit them all. ``descriptor_indices`` indexes into
-    ``ReductionKernelFact.reductions``.
-
-    ``live_tiles`` is the group's resident tile set — one ``dim_block_ids`` tuple per
-    register-resident tile (the block id each dim spans, ``None`` for a static/broadcast dim). It
-    is the peak live set of the group's home graph, combined with the for-loop bodies the group
-    drives and its If/Else branch siblings (see device_ir ``_group_live_tiles``). Each loop-carried
-    accumulator is captured inline at its real shape, so the Stage-2 footprint can sum ``∏(dim
-    widths)`` per actual tile. Empty when the fact is built without a live env (a bare-spec test).
-    """
-
-    graph_id: int
-    descriptor_indices: tuple[int, ...]
-    live_tiles: tuple[tuple[int | None, ...], ...] = ()
+    fixed_tile_size_hint: int | None = None
 
 
 class ReductionKernelFact(NamedTuple):
-    """The per-kernel Stage-1 product that Stage 2 consumes: the list of reduction descriptors,
-    their co-residency groups (``graph_id`` classes), the non-reduction user-tiled loops (sized as
-    a separate pass), and the parallel grid axes (rows with no reduction over them).
+    """The per-kernel reduction product: reduction descriptors, every tunable off-grid
+    non-reduction loop, parallel grid axes, the complete live-tile timeline, and axes whose
+    contiguous memory access makes them coalescing-sensitive.
 
     Built by ``build_reduction_kernel_fact``. ``reductions`` may be empty (a kernel with only
     GRID_TILE / DECLINED reductions, or none) — the seed then declines.
     """
 
     reductions: tuple[ReductionDescriptor, ...]
-    coresidency_groups: tuple[CoResidencyGroup, ...]
     non_reduction_loop_block_ids: tuple[int, ...] = ()
     grid_axis_block_ids: tuple[int, ...] = ()
+    live_tile_steps: tuple[tuple[LiveTile, ...], ...] = ()
+    coalescing_sensitive_block_ids: tuple[int, ...] = ()
 
 
 class MatmulWithReductionEpilogueFact(NamedTuple):
@@ -687,9 +671,7 @@ class MemoryOpFact(NamedTuple):
 class AccumulatorFact(NamedTuple):
     """One loop-carried tensor accumulator in a reduction loop, recorded at compile time.
     Reduction-AGNOSTIC (like ``MemoryOpFact``): ``dim_block_ids`` is the per-dim block-id
-    provenance (``None`` for a static dim), ``itemsize`` the element size. Accumulators whose last
-    dim is the reduction axis feed ``ReductionDescriptor.carried_2d_count`` (a 1-D ``[M_BLOCK]``
-    scalar accumulator counts as 0).
+    provenance (``None`` for a static dim), and ``itemsize`` is the element size.
     """
 
     dim_block_ids: tuple[int | None, ...]

--- a/helion/autotuner/llm/prompting.py
+++ b/helion/autotuner/llm/prompting.py
@@ -209,11 +209,9 @@ _HEURISTIC_PURPOSES: Mapping[str, str] = {
         "skinny GEMM (one operand dim >> the other): tile the long dims and "
         "use a deep K tile"
     ),
-    "triton_reduction_tile": (
-        "canonical row reduction (softmax/rms_norm/cross_entropy): one row per "
-        "program with a single persistent pass over the reduction axis "
-        "(reduction_loops null, not a rolled loop), warps scaled to the "
-        "reduction width"
+    "triton_reduction": (
+        "reduction kernel: size all live tiles together, choose reduction "
+        "persistence or chunking, and scale warps to selected parallel work"
     ),
 }
 

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -57,19 +57,8 @@ from helion._compiler.autotuner_heuristics.triton import (
 from helion._compiler.autotuner_heuristics.triton import TritonH100MultiMatmulHeuristic
 from helion._compiler.autotuner_heuristics.triton import TritonNarrowReductionHeuristic
 from helion._compiler.autotuner_heuristics.triton import TritonPointwiseSeedHeuristic
+from helion._compiler.autotuner_heuristics.triton import TritonReductionHeuristic
 from helion._compiler.autotuner_heuristics.triton import TritonSkinnyGemmHeuristic
-from helion._compiler.autotuner_heuristics.triton import (
-    TritonStandardReductionHeuristicSM90,
-)
-from helion._compiler.autotuner_heuristics.triton import (
-    TritonStandardReductionHeuristicSM100,
-)
-from helion._compiler.autotuner_heuristics.triton import (
-    TritonUserTiledReductionHeuristicSM90,
-)
-from helion._compiler.autotuner_heuristics.triton import (
-    TritonUserTiledReductionHeuristicSM100,
-)
 from helion._compiler.autotuner_heuristics.triton import _h100_matmul_tile
 from helion._compiler.backend import CuteBackend
 from helion._compiler.backend import TritonBackend
@@ -282,11 +271,11 @@ from helion.autotuner.config_fragment import EnumFragment
 from helion.autotuner.config_generation import ConfigGeneration
 from helion.autotuner.config_spec import BlockSizeSpec
 from helion.autotuner.config_spec import ConfigSpec
-from helion.autotuner.config_spec import CoResidencyGroup
 from helion.autotuner.config_spec import DotAxes
 from helion.autotuner.config_spec import DotAxisKind
 from helion.autotuner.config_spec import DotSite
 from helion.autotuner.config_spec import KernelMatmulFact
+from helion.autotuner.config_spec import LiveTile
 from helion.autotuner.config_spec import MatmulFact
 from helion.autotuner.config_spec import ReductionCategory
 from helion.autotuner.config_spec import ReductionDescriptor
@@ -1307,10 +1296,7 @@ class TestAutotunerHeuristic(TestCase):
             TritonH100FormulaMatmulHeuristic,
             TritonH100MultiMatmulHeuristic,
             TritonPointwiseSeedHeuristic,
-            TritonStandardReductionHeuristicSM90,
-            TritonStandardReductionHeuristicSM100,
-            TritonUserTiledReductionHeuristicSM90,
-            TritonUserTiledReductionHeuristicSM100,
+            TritonReductionHeuristic,
         ):
             self.assertEqual(
                 heuristic.CACHE_SPECIALIZATION_FACTS,
@@ -5166,18 +5152,16 @@ class TestPointwiseArchConstants(TestCase):
                 )
 
 
-class TestTritonStandardReductionHeuristic(TestCase):
-    """Triton standard row-reduction heuristic: seeds the "one row per program"
-    skeleton with an rnumel-scaled ``num_warps`` ramp and faithful per-slot load
-    eviction, fires only for a canonical row reduction, and its persistent seed
-    survives flatten/unflatten (the config_spec sentinel round-trip fix).
+class TestTritonReductionHeuristicUnit(TestCase):
+    """Triton reduction heuristic: sizes a unified live candidate,
+    chooses warps from lane-parallel reduction width, seeds faithful per-slot load
+    eviction, and preserves persistent sentinels through flatten/unflatten.
     """
 
     def _reduction_spec(
         self,
         *,
         reduction_size_hint: int,
-        num_load: int = 1,
         itemsize: int = 4,
         row_reread: bool = False,
     ) -> ConfigSpec:
@@ -5186,33 +5170,20 @@ class TestTritonStandardReductionHeuristic(TestCase):
         spec.reduction_loops.append(
             ReductionLoopSpec(block_id=1, size_hint=reduction_size_hint)
         )
-        # The deepened heuristic reads the primary ReductionDescriptor (the workload facts it
-        # keys the warp ramp / eviction / persist decision on) off the ReductionKernelFact; the
-        # reduction axis is block_id=1 (the rolled reduction loop above, so a FULL_SLICE), the
-        # row/grid axis is block_id=0.
         desc = ReductionDescriptor(
             category=ReductionCategory.FULL_SLICE,
             block_id=1,
             graph_id=0,
             size_hint=reduction_size_hint,
-            itemsize=itemsize,
             input_load_itemsize=itemsize,
             row_reread=row_reread,
-            num_load=num_load,
         )
         spec.reduction_kernel_fact = ReductionKernelFact(
             reductions=(desc,),
-            coresidency_groups=(
-                CoResidencyGroup(
-                    graph_id=0,
-                    descriptor_indices=(0,),
-                    # The resident live tiles of a one-row reduction (softmax/rms_norm-like): the
-                    # ``[grid_M, rdim]`` read/compute tile + a ``[grid_M]`` scalar carry. The grid
-                    # axis (block_id 0) APPEARS in a live tile -> it is register-RESIDENT, so
-                    # ``_has_reduced_away_grid`` is False (it is NOT a grad-parameter ``.sum(0)``
-                    # collapse). Without this the grid axis is in no tile and the residency test
-                    # wrongly flags a collapse, tripping the num_warps>=8 grad-param floor.
-                    live_tiles=((0, 1), (0,)),
+            live_tile_steps=(
+                (
+                    LiveTile((0, 1), (None, None), itemsize, "other"),
+                    LiveTile((0,), (None,), itemsize, "carry"),
                 ),
             ),
             grid_axis_block_ids=(0,),
@@ -5220,35 +5191,23 @@ class TestTritonStandardReductionHeuristic(TestCase):
         return spec
 
     def _reduction_env(self, spec: ConfigSpec) -> MagicMock:
-        # The deepened heuristic reads env.backend.max_tensor_numel (the structural
-        # persistent cap) — provide the real Triton cap so a sub-cap rnumel stays
-        # persistent.
         from types import SimpleNamespace
-
-        from helion.autotuner.config_generation import TRITON_MAX_TENSOR_NUMEL
 
         env = MagicMock()
         env.backend_name = "triton"
-        env.backend.max_tensor_numel = TRITON_MAX_TENSOR_NUMEL
         env.config_spec = spec
         env.device = DEVICE
-        # ``_primary_descriptor_selected`` filters the sized descriptors to the BACKED axes
-        # (``free_unbacked_symbols(env.block_sizes[bid].size)``), so the descriptor axes'
-        # ``env.block_sizes[bid].size`` must be a real (backed) int — a bare MagicMock can't be
-        # fed to sympy. Resolve each descriptor's block_id to its static ``size_hint``. For any
-        # OTHER block_id (the grid/M axis) keep a non-int so ``_grid_rows`` returns 0 (no static
-        # grid -> the occupancy-gated narrow-w1 warps lever stays disabled, as it was when the
-        # mock had no configured sizes at all).
+        # Primary selection requires concrete sizes for reduction axes.
         sizes = {d.block_id: d.size_hint for d in spec.reduction_kernel_fact.reductions}
         env.block_sizes.__getitem__.side_effect = lambda bid: SimpleNamespace(
             size=sizes[bid] if bid in sizes else MagicMock()
         )
         return env
 
-    def test_seed_is_persistent_one_row(self) -> None:
-        # The structural seed: one row per program + persistent reduction. The
-        # deepened heuristic ALSO seeds num_warps via the rnumel ramp (rnumel=1024
-        # -> 4 warps) and num_stages=1, rather than leaving them to the autotuner.
+    def test_seed_is_persistent_with_reduction_warps(self) -> None:
+        # The unified allocator may batch rows when live bytes and launch supply
+        # permit it. The reduction remains persistent and its 1024-wide lane work
+        # drafts four warps, then climbs to eight under the spill limit.
         env = self._reduction_env(self._reduction_spec(reduction_size_hint=1024))
         # The mock env has no real GPU device, so patch hardware info / SM count (this
         # heuristic only fires on GPU in production and the SM count is irrelevant here).
@@ -5256,49 +5215,127 @@ class TestTritonStandardReductionHeuristic(TestCase):
             patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE),
             patch("helion.runtime.get_num_sm", return_value=132),
         ):
-            seed = TritonStandardReductionHeuristicSM90.get_seed_config(
-                env, MagicMock()
-            )
-        self.assertEqual(seed.config["block_sizes"], [1])
+            seed = TritonReductionHeuristic.get_seed_config(env, MagicMock())
+        self.assertEqual(len(seed.config["block_sizes"]), 1)
+        self.assertGreaterEqual(seed.config["block_sizes"][0], 1)
         self.assertEqual(seed.config["reduction_loops"], [None])
-        # rnumel ramp: 1024 falls in the <=1024 band -> 4 warps.
-        self.assertEqual(seed.config["num_warps"], 4)
+        self.assertEqual(seed.config["num_warps"], 8)
         self.assertEqual(seed.config["num_stages"], 1)
 
-    def test_single_load_seeds_stream_eviction_over_load_slots(self) -> None:
-        # A single-load streaming reduction (num_load==1: e.g. sum) is read once
-        # and never reused, so every load slot -> 'first' (evict_first frees L2),
-        # broadcast over the spec's load slots. Build the fragment explicitly so
-        # the test does not depend on the host backend's eviction choices.
-        from helion.autotuner.config_fragment import EnumFragment
-        from helion.autotuner.config_fragment import ListOf
-
-        spec = self._reduction_spec(reduction_size_hint=1024, num_load=1)
-        spec.load_eviction_policies = ListOf(
-            EnumFragment(choices=("", "first", "last")), length=4
-        )
-        env = self._reduction_env(spec)
-        # The mock env has no real GPU device, so patch hardware info / SM count (this
-        # heuristic only fires on GPU in production and the SM count is irrelevant here).
-        with (
-            patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE),
-            patch("helion.runtime.get_num_sm", return_value=132),
-        ):
-            seed = TritonStandardReductionHeuristicSM90.get_seed_config(
-                env, MagicMock()
-            )
+    def test_warp_selection_descends_when_resident_warps_are_retained(
+        self,
+    ) -> None:
         self.assertEqual(
-            seed.config["load_eviction_policies"],
-            ["first", "first", "first", "first"],
+            self._choose_warps_with_model(
+                width=8192,
+                peak_live_bytes=8 * 1024,
+                warp_scores={1: 8.0, 2: 16.0, 4: 32.0, 16: 32.0},
+            ),
+            4,
         )
+
+    def test_warp_selection_keeps_draft_when_launch_caps_lower_rungs(
+        self,
+    ) -> None:
+        self.assertEqual(
+            self._choose_warps_with_model(
+                width=2048,
+                peak_live_bytes=8 * 1024,
+                warp_scores={1: 1.0, 2: 2.0, 4: 4.0, 8: 8.0},
+            ),
+            8,
+        )
+
+    def test_light_warp_selection_preserves_full_draft_score(self) -> None:
+        self.assertEqual(
+            self._choose_warps_with_model(
+                width=2048,
+                peak_live_bytes=4 * 1024,
+                warp_scores={1: 8.0, 2: 16.0, 4: 32.0, 8: 64.0},
+            ),
+            8,
+        )
+
+    def test_high_warp_selection_uses_calibrated_residency(self) -> None:
+        scores = {1: 2.0, 2: 4.0, 4: 8.0, 8: 16.0, 16: 32.0}
+        self.assertEqual(
+            self._choose_warps_with_model(
+                width=8192,
+                peak_live_bytes=64 * 1024,
+                warp_scores=scores,
+                calibrated_scores={**scores, 8: 32.0},
+            ),
+            8,
+        )
+
+    def test_high_spill_disables_calibrated_residency(self) -> None:
+        scores = {1: 2.0, 2: 4.0, 4: 8.0, 8: 16.0, 16: 32.0}
+        self.assertEqual(
+            self._choose_warps_with_model(
+                width=8192,
+                peak_live_bytes=64 * 1024,
+                warp_scores=scores,
+                calibrated_scores={**scores, 8: 32.0},
+                spill_pressures={8: 0.51},
+            ),
+            16,
+        )
+
+    def _choose_warps_with_model(
+        self,
+        *,
+        width: int,
+        peak_live_bytes: int,
+        warp_scores: dict[int, float],
+        calibrated_scores: dict[int, float] | None = None,
+        spill_pressures: dict[int, float] | None = None,
+    ) -> int:
+        candidate = MagicMock(reduction_widths=((1, width),))
+        pd = MagicMock(size_hint=width)
+        calibrated_scores = calibrated_scores or warp_scores
+        spill_pressures = spill_pressures or {}
+
+        def score(resources: MagicMock, **kwargs: float) -> float:
+            scores = (
+                calibrated_scores
+                if kwargs.get("register_estimate_scale", 1.0) < 1.0
+                else warp_scores
+            )
+            return scores[resources.num_warps]
+
+        with (
+            patch.object(
+                TritonReductionHeuristic,
+                "_reduction_resources",
+                side_effect=lambda _env, _candidate, warps, _num_sm: MagicMock(
+                    num_warps=warps,
+                    peak_live_bytes=peak_live_bytes,
+                ),
+            ),
+            patch.object(
+                TritonReductionHeuristic,
+                "_reduction_spill_pressure",
+                side_effect=lambda resources: spill_pressures.get(
+                    resources.num_warps, 0.25
+                ),
+            ),
+            patch.object(
+                TritonReductionHeuristic,
+                "_reduction_effective_warp_score",
+                side_effect=score,
+            ),
+        ):
+            return TritonReductionHeuristic._choose_reduction_num_warps(
+                MagicMock(), candidate, pd, 132
+            )
 
     def test_persistent_seed_round_trips_through_config_generation(self) -> None:
         # reduction_loops=[None] (persistent) MUST survive flatten/unflatten. For
         # a wide reduction (size_hint 32000) a sentinel < size_hint would decode
         # back to the SLOW looped family this heuristic exists to avoid; the
         # config_spec fix encodes None as the fragment's ``high`` (>= size_hint).
-        # row_reread=True makes the wide reduction persist under the read-once persist
-        # gate (read-once reductions deliberately loop), so there is a [None] to round-trip.
+        # row_reread=True allows the late full-row persistence probe, so there
+        # is a [None] sentinel to round-trip.
         from helion.autotuner.config_generation import ConfigGeneration
 
         spec = self._reduction_spec(reduction_size_hint=32000, row_reread=True)
@@ -5309,9 +5346,7 @@ class TestTritonStandardReductionHeuristic(TestCase):
             patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE),
             patch("helion.runtime.get_num_sm", return_value=132),
         ):
-            seed = TritonStandardReductionHeuristicSM90.get_seed_config(
-                env, MagicMock()
-            )
+            seed = TritonReductionHeuristic.get_seed_config(env, MagicMock())
         spec.compiler_seed_configs = [seed]
         pairs = ConfigGeneration(spec).seed_flat_config_pairs()
         self.assertEqual(len(pairs), 1)
@@ -5327,16 +5362,12 @@ class TestTritonStandardReductionHeuristic(TestCase):
             spec = ConfigSpec(backend=TritonBackend())
             spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=1024))
             env.config_spec = spec
-            self.assertFalse(
-                TritonStandardReductionHeuristicSM90.is_eligible(env, MagicMock())
-            )
+            self.assertFalse(TritonReductionHeuristic.is_eligible(env, MagicMock()))
             # A matmul fact disqualifies even a 1-tile/1-reduction shape.
             spec_mm = self._reduction_spec(reduction_size_hint=1024)
             spec_mm.matmul_facts = [MagicMock()]
             env.config_spec = spec_mm
-            self.assertFalse(
-                TritonStandardReductionHeuristicSM90.is_eligible(env, MagicMock())
-            )
+            self.assertFalse(TritonReductionHeuristic.is_eligible(env, MagicMock()))
 
     @onlyBackends(["triton"])
     @skipIfRefEager("Compiler heuristics are not collected in ref eager mode")
@@ -5372,38 +5403,33 @@ class TestTritonStandardReductionHeuristic(TestCase):
                 torch.randn(256, 256, device=DEVICE, dtype=HALF_DTYPE),
             )
         )
-        # Pin the sm90/H100 target so the sm90 heuristic is exercised regardless of the CI
-        # runner's GPU: the hardware gate now lives in ``is_eligible`` (sm100/B200 routes to
-        # ``TritonStandardReductionHeuristicSM100``, other GPUs to the narrow fallback), so on a
-        # B200 runner the unpatched ``is_eligible`` would be False.
+        # Pin a tuned target regardless of the CI runner's GPU. Other architectures route
+        # standard reductions to the narrow fallback.
         with (
             patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE),
             patch("helion.runtime.get_num_sm", return_value=132),
         ):
             self.assertTrue(
-                TritonStandardReductionHeuristicSM90.is_eligible(
+                TritonReductionHeuristic.is_eligible(
                     red.env, red.host_function.device_ir
                 )
             )
-            seed = TritonStandardReductionHeuristicSM90.get_seed_config(
+            seed = TritonReductionHeuristic.get_seed_config(
                 red.env, red.host_function.device_ir
             )
             # A matmul is not a reduction, so the reduction seed declines even on its own target.
             self.assertFalse(
-                TritonStandardReductionHeuristicSM90.is_eligible(
-                    mm.env, mm.host_function.device_ir
-                )
+                TritonReductionHeuristic.is_eligible(mm.env, mm.host_function.device_ir)
             )
-        self.assertEqual(seed.config["block_sizes"], [1])
+        self.assertEqual(len(seed.config["block_sizes"]), 1)
+        self.assertGreaterEqual(seed.config["block_sizes"][0], 1)
         self.assertEqual(seed.config["reduction_loops"], [None])
 
     @onlyBackends(["triton"])
     @skipIfRefEager("Compiler heuristics are not collected in ref eager mode")
-    def test_exactly_one_reduction_track_eligible_per_hardware(self) -> None:
-        # The hardware gate lives in ``is_eligible``: for a standard reduction, EXACTLY one of
-        # the three standard-track classes fires per GPU — sm90 -> SM90, sm100 -> SM100, anything
-        # else -> the narrow fallback — and none of them return None-for-deferral from
-        # ``get_seed_config``. This is the invariant the class split exists to guarantee.
+    def test_tuned_reduction_and_narrow_fallback_are_disjoint(self) -> None:
+        # The unified tuned class owns sm90 and sm100. Other hardware uses the narrow
+        # standard-reduction fallback, so exactly one class is eligible.
         @helion.kernel(backend="triton")
         def row_reduction(x: torch.Tensor) -> torch.Tensor:
             m, _ = x.size()
@@ -5420,8 +5446,8 @@ class TestTritonStandardReductionHeuristic(TestCase):
         env, device_ir = red.env, red.host_function.device_ir
         # (hardware, the one class expected to fire).
         cases = [
-            (HOPPER_HARDWARE, TritonStandardReductionHeuristicSM90),
-            (BLACKWELL_HARDWARE, TritonStandardReductionHeuristicSM100),
+            (HOPPER_HARDWARE, TritonReductionHeuristic),
+            (BLACKWELL_HARDWARE, TritonReductionHeuristic),
             (
                 HardwareInfo(
                     device_kind="cuda",
@@ -5433,8 +5459,7 @@ class TestTritonStandardReductionHeuristic(TestCase):
             ),
         ]
         tracks = [
-            TritonStandardReductionHeuristicSM90,
-            TritonStandardReductionHeuristicSM100,
+            TritonReductionHeuristic,
             TritonNarrowReductionHeuristic,
         ]
         for hardware, expected in cases:
@@ -5451,7 +5476,8 @@ class TestTritonStandardReductionHeuristic(TestCase):
                 # The eligible class always yields a real Config (never None-for-deferral).
                 seed = expected.get_seed_config(env, device_ir)
                 self.assertIsNotNone(seed)
-                self.assertEqual(seed.config["block_sizes"], [1])
+                self.assertEqual(len(seed.config["block_sizes"]), 1)
+                self.assertGreaterEqual(seed.config["block_sizes"][0], 1)
 
 
 _FP8_SKINNY_M_SEED_BLOCK_SIZES = [1, 256]
@@ -10596,15 +10622,13 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
 
 
 class TestTritonReductionHeuristic(TestCase):
-    """Lock the reduction seed heuristics' branch decisions on two kernels, one per
-    track:
+    """Lock representative liveness-based reduction seed decisions on both tracks:
 
     - rms_norm wide (rnumel=16384): the standard path
-      (``TritonStandardReductionHeuristicSM90``) seeds a persistent reduction
+      (``TritonReductionHeuristic``) seeds a persistent reduction
       (``reduction_loops=[None]``) with the rnumel-ramp warp count.
-    - kl_div wide (rnumel=131072): the Band-B (user-tiled) path
-      (``TritonUserTiledReductionHeuristicSM90``) caps R_BLOCK by the accumulator footprint
-      instead of going full-N persistent, with M at floor 1.
+    - kl_div wide (rnumel=131072): the user-tiled path resolves the complete live
+      timeline and caps R_BLOCK instead of going full-N, with M at floor 1.
     """
 
     @onlyBackends(["triton"])
@@ -10618,7 +10642,7 @@ class TestTritonReductionHeuristic(TestCase):
             torch.randn([n], device=DEVICE, dtype=torch.float32),
             1e-5,
         )
-        heuristic = TritonStandardReductionHeuristicSM90
+        heuristic = TritonReductionHeuristic
 
         # Pin the kernel to the triton backend: autotuner_heuristics is keyed on
         # env.backend_name, and the tileir lane (where @onlyBackends(["triton"]) still
@@ -10626,9 +10650,8 @@ class TestTritonReductionHeuristic(TestCase):
         # assertIn below fails. Pinning keeps backend_name "triton" on every lane.
         kernel = helion.kernel(rms_norm_fwd.fn, backend="triton")
 
-        # Force the sm90 deep path so the test exercises the H100-tuned seed on any
-        # runner (off-sm90 a different class fires: SM100 on B200, the narrow fallback
-        # elsewhere).
+        # Force a tuned target so the test exercises the unified H100/B200 seed on
+        # any runner; other hardware uses the narrow standard-only fallback.
         with patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE):
             bound = kernel.bind(args)
 
@@ -10641,7 +10664,7 @@ class TestTritonReductionHeuristic(TestCase):
             # row in the reduction scope), so no reduce-then-apply tile is captured.
             self.assertEqual(kf.non_reduction_loop_block_ids, ())
             self.assertIn(
-                TritonStandardReductionHeuristicSM90.name,
+                TritonReductionHeuristic.name,
                 bound.config_spec.autotuner_heuristics,
             )
             self.assertTrue(
@@ -10660,14 +10683,14 @@ class TestTritonReductionHeuristic(TestCase):
 
     @onlyBackends(["triton"])
     @skipIfRefEager("Compiler reduction facts are not collected in ref eager mode")
-    def test_kl_div_wide_seeds_band_b_r_block_cap(self) -> None:
+    def test_kl_div_wide_seeds_liveness_r_block_cap(self) -> None:
         from examples.kl_div import kl_div_forward
 
         m, n = 4096, 131072
         log_q = torch.log_softmax(torch.randn([m, n], device=DEVICE), dim=-1)
         p = torch.softmax(torch.randn([m, n], device=DEVICE), dim=-1)
         args = (log_q, p)
-        heuristic = TritonUserTiledReductionHeuristicSM90
+        heuristic = TritonReductionHeuristic
 
         # Pin the kernel to the triton backend: autotuner_heuristics is keyed on
         # env.backend_name, and the tileir lane (where @onlyBackends(["triton"]) still
@@ -10675,53 +10698,109 @@ class TestTritonReductionHeuristic(TestCase):
         # assertIn below fails. Pinning keeps backend_name "triton" on every lane.
         kernel = helion.kernel(kl_div_forward.fn, backend="triton")
 
-        # Force the sm90 deep path so the Band-B seed is exercised on any runner
-        # (off-sm90 a different class fires: SM100 on B200; the narrow fallback covers
-        # only the standard track, so user-tiled simply does not seed elsewhere).
+        # Force a tuned target so the liveness allocator is exercised on any runner.
+        # The narrow fallback on other hardware covers only standard reductions.
         with patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE):
             bound = kernel.bind(args)
 
-            # Single reduction descriptor carrying a 2D [M, R] tile -> Band B.
+            # The complete timeline captures the carried [M, R] state directly.
             kf = bound.config_spec.reduction_kernel_fact
             self.assertIsNotNone(kf)
             self.assertEqual(len(kf.reductions), 1)
             fact = kf.reductions[0]
             self.assertEqual(fact.size_hint, n)
-            self.assertGreaterEqual(fact.carried_2d_count, 1)
+            self.assertTrue(kf.live_tile_steps)
+            self.assertTrue(
+                any(
+                    fact.block_id in tile.dim_block_ids and len(tile.dim_block_ids) >= 2
+                    for step in kf.live_tile_steps
+                    for tile in step
+                    if tile.kind != "global"
+                )
+            )
             self.assertEqual(kf.non_reduction_loop_block_ids, ())
             self.assertIn(
-                TritonUserTiledReductionHeuristicSM90.name,
+                TritonReductionHeuristic.name,
                 bound.config_spec.autotuner_heuristics,
             )
             self.assertTrue(
                 heuristic.is_eligible(bound.env, bound.host_function.device_ir)
             )
 
-            # Exactly one seed; R_BLOCK is capped (NOT full-N persistent) by the ONE budget
-            # allocator, and the grid (M) axis sits at its floor of 1.
+            # Exactly one seed; the peak live timeline caps R_BLOCK well below the
+            # full extent, and the grid (M) axis remains at its floor. The serial
+            # occupancy exchange retains the 8192-wide chunk for this shape.
             seeds = compiler_seed_configs(bound.env, bound.host_function.device_ir)
         self.assertEqual(len(seeds), 1)
         seed = seeds[0].config
-        # The budget allocator sizes the carried [M_BLOCK, R_BLOCK] tile against ONE group budget
-        # (num_live × itemsize footprint vs the CARRIED budget), NOT a bespoke carried byte cap.
-        # The carried accumulator is live the whole loop with body_live_tiles copies, so the budget
-        # depletes to R_BLOCK = pow2(CARRIED_PERSIST_MAX_BYTES / (num_live × itemsize)). A carried
-        # reduction holds its [M, R] tile resident across the whole loop (not streamed-then-released),
-        # so it sizes against the TIGHTER CARRIED_PERSIST_MAX_BYTES (= ROW_PERSIST // 2 = 122880), a
-        # single budget CONSTANT — the footprint FORMULA is the same uniform num_live × ∏(working
-        # tile) as every other kernel (no buffer-count multiplier: body_live_tiles already counts the
-        # carried buffers). For kl_div (body_live_tiles == 6, fp32) that is pow2(122880 / (6 × 4)) =
-        # pow2(5120) = 4096 — capped well below next_pow2(131072) and M floored to 1 (budget spent).
-        # 4096 is the MEASURED optimum (~+2% vs the old 8192). Floor-vs-resident falls out of
-        # depletion: no carried recognizer, no separate CARRIED_TILE_MAX_BYTES.
         r_block = seed["block_sizes"][0]
-        self.assertEqual(seed["block_sizes"], [4096, 1])
+        self.assertEqual(seed["block_sizes"], [8192, 1])
         self.assertLess(r_block, n)
-        # rnumel 131072 > the 16384 warps-32 breakpoint -> 32 warps.
+        # Warps follow the selected lane-parallel chunk, not the raw logical extent.
         self.assertEqual(seed["num_warps"], 32)
         self.assertEqual(seed["num_stages"], 1)
-        # The carried-tile path must NOT use the standard reduction_loops knob.
+        # User-tiled reductions emit through block_sizes, never reduction_loops.
         self.assertNotIn("reduction_loops", seed)
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler reduction facts are not collected in ref eager mode")
+    def test_fixed_reduction_tile_is_distinct_from_full_slice(self) -> None:
+        @helion.kernel(backend="triton")
+        def fixed_tile_reduction(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty([m], dtype=torch.float32, device=x.device)
+            for tile_m in hl.tile(m):
+                acc = hl.zeros([tile_m], dtype=torch.float32)
+                for tile_n in hl.tile(n, block_size=128):
+                    acc = acc + x[tile_m, tile_n].to(torch.float32).sum(dim=-1)
+                out[tile_m] = acc
+            return out
+
+        def descriptor(
+            n: int,
+        ) -> tuple[ReductionDescriptor, dict[str, Any], tuple[str, ...]]:
+            fixed_tile_reduction.reset()
+            with patch(
+                "helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE
+            ):
+                bound = fixed_tile_reduction.bind(
+                    (torch.randn([64, n], device=DEVICE),)
+                )
+                kf = bound.config_spec.reduction_kernel_fact
+                self.assertIsNotNone(kf)
+                self.assertEqual(len(kf.reductions), 1)
+                fact = kf.reductions[0]
+                self.assertNotIn(
+                    fact.block_id,
+                    bound.config_spec.block_sizes.valid_block_ids(),
+                )
+                seeds = compiler_seed_configs(bound.env, bound.host_function.device_ir)
+            self.assertEqual(len(seeds), 1)
+            return (
+                fact,
+                seeds[0].config,
+                tuple(bound.config_spec.autotuner_heuristics),
+            )
+
+        partial, partial_seed, partial_heuristics = descriptor(1024)
+        self.assertEqual(partial.category, ReductionCategory.FIXED_TILE)
+        self.assertEqual(partial.size_hint, 1024)
+        self.assertEqual(partial.fixed_tile_size_hint, 128)
+        self.assertIn(
+            TritonReductionHeuristic.name,
+            partial_heuristics,
+        )
+        self.assertNotIn("reduction_loops", partial_seed)
+
+        full, full_seed, full_heuristics = descriptor(128)
+        self.assertEqual(full.category, ReductionCategory.FULL_SLICE)
+        self.assertEqual(full.size_hint, 128)
+        self.assertIsNone(full.fixed_tile_size_hint)
+        self.assertIn(
+            TritonReductionHeuristic.name,
+            full_heuristics,
+        )
+        self.assertNotIn("reduction_loops", full_seed)
 
     @onlyBackends(["triton"])
     @skipIfRefEager("Compiler reduction facts are not collected in ref eager mode")
@@ -10768,9 +10847,9 @@ class TestTritonReductionHeuristic(TestCase):
                 self.assertEqual(kf.grid_axis_block_ids, (0,))
                 self.assertEqual(len(kf.non_reduction_loop_block_ids), 1)
                 self.assertNotIn(fact.block_id, kf.non_reduction_loop_block_ids)
-                self.assertEqual(fact.carried_2d_count, 0)
+                self.assertTrue(kf.live_tile_steps)
                 self.assertIn(
-                    TritonStandardReductionHeuristicSM90.name,
+                    TritonReductionHeuristic.name,
                     bound.config_spec.autotuner_heuristics,
                 )
                 # Exactly one seed; block_sizes has an entry per tiled dim (grid +
@@ -10787,28 +10866,14 @@ class TestTritonReductionHeuristic(TestCase):
                 kf.non_reduction_loop_block_ids[0]
             )
             self.assertGreater(seed["block_sizes"][norm_idx], 1)
-            # Persistent (narrow row) -> reduction_loops=[None]; looped (wide row past
-            # the byte cap) -> reduction_loops=[LOOPED_CHUNK].
+            # A narrow row remains persistent. A wide row emits a finite chunk
+            # selected from the same live-state model as the normalize tile.
             if expect_looped:
-                self.assertEqual(
-                    seed["reduction_loops"],
-                    [TritonStandardReductionHeuristicSM90.LOOPED_CHUNK],
-                )
-                # At m_block==1 the normalize tile is clamped to the SAME ÷M_BLOCK
-                # register-resident footprint as the reduction tile, NOT left at
-                # next_pow2(N). With m_block==1 / fp32 the budget is prev_pow2(
-                # ROW_PERSIST_MAX_BYTES // (1 * 4)) == 32768, which is < next_pow2(131072).
-                # This is the only test cell that exercises the cap at M_BLOCK==1, so pin
-                # the value (a > 1 check would also pass on the OLD M_BLOCK>1-gated cap that
-                # left this tile uncapped).
-                from helion._utils import prev_power_of_2
-
-                expected_norm = prev_power_of_2(
-                    TritonStandardReductionHeuristicSM90.ROW_PERSIST_MAX_BYTES
-                    // (1 * 4)
-                )
-                self.assertEqual(expected_norm, 32768)
-                self.assertEqual(seed["block_sizes"][norm_idx], expected_norm)
+                chunk = seed["reduction_loops"][0]
+                self.assertIsInstance(chunk, int)
+                self.assertGreater(chunk, 1)
+                self.assertLess(chunk, n)
+                self.assertLess(seed["block_sizes"][norm_idx], n)
             else:
                 self.assertEqual(seed["reduction_loops"], [None])
             # The emitted seed must round-trip through normalize() without raising.
@@ -10820,80 +10885,93 @@ class TestTritonReductionHeuristic(TestCase):
         # wrongly declined into a wrong-length crash; now emits a widened looped seed).
         check(1024, 131072, expect_looped=True)
 
-    def test_independent_loops_not_floored_by_budget_allocator(self) -> None:
-        # The ONE budget allocator (``size_reduction_tiles``) sizes a USER_TILE reduction
-        # axis AND a co-occurring non-reduction (normalize) loop / secondary reducing axis
-        # so neither FLOORS to 1 (the [..., 1] serialization catastrophe). No example
-        # kernel has a dynamic-extent non-reduction loop, so this pins the behavior on a
-        # constructed spec (bare-spec, no active env — the allocator reads stored hints).
-        from helion.autotuner.config_spec import BlockSizeSpec
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler reduction facts are not collected in ref eager mode")
+    def test_padded_apply_loop_skips_padding_neutral_half(self) -> None:
+        from pretuned_kernels.dynamic_per_token_scaled_fp8_quant.dynamic_per_token_scaled_fp8_quant import (
+            dynamic_per_token_scaled_fp8_quant,
+        )
 
-        H = TritonUserTiledReductionHeuristicSM90
-        size_hint = 4096  # next_pow2(size_hint) == 4096
+        tokens, hidden = 64, 5120
+        x = torch.randn(tokens, hidden, device=DEVICE, dtype=torch.bfloat16)
+        result = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+        scale = torch.empty(tokens, 1, device=DEVICE, dtype=torch.float32)
+        kernel = helion.kernel(
+            dynamic_per_token_scaled_fp8_quant.fn,
+            backend="triton",
+        )
+        with patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE):
+            bound = kernel.bind((result, x, scale))
+            kf = bound.config_spec.reduction_kernel_fact
+            self.assertIsNotNone(kf)
+            self.assertEqual(len(kf.non_reduction_loop_block_ids), 1)
+            apply_idx = bound.config_spec.block_sizes.block_id_to_index(
+                kf.non_reduction_loop_block_ids[0]
+            )
+            seeds = compiler_seed_configs(bound.env, bound.host_function.device_ir)
 
-        def spec_with(reduction_bid: int, norm_bid: int) -> ConfigSpec:
-            spec = ConfigSpec(backend=TritonBackend())
-            # grid (block 0), reduction axis, normalize-loop axis — all block_sizes.
-            spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=1024))
-            spec.block_sizes.append(
-                BlockSizeSpec(block_id=reduction_bid, size_hint=size_hint)
-            )
-            spec.block_sizes.append(
-                BlockSizeSpec(block_id=norm_bid, size_hint=size_hint)
-            )
-            # USER_TILE reduction (rdim is a block_sizes entry), grid row block 0, and a
-            # non-reduction normalize loop ``norm_bid`` captured on the kernel fact.
-            desc = ReductionDescriptor(
-                category=ReductionCategory.USER_TILE,
-                block_id=reduction_bid,
-                graph_id=0,
-                size_hint=size_hint,
-                itemsize=4,
-                input_load_itemsize=4,
-                num_load=1,
-            )
-            spec.reduction_kernel_fact = ReductionKernelFact(
-                reductions=(desc,),
-                coresidency_groups=(
-                    CoResidencyGroup(graph_id=0, descriptor_indices=(0,)),
-                ),
-                non_reduction_loop_block_ids=(norm_bid,),
-                grid_axis_block_ids=(0,),
-            )
-            return spec
+        self.assertEqual(len(seeds), 1)
+        # 4096 still schedules 8192 elements, while 2048 schedules only 6144.
+        self.assertEqual(seeds[0].config["block_sizes"][apply_idx], 2048)
 
-        def pd(reduction_bid: int) -> ReductionDescriptor:
-            return ReductionDescriptor(
-                category=ReductionCategory.USER_TILE,
-                block_id=reduction_bid,
-                graph_id=0,
-                size_hint=size_hint,
-                itemsize=4,
-                input_load_itemsize=4,
-                num_load=1,
-            )
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler reduction facts are not collected in ref eager mode")
+    def test_independent_loop_gets_non_reduction_loop_policy(self) -> None:
+        @helion.kernel(backend="triton")
+        def reduction_with_independent_loop(
+            x: torch.Tensor, values: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            m, _ = x.size()
+            _, k = values.size()
+            sums = torch.empty([m], dtype=x.dtype, device=x.device)
+            out = torch.empty_like(values)
+            for tile_m in hl.tile(m):
+                sums[tile_m] = torch.sum(x[tile_m, :], dim=-1)
+                for tile_k in hl.tile(k):
+                    out[tile_m, tile_k] = values[tile_m, tile_k] * 2
+            return sums, out
 
-        # The allocator runs without an active CompileEnvironment (it reads stored hints);
-        # device_ir is only consulted for materialized features (none here), so a MagicMock
-        # whose attribute access yields empty iterables is fine.
-        from unittest.mock import MagicMock
-
-        # reduce-then-apply: the reduction axis is sized to its full extent (persistent /
-        # budget-admitted) and the normalize loop is sized to its own extent — NOT 1.
-        spec = spec_with(reduction_bid=1, norm_bid=2)
-        device_ir = MagicMock()
-        device_ir.grid_block_ids = []
-        with (
-            patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE),
-            patch("helion.runtime.get_num_sm", return_value=132),
-        ):
-            alloc = H.size_reduction_tiles(MagicMock(), spec, device_ir, pd(1))
-        red_idx = spec.block_sizes.block_id_to_index(1)
-        norm_idx = spec.block_sizes.block_id_to_index(2)
-        self.assertEqual(alloc.block_sizes[red_idx], 4096)  # rdim sized to extent
-        self.assertEqual(
-            alloc.block_sizes[norm_idx], 4096
-        )  # normalize loop NOT floored
-        self.assertNotEqual(alloc.block_sizes[norm_idx], 1)
-        # grid (M) row axis floored (no widen headroom is required; it just must be valid).
-        self.assertGreaterEqual(alloc.block_sizes[0], 1)
+        m, n, k = 64, 2048, 8192
+        args = (
+            torch.randn([m, n], device=DEVICE, dtype=torch.float32),
+            torch.randn([m, k], device=DEVICE, dtype=torch.float32),
+        )
+        cases = (
+            (
+                HOPPER_HARDWARE,
+                TritonReductionHeuristic,
+                1024,
+            ),
+            (
+                BLACKWELL_HARDWARE,
+                TritonReductionHeuristic,
+                1024,
+            ),
+        )
+        for hardware, heuristic, expected_apply_block in cases:
+            reduction_with_independent_loop.reset()
+            with patch("helion._hardware.get_hardware_info", return_value=hardware):
+                bound = reduction_with_independent_loop.bind(args)
+                kf = bound.config_spec.reduction_kernel_fact
+                self.assertIsNotNone(kf)
+                self.assertEqual(len(kf.reductions), 1)
+                reduction = kf.reductions[0]
+                self.assertEqual(reduction.size_hint, n)
+                self.assertEqual(len(kf.non_reduction_loop_block_ids), 1)
+                apply_bid = kf.non_reduction_loop_block_ids[0]
+                apply_idx = bound.config_spec.block_sizes.block_id_to_index(apply_bid)
+                self.assertEqual(bound.config_spec.block_sizes[apply_idx].size_hint, k)
+                self.assertNotEqual(
+                    bound.config_spec.block_sizes[apply_idx].size_hint,
+                    reduction.size_hint,
+                )
+                self.assertIn(
+                    heuristic.name,
+                    bound.config_spec.autotuner_heuristics,
+                )
+                seeds = compiler_seed_configs(bound.env, bound.host_function.device_ir)
+            self.assertEqual(len(seeds), 1)
+            seed = seeds[0].config
+            self.assertEqual(seed["block_sizes"][apply_idx], expected_apply_block)
+            # H100 and B200 share the candidate and warp policy.
+            self.assertEqual(seed["num_warps"], 8)

--- a/test/test_memory_op_facts.py
+++ b/test/test_memory_op_facts.py
@@ -87,16 +87,11 @@ class TestMemoryOpFacts(RefEagerTestBase, TestCase):
         kf = spec.reduction_kernel_fact
         self.assertIsNotNone(kf)
         self.assertEqual(len(kf.reductions), 1)
-        fact = kf.reductions[0]
-        # num_load scopes to the rdim's original graph(s) (one streamed input row), so the
-        # rolled-subgraph copy is not double-counted.
-        self.assertEqual(fact.num_load, 1)
 
         # The collector ran after the rolling, so the rolled reduction subgraph's load
-        # copy is accounted for: a load fact lives in a later graph than the root, and the
-        # full set has > 1 load fact even though num_load == 1.
+        # copy is accounted for: a load fact lives in a later graph than the root.
         self.assertTrue(any(s.graph_id > 0 for s in specs if s.kind == "load"))
-        self.assertGreater(sum(1 for s in specs if s.kind == "load"), fact.num_load)
+        self.assertGreater(sum(1 for s in specs if s.kind == "load"), 1)
 
     def test_load_store_metadata(self):
         x = torch.randn([256, 256], device=DEVICE, dtype=torch.float32)


### PR DESCRIPTION
Stacked PRs:
 * __->__#3551
 * #3546

--- --- ---

## Summary

- Replace the four H100/B200 standard/user-tiled reduction seed classes with one liveness-based reduction heuristic.
- Size reduction, grid, and serial axes against peak live state, then use estimated register pressure, resource residency, launch supply, and useful work to adjust blocks and select `num_warps` in both directions.
- Keep persistence as a narrow late probe, preserve the fallback for other hardware, and remove the superseded proxy and fact machinery.

## H100 performance

Measured on physical H100 GPU 1. Each value is the geomean speedup over the old `pytorch/helion:main` seed (`1.00x`); higher is faster. The four arms were compiled with the same frozen compiler and measured together using CUDA graphs, cold L2, and nine timing rounds.

### AOT pre-tuned references

| Kernel | Valid cells | AOT reference | Default | Old seed | New seed | AOT |
|---|---:|---|---:|---:|---:|---:|
| RMSNorm | 6/6 | exact | 0.949x | 1.000x | 1.003x | 1.036x |
| LayerNorm | 6/6 | exact | 0.800x | 1.000x | 0.970x | 1.011x |
| Softmax | 6/6 | exact | 0.802x | 1.000x | 1.031x | 0.939x |
| Cross entropy | 6/6 | exact | 0.956x | 1.000x | 1.078x | 1.227x |
| Dynamic per-token FP8 quant | 9/9 | exact | 0.271x | 1.000x | 1.035x | 1.025x |
| Per-token group FP8 quant | 9/9 | 3 exact, 6 selector fallback | 1.000x | 1.000x | 0.997x | 1.019x |
| RMSNorm dynamic per-token quant | 9/9 | exact | 0.126x | 1.000x | 1.036x | 1.049x |
| RMSNorm per-block quant | 9/9 | 5 exact, 4 selector fallback | 0.496x | 1.000x | 1.000x | 1.027x |
| SiLU-and-mul per-block quant | 9/9 | 3 exact, 6 selector fallback | 0.999x | 1.000x | 1.046x | 1.064x |
| Fused QK norm RoPE | 9/9 | exact | 0.973x | 1.000x | 0.998x | 1.048x |

Exact references use the shape's pre-tuned AOT config. Selector fallback uses another pre-tuned AOT config selected by the existing config selector when an exact shape match is unavailable.

### Hot `torch.compile()` references

| Kernel | Valid cells | Default | Old seed | New seed | `torch.compile()` |
|---|---:|---:|---:|---:|---:|
| KL divergence | 6/6 | 0.118x | 1.000x | 1.014x | 0.906x |
| JSD | 6/6 | 0.229x | 1.000x | 1.042x | 1.218x |
| Fused linear JSD | 6/6 | 0.637x | 1.000x | 1.000x | 0.964x |
| GRPO | 6/6 | 0.320x | 1.000x | 1.292x | 1.030x |
| RMSNorm backward | 5/6 | 0.053x | 1.000x | 1.000x | 0.908x |
| LayerNorm backward | 6/6 | 0.034x | 1.000x | 1.000x | 0.800x |

Overall, the new seed is `1.030x` the old seed across 113 valid cells. RMSNorm backward `[2048, 11008]` is excluded because all three Helion arms failed the existing `grad_x` tolerance; hot `torch.compile()` passed.

## Tests

- `test_autotuner_heuristics.py`: 118 passed, 31 skipped, 233 subtests
- `test_memory_op_facts.py`: 6 passed
- `test_matmul_heuristics.py`: 47 passed
- `test_tensor_numel_constraints.py`: 24 passed
- Final frozen-config cleanup check: 0/114 configs changed


