### PR TITLE
[cutedsl] Vectorize grid-level lane loops for pointwise kernels

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from .common import dedupe_configs
 from .cute import CuteFlashAttentionHeuristic
 from .cute import CuteFp8GemmSkinnyMHeuristic
+from .cute import CutePointwiseVecHeuristic
 from .cute import CuteReductionTileHeuristic
 from .cute import CuteReductionWideChunkHeuristic
 from .cute import CuteResidentMultiRowHeuristic
@@ -65,6 +66,7 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
         CuteResidentRowHeuristic,
         CuteResidentRowWideClusterHeuristic,
         CuteResidentMultiRowHeuristic,
+        CutePointwiseVecHeuristic,
     ),
     "triton": (
         # The two sm90 front ends are disjoint and share the B200 decision flow,

--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
@@ -2343,6 +2344,124 @@ class CuteTcgen05ClusterM2Heuristic(AutotunerHeuristic):
                 "tensor_descriptor",
             ]
         return Config(**seed)
+
+
+class CutePointwiseVecHeuristic(AutotunerHeuristic):
+    """Seed config for PURE pointwise kernels (add, gelu, cast, ...).
+
+    The cute default maps one thread per element with scalar loads (~5% of
+    HBM on B200).  Seed the vectorized lane-loop form instead: the stride-1
+    tile axis gets ``block = NT * V * UNROLL`` elements served by ``NT``
+    threads with ``cute_vector_widths = V`` sized to a 16-byte LDG.128
+    (V=8 for 16-bit dtypes, V=4 for fp32); every other tiled axis stays at
+    block 1.  Works for both the flattened (1D) and N-D grid strategies —
+    both share the tile_unroll vec-hoist protocol.
+
+    Fires on the presence of ``PointwiseElementwiseFact`` (built only in
+    the absence of reduction/matmul/accumulator facts, so it never claws a
+    reducing kernel into this track).
+    """
+
+    name = "cute_pointwise_vec"
+    backend = "cute"
+
+    NT = 256  # threads per CTA
+    UNROLL = 2  # vectors per thread (outer lane iters)
+
+    @classmethod
+    def _vec_axis_and_width(
+        cls, env: CompileEnvironment
+    ) -> tuple[int, int, int] | None:
+        """Returns (vec_block_id, V, axis size_hint), or None if no axis
+        can host a vec lane loop."""
+        spec = env.config_spec
+        if not spec.pointwise_facts:
+            return None
+        fact = spec.pointwise_facts[0]
+        if not spec.block_sizes:
+            return None
+        candidates = [s.block_id for s in spec.block_sizes]
+        vec_block = None
+        for bid in reversed(candidates):
+            if bid in fact.contig_block_ids:
+                vec_block = bid
+                break
+        if vec_block is None:
+            vec_block = candidates[-1]
+        if vec_block not in spec.cute_vector_widths.valid_block_ids():
+            return None
+        if vec_block not in spec.num_threads.valid_block_ids():
+            return None
+        size_hint = spec.block_sizes.block_id_lookup(vec_block).size_hint
+        vec = 16 // max(1, fact.storage_itemsize)
+        # The hoist requires numel % V == 0; shrink V until it divides.
+        while vec > 1 and size_hint % vec != 0:
+            vec //= 2
+        if vec <= 1:
+            return None
+        return vec_block, vec, size_hint
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        return cls._vec_axis_and_width(env) is not None
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        spec = env.config_spec
+        picked = cls._vec_axis_and_width(env)
+        if picked is None:
+            return None
+        vec_block, vec, size_hint = picked
+        bs_high = spec.block_sizes.block_id_lookup(vec_block)._fragment(spec).high
+        nt, unroll = cls.NT, cls.UNROLL
+        while nt * vec * unroll > bs_high and unroll > 1:
+            unroll //= 2
+        while nt * vec * unroll > bs_high and nt > 1:
+            nt //= 2
+        block = nt * vec * unroll
+        if block > bs_high or nt <= 1:
+            return None
+        seed: dict[str, Any] = {
+            "block_sizes": [
+                block if s.block_id == vec_block else 1 for s in spec.block_sizes
+            ],
+            "num_threads": _seq_config_list(spec.num_threads, {vec_block: nt}),
+            "cute_vector_widths": _seq_config_list(
+                spec.cute_vector_widths, {vec_block: vec}
+            ),
+        }
+        try:
+            return Config(**seed)
+        except Exception:
+            return None
+
+    @classmethod
+    def get_seed_configs(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> list[Config] | None:
+        primary = cls.get_seed_config(env, device_ir)
+        if primary is None:
+            return None
+        spec = env.config_spec
+        seeds = [primary]
+        # Transcendental-heavy pointwise kernels (gelu/silu/...) are often
+        # SFU/ALU-bound with accurate math; plant a fastmath alternate so the
+        # search benchmarks it (the baseline accuracy check drops it where
+        # numerics drift past tolerance).
+        fact = spec.pointwise_facts[0] if spec.pointwise_facts else None
+        if (
+            fact is not None
+            and fact.sfu_ops > 0
+            and spec.cute_has_transcendentals
+            and spec.supports_config_key("cute_fastmath")
+        ):
+            fm_seed: dict[str, Any] = dict(primary.config)
+            fm_seed["cute_fastmath"] = True
+            with contextlib.suppress(Exception):
+                seeds.append(Config(**fm_seed))
+        return seeds
 
 
 class CuteFp8GemmSkinnyMHeuristic(AutotunerHeuristic):

--- a/helion/_compiler/cute/argreduce.py
+++ b/helion/_compiler/cute/argreduce.py
@@ -141,7 +141,21 @@ def _argreduce_scan_ready_expr(
         extent = lane_extents.get(lane_var)
         if extent is None or extent <= 0:
             continue
-        terms.append(f"(({lane_var}) == {extent - 1})")
+        # ``lane_loops`` records the full elements-per-thread, but a vec'd
+        # lane loop runs its outer var over extent // V with a constexpr-V
+        # inner loop: the last element is the last vec lane of the last
+        # outer iteration.
+        wrapper = grid_state.vec_lane_wrappers.get(lane_var)
+        vec_width = getattr(strategy, "_cute_lane_vec_width_by_block", {}).get(
+            block_id, 1
+        )
+        if wrapper is not None and vec_width > 1 and extent % vec_width == 0:
+            terms.append(
+                f"(({lane_var}) == {extent // vec_width - 1} "
+                f"and ({wrapper.vec_lane_var}) == {vec_width - 1})"
+            )
+        else:
+            terms.append(f"(({lane_var}) == {extent - 1})")
     if not terms:
         return None
     return " and ".join(terms)

--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -909,6 +909,7 @@ class CuteBackend(Backend):
             or key == "cute_reduction_reloads"
             or key == "cute_cluster_n"
             or key == "cute_min_blocks_per_mp"
+            or key == "cute_fastmath"
             or key.startswith(("tcgen05_", "cute_flash_"))
         ):
             return True
@@ -1168,6 +1169,7 @@ class CuteBackend(Backend):
             "_cute_float4_e2m1fn_x16_to_float16": "from helion._compiler.cute.quantized_helpers import float4_e2m1fn_x16_to_float16 as _cute_float4_e2m1fn_x16_to_float16",
             "_cute_bfloat16_x16_to_float16": "from helion._compiler.cute.quantized_helpers import bfloat16_x16_to_float16 as _cute_bfloat16_x16_to_float16",
             "_cute_store_u16_vec": "from helion._compiler.cute.vec_utils import store_u16_vec as _cute_store_u16_vec",
+            "_cute_store_u32_vec": "from helion._compiler.cute.vec_utils import store_u32_vec as _cute_store_u32_vec",
             "_cute_grid_barrier": "from helion._compiler.cute.grid_barrier import grid_barrier as _cute_grid_barrier",
             "_cute_atomic_max_float32": "from helion._compiler.cute.atomic_helpers import atomic_max_float32 as _cute_atomic_max_float32",
             "_cute_atomic_min_float32": "from helion._compiler.cute.atomic_helpers import atomic_min_float32 as _cute_atomic_min_float32",

--- a/helion/_compiler/cute/memory_ops.py
+++ b/helion/_compiler/cute/memory_ops.py
@@ -1836,7 +1836,7 @@ def _(state: CodegenState) -> ast.AST:
         store_uses_pointer
         and topk_lane_expr is None
         and extra_mask is None
-        and tensor.dtype in (torch.float16, torch.bfloat16)
+        and tensor.dtype in (torch.float16, torch.bfloat16, torch.float32)
     ):
         vec_ctx = _cute_vector_load_ctx(state, tensor, subscript, index_exprs, None)
         if vec_ctx is not None and vec_ctx[2] == "tile_unroll":
@@ -1855,6 +1855,7 @@ def _(state: CodegenState) -> ast.AST:
                 index_exprs,
                 ast.unparse(value),
                 mask_expr,
+                tensor.dtype,
             )
             if append_stmt is not None:
                 state.add_statement(append_stmt)
@@ -1874,6 +1875,7 @@ def _(state: CodegenState) -> ast.AST:
                     index_exprs,
                     ast.unparse(value),
                     mask_expr,
+                    tensor.dtype,
                 )
                 if append_stmt is not None:
                     state.add_statement(append_stmt)
@@ -2034,6 +2036,7 @@ def _cute_vector_load_ctx(
     # position.
     inner_block_id: int | None = None
     lane_axis_pos: int | None = None
+    lane_on_stride1 = False
     expr_pos = -1
     tensor_dim = 0
     for idx in subscript:
@@ -2046,6 +2049,7 @@ def _cute_vector_load_ctx(
                 if tensor_dim == stride1_tensor_dim or inner_block_id is None:
                     inner_block_id = bid
                     lane_axis_pos = expr_pos
+                    lane_on_stride1 = tensor_dim == stride1_tensor_dim
         elif isinstance(idx, slice) and idx == slice(None):
             if tensor_dim < tensor.ndim:
                 dim_size = tensor.shape[tensor_dim]
@@ -2095,6 +2099,7 @@ def _cute_vector_load_ctx(
                     if tensor_dim == stride1_tensor_dim or inner_block_id is None:
                         inner_block_id = cand
                         lane_axis_pos = expr_pos
+                        lane_on_stride1 = tensor_dim == stride1_tensor_dim
         tensor_dim += 1
     if inner_block_id is None or lane_axis_pos is None:
         return None
@@ -2144,6 +2149,13 @@ def _cute_vector_load_ctx(
     from ..tile_strategy import BlockSizeTileStrategy
 
     if isinstance(strategy, BlockSizeTileStrategy):
+        # The hoisted load reads V CONTIGUOUS elements from the per-thread
+        # base, so the lane axis must actually be the tensor's stride-1
+        # dim.  A lane block accepted via the ``inner_block_id is None``
+        # fallback (e.g. ``x[tile_m, 0]`` where dim 1 is contiguous) would
+        # vectorize along the wrong dim and read garbage.
+        if not lane_on_stride1:
+            return None
         vec_by_block = getattr(strategy, "_cute_lane_vec_width_by_block", None)
         if not isinstance(vec_by_block, dict):
             return None

--- a/helion/_compiler/cute/vec_utils.py
+++ b/helion/_compiler/cute/vec_utils.py
@@ -24,3 +24,12 @@ def store_u16_vec(ptr: object, vals: list) -> None:
     vecty = ir.VectorType.get([len(vals)], cutlass.Uint16.mlir_type)
     packed = _vector_dialect.from_elements(vecty, [v.ir_value() for v in vals])
     cute.arch.store(ptr, packed)
+
+
+def store_u32_vec(ptr: object, vals: list) -> None:
+    """``store_u16_vec`` for ``cutlass.Uint32`` lanes (fp32 stores bitcast
+    their values to Uint32 first): one ST.64/ST.128 instead of per-element
+    4-byte stores."""
+    vecty = ir.VectorType.get([len(vals)], cutlass.Uint32.mlir_type)
+    packed = _vector_dialect.from_elements(vecty, [v.ir_value() for v in vals])
+    cute.arch.store(ptr, packed)

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -1124,6 +1124,31 @@ class DeviceIR:
         # non-reduction tile slots after them (keeps the rdim slot at index 0).
         if env.backend_name == "cute":
             self._register_cute_tile_vec_slots(env)
+            self._scan_cute_transcendentals(env)
+
+    def _scan_cute_transcendentals(self, env: CompileEnvironment) -> None:
+        """Set ``config_spec.cute_has_transcendentals`` when any device graph
+        contains a transcendental op — gates the ``cute_fastmath`` knob so
+        FMA-only kernels don't grow a dead search dimension."""
+        aten = torch.ops.aten
+        targets = {
+            aten.exp.default,
+            aten.exp2.default,
+            aten.log.default,
+            aten.log2.default,
+            aten.tanh.default,
+            aten.sigmoid.default,
+            aten.rsqrt.default,
+            aten.sqrt.default,
+            aten.sin.default,
+            aten.cos.default,
+            aten.erf.default,
+        }
+        for graph_info in self.graphs:
+            for node in graph_info.graph.nodes:
+                if node.op == "call_function" and node.target in targets:
+                    env.config_spec.cute_has_transcendentals = True
+                    return
 
     def _register_cute_tile_vec_slots(self, env: CompileEnvironment) -> None:
         """Eagerly register cute_vector_widths slots for non-reduction tile blocks.

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -1447,7 +1447,19 @@ def generate_ast(
             load_transform=load_transform,
             extra_params=extra_params,
         )
-        with codegen.device_function:
+        fast_math_cm: contextlib.AbstractContextManager[None] = contextlib.nullcontext()
+        if env.backend_name == "cute" and (
+            env.settings.fast_math or bool(config.config.get("cute_fastmath", False))
+        ):
+            # Route the ``cute_fastmath`` config knob (or the global
+            # ``fast_math`` setting) into the inductor CuteDSL op overrides:
+            # every cute.math call in this codegen gets ``fastmath=True``.
+            from torch._inductor.codegen.cutedsl.cutedsl_op_overrides import (
+                use_cutedsl_fast_math,
+            )
+
+            fast_math_cm = use_cutedsl_fast_math(True)
+        with codegen.device_function, fast_math_cm:
             CompileEnvironment.current().backend.pre_codegen(
                 graphs=codegen.codegen_graphs,
                 config=config,

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -1206,8 +1206,13 @@ class GenerateASTFromInductor(DefaultHandler):
     def rsqrt(self, x: object) -> str:  # type: ignore[override]
         backend_name = CompileEnvironment.current().backend_name
         if backend_name == "cute":
+            from torch._inductor.codegen.cutedsl.cutedsl_op_overrides import (
+                _CUTEDSL_FAST_MATH,
+            )
+
+            suffix = ", fastmath=True" if _CUTEDSL_FAST_MATH.get() else ""
             return self._lift(
-                expr_from_string("cute.math.rsqrt({x})", x=self._to_ast(x))
+                expr_from_string(f"cute.math.rsqrt({{x}}{suffix})", x=self._to_ast(x))
             )
         if backend_name == "pallas":
             return self._lift(expr_from_string("lax.rsqrt({x})", x=self._to_ast(x)))

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -1921,12 +1921,36 @@ class ForiLoopState(DeviceLoopOrGridState):
 
 
 @dataclasses.dataclass
+class VecLaneWrapper:
+    """Pre-built outer x constexpr-V lane structure for a GRID lane loop.
+
+    Grid lane loops are materialized late (``DeviceGridState.wrap_body``),
+    but the vec-load/store hoist protocol needs the outer-lane body list and
+    the constexpr V-loop node to exist DURING body codegen (memory_ops
+    splices hoisted ``cute.arch.load(..., V)`` statements into it).  So
+    ``PerThreadNDTileStrategy.codegen_grid`` pre-builds the structure and
+    ``wrap_body`` just plugs the user body into ``vloop.body``.
+    """
+
+    outer_for: ast.For
+    vloop: ast.For
+    vec_lane_var: str
+    base_index_var: str
+
+
+@dataclasses.dataclass
 class DeviceGridState(DeviceLoopOrGridState):
     lane_loops: list[tuple[str, int]] = dataclasses.field(default_factory=list)
     lane_loop_blocks: set[int] = dataclasses.field(default_factory=set)
     lane_setup_statements: list[ast.AST] = dataclasses.field(default_factory=list)
     outer_prefix: list[ast.AST] = dataclasses.field(default_factory=list)
     outer_suffix: list[ast.AST] = dataclasses.field(default_factory=list)
+    # lane_var -> pre-built vec partition (see VecLaneWrapper).  Only grid
+    # lane loops whose block has ``cute_vector_widths[block] > 1`` (and a
+    # divisible elements-per-thread) get an entry.
+    vec_lane_wrappers: dict[str, VecLaneWrapper] = dataclasses.field(
+        default_factory=dict
+    )
 
     def has_lane_loops(self) -> bool:
         return bool(self.lane_loops)
@@ -1948,6 +1972,16 @@ class DeviceGridState(DeviceLoopOrGridState):
         needed: set[str] = set()
         for stmt in body:
             needed |= set(ReadWrites.from_ast(stmt).reads)
+        # A vec wrapper whose lane body received memory_ops splices (hoisted
+        # vec loads before the V-loop, store flushes after it) must be kept
+        # regardless of what the inner body reads: the flush IS the store.
+        # Its splices also read setup vars (masks, sibling index vars), so
+        # fold those reads in before selecting kept_setup.
+        spliced_wrappers: set[str] = set()
+        for lane_var, wrapper in self.vec_lane_wrappers.items():
+            if len(wrapper.outer_for.body) > 2:  # more than [base, vloop]
+                spliced_wrappers.add(lane_var)
+                needed |= set(ReadWrites.from_ast(wrapper.outer_for).reads)
         kept_setup: list[ast.AST] = []
         for stmt in reversed(self.lane_setup_statements):
             rw = ReadWrites.from_ast(stmt)
@@ -1957,6 +1991,18 @@ class DeviceGridState(DeviceLoopOrGridState):
         kept_setup.reverse()
         wrapped: list[ast.AST] = [*kept_setup, *body]
         for lane_var, extent in reversed(self.lane_loops):
+            wrapper = self.vec_lane_wrappers.get(lane_var)
+            if wrapper is not None:
+                # The per-element index var reads ``base_index_var`` +
+                # ``vec_lane_var`` (not ``lane_var`` directly), so test all
+                # three before dropping the structure as dead.
+                if lane_var not in spliced_wrappers and not (
+                    {lane_var, wrapper.vec_lane_var, wrapper.base_index_var} & needed
+                ):
+                    continue
+                wrapper.vloop.body = wrapped  # type: ignore[assignment]
+                wrapped = [wrapper.outer_for]
+                continue
             if lane_var not in needed:
                 continue
             wrapped = [_create_lane_loop(lane_var, extent, wrapped)]
@@ -4118,6 +4164,7 @@ class PerThreadNDTileStrategy(NDTileStrategy):
 
         lane_setup_statements: list[ast.AST] = []
         outer_setup_statements: list[ast.AST] = []
+        vec_wrappers: dict[str, VecLaneWrapper] = {}
         tracker = ThreadAxisTracker()
         thread_axis_offset = self._thread_axis_offset(state)
         thread_axis_map = self._thread_axis_map()
@@ -4185,7 +4232,85 @@ class PerThreadNDTileStrategy(NDTileStrategy):
             else:
                 idx_expr = offset_var
             if lane_var := self._lane_var_by_block.get(block_idx):
-                idx_expr = f"{idx_expr} + {env.backend.lane_offset_expr(lane_var)}"
+                vec_width = self._cute_lane_vec_width_by_block.get(block_idx, 1)
+                lane_strided = (
+                    self._cute_lane_layout_by_block.get(block_idx, "blocked")
+                    == "strided"
+                    and uses_thread_axis
+                    and isinstance(static_extent, int)
+                )
+                if (
+                    vec_width > 1
+                    and uses_thread_axis
+                    and elements_per_thread % vec_width == 0
+                    # A matmul fallback may suppress root lane loops AFTER
+                    # loads already hoisted into the wrapper (cute_mma's
+                    # request_root_lane_loop_suppression), which would strand
+                    # the hoists; keep grid vec to matmul-free kernels.
+                    and not env.config_spec.matmul_facts
+                ):
+                    # Same outer x constexpr-V lane partition as
+                    # ``codegen_device_loop`` (see the comments there), so
+                    # the memory_ops vec-load/store hoist protocol applies
+                    # to GRID lane loops too.  The loops themselves are
+                    # materialized later by ``DeviceGridState.wrap_body``
+                    # from the pre-built ``VecLaneWrapper``.
+                    vec_lane_var = self.fn.new_var(f"vec_lane_{block_idx}", dce=False)
+                    self._cute_vec_lane_var_by_block[block_idx] = vec_lane_var
+                    inner_for = cast(
+                        "ast.For",
+                        ast.parse(
+                            f"for {vec_lane_var} in cutlass.range_constexpr({vec_width}):\n"
+                            f"    pass"
+                        ).body[0],
+                    )
+                    lane_body: list[ast.AST] = [inner_for]
+                    self._cute_lane_body_by_block[block_idx] = lane_body
+                    self._cute_lane_vloop_by_block[block_idx] = inner_for
+                    base_index_var = self.fn.new_var(
+                        f"lane_base_{block_idx}", dce=False
+                    )
+                    self._cute_lane_base_index_var_by_block[block_idx] = base_index_var
+                    if lane_strided:
+                        # ``base = offset + (outer*NT + tid) * V``
+                        base_expr = (
+                            f"{offset_var} + "
+                            f"({env.backend.lane_offset_expr(lane_var)} "
+                            f"* {static_extent} + "
+                            f"{env.backend.thread_index_expr(axis=axis)}) "
+                            f"* {vec_width}"
+                        )
+                    else:
+                        # ``base = offset + tid*EPT + outer*V``
+                        base_expr = (
+                            f"{idx_expr} + "
+                            f"{env.backend.lane_offset_expr(lane_var)} "
+                            f"* {vec_width}"
+                        )
+                    lane_body.insert(
+                        0,
+                        statement_from_string(f"{base_index_var} = {base_expr}"),
+                    )
+                    outer_for = _create_lane_loop(
+                        lane_var, elements_per_thread // vec_width, lane_body
+                    )
+                    vec_wrappers[lane_var] = VecLaneWrapper(
+                        outer_for=outer_for,
+                        vloop=inner_for,
+                        vec_lane_var=vec_lane_var,
+                        base_index_var=base_index_var,
+                    )
+                    idx_expr = f"{base_index_var} + cutlass.Int32({vec_lane_var})"
+                elif lane_strided:
+                    # ``idx = offset + tid + lane * NT`` — consecutive
+                    # threads touch consecutive elements each lane iter.
+                    idx_expr = (
+                        f"{offset_var} + {env.backend.thread_index_expr(axis=axis)}"
+                        f" + {env.backend.lane_offset_expr(lane_var)}"
+                        f" * {static_extent}"
+                    )
+                else:
+                    idx_expr = f"{idx_expr} + {env.backend.lane_offset_expr(lane_var)}"
                 target = lane_setup_statements
             else:
                 # Setup that does not depend on a lane variable can be hoisted
@@ -4246,6 +4371,7 @@ class PerThreadNDTileStrategy(NDTileStrategy):
             outer_prefix=outer_setup_statements,
             thread_axis_sizes=tracker.sizes,
             block_thread_axes=tracker.block_axes,
+            vec_lane_wrappers=vec_wrappers,
         )
 
     def codegen_device_loop(self, state: CodegenState) -> DeviceLoopState:
@@ -4541,6 +4667,52 @@ class PerThreadFlattenedTileStrategy(FlattenedTileStrategy):
         self._lane_var: str | None = None
         if num_threads > 0 and isinstance(block_size, int) and num_threads < block_size:
             self._lane_var = self.new_var("lane", dce=False)
+        # Vec-partition state for the memory_ops ``tile_unroll`` hoist
+        # protocol (same shape as ``PerThreadNDTileStrategy``).  Only the
+        # single-block (1D) form participates: with multiple flattened
+        # blocks the per-dim index vars are div/mod-derived per element, so
+        # a hoisted base pointer built from ``index_exprs`` would reference
+        # per-element vars that do not exist at the hoist point.
+        self._cute_lane_layout: str = "blocked"
+        self._cute_lane_vec_width_by_block: dict[int, int] = {}
+        self._cute_vec_lane_var_by_block: dict[int, str] = {}
+        self._cute_lane_base_index_var_by_block: dict[int, str] = {}
+        self._cute_lane_body_by_block: dict[int, list] = {}
+        self._cute_lane_vloop_by_block: dict[int, ast.For] = {}
+        self._cute_lane_vec_stores_by_block: dict[int, dict] = {}
+        self._cute_lane_vec_loads_by_block: dict[int, dict] = {}
+        if self._lane_var is not None and len(block_ids) == 1:
+            env = CompileEnvironment.current()
+            block_id = block_ids[0]
+            cfg = fn.config.config
+            if block_id in env.config_spec.cute_lane_layouts.valid_block_ids():
+                layout = env.config_spec.cute_lane_layouts.config_get(
+                    cast("list[str]", cfg.get("cute_lane_layouts", []) or []),
+                    block_id,
+                    "blocked",
+                )
+                if isinstance(layout, str):
+                    self._cute_lane_layout = layout
+            if block_id in env.config_spec.cute_vector_widths.valid_block_ids():
+                vec_width = env.config_spec.cute_vector_widths.config_get(
+                    cast("list[int]", cfg.get("cute_vector_widths", []) or []),
+                    block_id,
+                    1,
+                )
+                assert isinstance(block_size, int)
+                elements_per_thread = block_size // num_threads
+                if (
+                    isinstance(vec_width, int)
+                    and vec_width > 1
+                    and elements_per_thread % vec_width == 0
+                ):
+                    self._cute_lane_vec_width_by_block[block_id] = vec_width
+
+    def _configured_block_size_int(self, block_size: SymIntLike) -> int | None:
+        # Shared with the tile_unroll hoist protocol (see the identically
+        # named method on PerThreadNDTileStrategy); the flattened block size
+        # is already a plain int whenever the lane path is active.
+        return block_size if isinstance(block_size, int) else None
 
     @property
     def _elements_per_thread(self) -> int:
@@ -4609,12 +4781,88 @@ class PerThreadFlattenedTileStrategy(FlattenedTileStrategy):
         env = CompileEnvironment.current()
         total_numel = sympy.S.One
         lane_setup_statements: list[ast.AST] = []
-
-        lane_setup_statements.append(
-            statement_from_string(
-                f"{offsets_var} = {offsets_base_var} + {env.backend.lane_offset_expr(self._lane_var)}"
-            )
+        vec_wrappers: dict[str, VecLaneWrapper] = {}
+        axis = self._flat_thread_axis()
+        thread_extent = self._thread_extent()
+        vec_width = self._cute_lane_vec_width_by_block.get(block_ids[0], 1)
+        lane_strided = self._cute_lane_layout == "strided" and isinstance(
+            thread_extent, int
         )
+
+        if vec_width > 1 and env.config_spec.matmul_facts:
+            # See the matmul-fallback lane-loop-suppression note in
+            # ``PerThreadNDTileStrategy.codegen_grid``.
+            vec_width = 1
+        if vec_width > 1:
+            # Same outer x constexpr-V lane partition as
+            # ``PerThreadNDTileStrategy.codegen_grid`` so the memory_ops
+            # tile_unroll vec-hoist protocol applies to flattened (1D)
+            # grid tiles too.
+            block_id = block_ids[0]
+            vec_lane_var = self.new_var("vec_lane", dce=False)
+            self._cute_vec_lane_var_by_block[block_id] = vec_lane_var
+            inner_for = cast(
+                "ast.For",
+                ast.parse(
+                    f"for {vec_lane_var} in cutlass.range_constexpr({vec_width}):\n"
+                    f"    pass"
+                ).body[0],
+            )
+            lane_body: list[ast.AST] = [inner_for]
+            self._cute_lane_body_by_block[block_id] = lane_body
+            self._cute_lane_vloop_by_block[block_id] = inner_for
+            base_index_var = self.new_var("lane_base", dce=False)
+            self._cute_lane_base_index_var_by_block[block_id] = base_index_var
+            if lane_strided:
+                # ``base = pid*BS + (outer*NT + tid) * V``
+                base_expr = (
+                    f"{offsets_base_var} + "
+                    f"({env.backend.lane_offset_expr(self._lane_var)} "
+                    f"* {thread_extent} + "
+                    f"{env.backend.thread_index_expr(axis=axis)}) "
+                    f"* {vec_width}"
+                )
+            else:
+                # ``base = pid*BS + tid*EPT + outer*V``
+                base_expr = (
+                    f"{offsets_base_var} + "
+                    f"{env.backend.lane_offset_expr(self._lane_var)} "
+                    f"* {vec_width}"
+                )
+            lane_body.insert(
+                0, statement_from_string(f"{base_index_var} = {base_expr}")
+            )
+            outer_for = _create_lane_loop(
+                self._lane_var, self._elements_per_thread // vec_width, lane_body
+            )
+            vec_wrappers[self._lane_var] = VecLaneWrapper(
+                outer_for=outer_for,
+                vloop=inner_for,
+                vec_lane_var=vec_lane_var,
+                base_index_var=base_index_var,
+            )
+            lane_setup_statements.append(
+                statement_from_string(
+                    f"{offsets_var} = {base_index_var} + cutlass.Int32({vec_lane_var})"
+                )
+            )
+        elif lane_strided:
+            # ``offsets = pid*BS + tid + lane * NT`` — consecutive threads
+            # touch consecutive elements each lane iter (coalesced even
+            # without vectorization).
+            lane_setup_statements.append(
+                statement_from_string(
+                    f"{offsets_var} = {offsets_base_var} + "
+                    f"{env.backend.lane_offset_expr(self._lane_var)}"
+                    f" * {thread_extent}"
+                )
+            )
+        else:
+            lane_setup_statements.append(
+                statement_from_string(
+                    f"{offsets_var} = {offsets_base_var} + {env.backend.lane_offset_expr(self._lane_var)}"
+                )
+            )
         for i, block_idx in enumerate(self._reorder(block_ids)):
             numel = env.block_sizes[block_idx].numel
             block_index_var = self.index_var(block_idx)
@@ -4641,10 +4889,20 @@ class PerThreadFlattenedTileStrategy(FlattenedTileStrategy):
         if isinstance(state.device_function.pid, ForEachProgramID):
             pids.shared_pid_var = state.device_function.pid.shared_pid_var
         pids.append(PIDInfo(pid_var, block_size_var, total_numel, self.block_ids[0]))
-        axis = self._flat_thread_axis()
-        state.add_statement(
-            f"{offsets_base_var} = {env.backend.lane_index_expr(f'({pid_var}) * ({block_size_var})', self._elements_per_thread, axis=axis)}"
-        )
+        if vec_width > 1 and lane_strided:
+            # The strided vec base folds the thread index in itself.
+            state.add_statement(
+                f"{offsets_base_var} = ({pid_var}) * ({block_size_var})"
+            )
+        elif lane_strided:
+            # ``offsets_base = pid*BS + tid`` (per-lane term adds lane*NT).
+            state.add_statement(
+                f"{offsets_base_var} = {env.backend.lane_index_expr(f'({pid_var}) * ({block_size_var})', 1, axis=axis)}"
+            )
+        else:
+            state.add_statement(
+                f"{offsets_base_var} = {env.backend.lane_index_expr(f'({pid_var}) * ({block_size_var})', self._elements_per_thread, axis=axis)}"
+            )
         pids.codegen(state)
         if isinstance(state.device_function.pid, ForEachProgramID):
             shared_pid = state.device_function.pid
@@ -4657,7 +4915,6 @@ class PerThreadFlattenedTileStrategy(FlattenedTileStrategy):
         if self._lane_var is not None:
             lane_loops = [(self._lane_var, self._elements_per_thread)]
         tracker = ThreadAxisTracker()
-        thread_extent = self._thread_extent()
         if self._uses_thread_axis() and isinstance(thread_extent, int):
             tracker.record_all(self.block_ids, axis, thread_extent)
         return DeviceGridState(
@@ -4668,6 +4925,7 @@ class PerThreadFlattenedTileStrategy(FlattenedTileStrategy):
             lane_setup_statements=lane_setup_statements,
             thread_axis_sizes=tracker.sizes,
             block_thread_axes=tracker.block_axes,
+            vec_lane_wrappers=vec_wrappers,
         )
 
     def codegen_device_loop(self, state: CodegenState) -> DeviceLoopState:

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -819,6 +819,7 @@ BACKEND_SPECIFIC_KEYS: frozenset[str] = (
         "cute_reduction_reloads",
         "cute_cluster_n",
         "cute_min_blocks_per_mp",
+        "cute_fastmath",
         "load_cache_modifiers",
         "store_cache_modifiers",
         "pallas_loop_type",
@@ -862,6 +863,7 @@ VALID_KEYS: frozenset[str] = frozenset(
         "cute_reduction_reloads",
         "cute_cluster_n",
         "cute_min_blocks_per_mp",
+        "cute_fastmath",
         *BACKEND_TUNABLE_KEYS,
         "advanced_controls_file",
         "epilogue_subtile",
@@ -1145,6 +1147,10 @@ class ConfigSpec:
         self.pointwise_facts: list[PointwiseElementwiseFact] = []
         self.store_indices: list[int] = []
         self.memory_op_facts: list[MemoryOpFact] = []
+        # True when the device IR contains transcendental ops (exp/tanh/...);
+        # gates the ``cute_fastmath`` search dimension (device_ir sets it
+        # during cute registration).
+        self.cute_has_transcendentals: bool = False
         self.backend_tunable_fragments = self.backend.tunable_fragments()
         unknown_tunables = set(self.backend_tunable_fragments) - BACKEND_TUNABLE_KEYS
         if unknown_tunables:
@@ -3387,6 +3393,17 @@ class ConfigSpec:
                     fields["cute_min_blocks_per_mp"] = EnumFragment(
                         choices=(0, 1, 2, 3, 4, 6)
                     )
+                # Fast-math transcendentals (MUFU tanh / ex2 / rcp / rsqrt
+                # instead of the accurate SASS expansions).  Only searched
+                # when the kernel actually contains transcendental ops; the
+                # autotuner's baseline accuracy check rejects it wherever
+                # the numerics drift past tolerance, so it is self-gating.
+                if (
+                    self.supports_config_key("cute_fastmath")
+                    and self.cute_has_transcendentals
+                    and not self.matmul_facts
+                ):
+                    fields["cute_fastmath"] = EnumFragment(choices=(False, True))
             if (
                 not self.cute_flash_search_enabled
                 and self.epilogue_subtile_autotune_choices is not None

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -948,13 +948,15 @@ def _cute_register_tile_unroll_vec_store(
     index_exprs: list[str],
     value_expr: str,
     mask_expr: str | None,
+    dtype: torch.dtype = torch.float16,
 ) -> ast.stmt | None:
     """Vector-store counterpart of ``_cute_register_tile_unroll_vec_hoist``.
 
     Replaces the per-lane scalar ``(ptr).store(value)`` inside the constexpr
     V-loop with an append onto a compile-time Python list, and splices ONE
-    ``_cute_store_u16_vec(base_ptr, vals)`` flush AFTER the V-loop, emitting
-    an ST.64/ST.128 instead of V scalar 2-byte stores.
+    ``_cute_store_u16_vec(base_ptr, vals)`` (bf16/fp16; ``_cute_store_u32_vec``
+    for fp32) flush AFTER the V-loop, emitting an ST.64/ST.128 instead of V
+    scalar stores.
 
     Caller must guarantee the per-element mask is uniform across the V
     lanes (``numel % V == 0``, no extra_mask); the flush reuses the scalar
@@ -990,7 +992,11 @@ def _cute_register_tile_unroll_vec_store(
     sites.append(list_var)
     vloop_pos = _cute_lane_vloop_insert_pos(strategy, block_id, lane_body)
     lane_body.insert(vloop_pos, statement_from_string(f"{list_var} = []"))
-    flush_expr = f"_cute_store_u16_vec({base_ptr_expr}, {list_var})"
+    carrier = _CUTE_VECTOR_UNROLL_CARRIER[dtype]
+    flush_helper = (
+        "_cute_store_u32_vec" if dtype is torch.float32 else "_cute_store_u16_vec"
+    )
+    flush_expr = f"{flush_helper}({base_ptr_expr}, {list_var})"
     if mask_expr is not None:
         flush_stmt = statement_from_string(f"if {mask_expr}:\n    {flush_expr}")
     else:
@@ -1002,7 +1008,7 @@ def _cute_register_tile_unroll_vec_store(
         flush_stmt,
     )
     return statement_from_string(
-        f"{list_var}.append(({value_expr}).bitcast(cutlass.Uint16))"
+        f"{list_var}.append(({value_expr}).bitcast({carrier}))"
     )
 
 
@@ -1013,6 +1019,7 @@ def _cute_register_reduction_unroll_vec_store(
     index_exprs: list[str],
     value_expr: str,
     mask_expr: str | None,
+    dtype: torch.dtype = torch.float16,
 ) -> ast.stmt | None:
     """Reduction-lane variant of ``_cute_register_tile_unroll_vec_store``.
 
@@ -1058,7 +1065,11 @@ def _cute_register_reduction_unroll_vec_store(
     )
     sites.append(list_var)
     lane_body.insert(_vloop_pos(), statement_from_string(f"{list_var} = []"))
-    flush_expr = f"_cute_store_u16_vec({base_ptr_expr}, {list_var})"
+    carrier = _CUTE_VECTOR_UNROLL_CARRIER[dtype]
+    flush_helper = (
+        "_cute_store_u32_vec" if dtype is torch.float32 else "_cute_store_u16_vec"
+    )
+    flush_expr = f"{flush_helper}({base_ptr_expr}, {list_var})"
     if mask_expr is not None:
         flush_stmt = statement_from_string(f"if {mask_expr}:\n    {flush_expr}")
     else:
@@ -1067,7 +1078,7 @@ def _cute_register_reduction_unroll_vec_store(
     # emitted store order matches the source order.
     lane_body.insert(_vloop_pos() + 1 + site_index, flush_stmt)
     return statement_from_string(
-        f"{list_var}.append(({value_expr}).bitcast(cutlass.Uint16))"
+        f"{list_var}.append(({value_expr}).bitcast({carrier}))"
     )
 
 
@@ -1132,19 +1143,24 @@ def _cute_register_tile_unroll_vec_hoist(
         env_local = CompileEnvironment.current()
         numel = env_local.block_sizes[block_id].numel
         numel_expr = state.sympy_expr(numel)
-        mask_vars = getattr(strategy, "mask_vars", None)
         block_pos = strategy.block_ids.index(block_id)  # pyrefly: ignore
-        static_bs = strategy._configured_block_size_int(  # pyrefly: ignore
-            strategy.block_size[block_pos]  # pyrefly: ignore
-        )
+        bs_obj = strategy.block_size  # pyrefly: ignore
+        if isinstance(bs_obj, (list, tuple)):
+            bs_obj = bs_obj[block_pos]
+        static_bs = strategy._configured_block_size_int(bs_obj)  # pyrefly: ignore
+        mask_vars = getattr(strategy, "mask_vars", None)
+        if isinstance(mask_vars, dict):
+            # PerThreadNDTileStrategy: per-block mask registry.
+            mask_elided = block_id in mask_vars and mask_vars[block_id] is None
+        else:
+            # FlattenedTileStrategy keeps a single (elision-aware) mask var.
+            mask_elided = strategy.mask_var(block_id) is None  # pyrefly: ignore
         try:
             numel_int = int(numel)
         except (TypeError, ValueError):
             numel_int = None
         if (
-            isinstance(mask_vars, dict)
-            and block_id in mask_vars
-            and (mask_vars[block_id] is None)
+            mask_elided
             and isinstance(static_bs, int)
             and numel_int is not None
             and static_bs >= numel_int

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -14052,12 +14052,14 @@ class TestCuteLowerings(unittest.TestCase):
         grid_strategy = SimpleNamespace(
             _lane_var_by_block={0: "lane_0", 1: "lane_1"},
             _elements_per_thread_for_block=lambda block_id: 2,
+            _cute_lane_vec_width_by_block={},
         )
         grid_state = SimpleNamespace(
             block_thread_axes={0: 0, 1: 1},
             has_lane_loops=lambda: True,
             lane_loops=[("lane_0", 2), ("lane_1", 2)],
             strategy=grid_strategy,
+            vec_lane_wrappers={},
         )
         cg = _FakeGenerateAST({0, 1}, current_grid_state=grid_state)
         ctx = SimpleNamespace(cg=cg, env={inp: ast.Name(id="inp_tile", ctx=ast.Load())})
@@ -14079,6 +14081,49 @@ class TestCuteLowerings(unittest.TestCase):
         emitted = "\n".join(ast.unparse(stmt) for stmt in cg.statements)
         self.assertIn("if lane_1 == 1:", emitted)
         self.assertNotIn("if lane_0 == 1:", emitted)
+
+    def test_codegen_cute_argreduce_scan_gate_on_vec_lane_loop(self) -> None:
+        """A vec'd lane loop runs its outer var over EPT // V; the scan-ready
+        gate must fire on the last vec lane of the last outer iteration (the
+        full-EPT condition would never be true)."""
+        graph = Graph()
+        inp = graph.placeholder("inp")
+        argmax = graph.call_function(torch.ops.aten.argmax.default, args=(inp, 1))
+        graph.output(argmax)
+        inp.meta["val"] = torch.empty(4, 8)
+        argmax.meta["val"] = torch.empty(4, dtype=torch.int64)
+
+        grid_strategy = SimpleNamespace(
+            _lane_var_by_block={0: "lane_0", 1: "lane_1"},
+            _elements_per_thread_for_block=lambda block_id: 4,
+            _cute_lane_vec_width_by_block={1: 2},
+        )
+        grid_state = SimpleNamespace(
+            block_thread_axes={0: 0, 1: 1},
+            has_lane_loops=lambda: True,
+            lane_loops=[("lane_0", 4), ("lane_1", 4)],
+            strategy=grid_strategy,
+            vec_lane_wrappers={"lane_1": SimpleNamespace(vec_lane_var="vec_lane_1")},
+        )
+        cg = _FakeGenerateAST({0, 1}, current_grid_state=grid_state)
+        ctx = SimpleNamespace(cg=cg, env={inp: ast.Name(id="inp_tile", ctx=ast.Load())})
+        env = _fake_env({4: 0, 8: 1})
+
+        with (
+            patch.object(CompileEnvironment, "current", return_value=env),
+            patch("helion._compiler.generate_ast.GenerateAST", _FakeGenerateAST),
+        ):
+            codegen_cute_tile_argreduce(
+                ctx,
+                argmax,
+                "argmax",
+                dim=1,
+                keepdim=False,
+            )
+
+        emitted = "\n".join(ast.unparse(stmt) for stmt in cg.statements)
+        self.assertIn("if lane_1 == 1 and vec_lane_1 == 1:", emitted)
+        self.assertNotIn("lane_1 == 3", emitted)
 
     def test_loop_contains_matmul_for_root_grid_phase(self) -> None:
         root_graph = Graph()

--- a/test/test_cute_pointwise_vec.py
+++ b/test/test_cute_pointwise_vec.py
@@ -1,0 +1,188 @@
+"""Tests for GRID-level lane-loop vectorization on the CuTe backend.
+
+Pointwise kernels (``for tile in hl.tile(...)`` at grid level) get the same
+outer x constexpr-V lane partition + hoisted ``cute.arch.load(..., V)`` /
+``_cute_store_u*_vec`` flush protocol as device loops when the config sets
+``num_threads[block] < block_size`` and ``cute_vector_widths[block] > 1``.
+
+Covers both strategies (``PerThreadNDTileStrategy`` for N-D tiles,
+``PerThreadFlattenedTileStrategy`` for 1D), fp32 Uint32-carrier stores, the
+``cute_fastmath`` knob, and two regressions found in review:
+
+- an index-independent store value must not drop the vec wrapper (the store
+  flush lives inside it),
+- a lane block accepted on a NON-stride-1 tensor dim must not be vectorized
+  (the hoist reads V contiguous elements).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import TestCase
+from helion._testing import code_and_output
+from helion._testing import onlyBackends
+import helion.language as hl
+
+cutlass = pytest.importorskip("cutlass")
+cute = pytest.importorskip("cutlass.cute")
+
+
+@helion.kernel(backend="cute", static_shapes=True)
+def _add2d(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(out.size()):
+        out[tile] = x[tile] + y[tile]
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=True)
+def _mul1d(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(out.size()):
+        out[tile] = x[tile] * y[tile]
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=True)
+def _const_store(x: torch.Tensor, s: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(out.size()):
+        out[tile] = s[0] * 2.0
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=True)
+def _col0_gather(x: torch.Tensor) -> torch.Tensor:
+    m = x.size(0)
+    out = torch.empty([m], dtype=x.dtype, device=x.device)
+    for tile_m in hl.tile(m):
+        out[tile_m] = x[tile_m, 0] * 2.0
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=True)
+def _tanh1d(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(out.size()):
+        out[tile] = torch.tanh(x[tile])
+    return out
+
+
+@onlyBackends(["cute"])
+class TestCutePointwiseVec(TestCase):
+    def test_nd_grid_vec_bf16(self) -> None:
+        """2D grid tile with nt<bs and V=8 emits one LDG.128 hoist per input
+        and a single u16 vec-store flush; results match eager."""
+        x = torch.randn(256, 2048, device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn(256, 2048, device=DEVICE, dtype=torch.bfloat16)
+        code, out = code_and_output(
+            _add2d,
+            (x, y),
+            block_sizes=[1, 2048],
+            num_threads=[1, 256],
+            cute_vector_widths=[1, 8],
+        )
+        self.assertIn("ir.VectorType.get([8], cutlass.Uint16.mlir_type)", code)
+        self.assertIn("_cute_store_u16_vec", code)
+        torch.testing.assert_close(out, x + y)
+
+    def test_flattened_grid_vec_fp32_u32_store(self) -> None:
+        """1D (flattened) grid tile with V=4 fp32: Uint32 vec loads and the
+        Uint32-carrier vec-store flush."""
+        x = torch.randn(2**16, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(2**16, device=DEVICE, dtype=torch.float32)
+        code, out = code_and_output(
+            _mul1d,
+            (x, y),
+            block_sizes=[1024],
+            num_threads=[256],
+            cute_vector_widths=[4],
+        )
+        self.assertIn("ir.VectorType.get([4], cutlass.Uint32.mlir_type)", code)
+        self.assertIn("_cute_store_u32_vec", code)
+        torch.testing.assert_close(out, x * y)
+
+    def test_strided_lane_layout_vec(self) -> None:
+        """Strided lane layout with vec: thread vec chunks interleave by NT."""
+        x = torch.randn(2**16, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(2**16, device=DEVICE, dtype=torch.float32)
+        code, out = code_and_output(
+            _mul1d,
+            (x, y),
+            block_sizes=[2048],
+            num_threads=[256],
+            cute_vector_widths=[4],
+            cute_lane_layouts=["strided"],
+        )
+        self.assertIn("ir.VectorType.get([4], cutlass.Uint32.mlir_type)", code)
+        torch.testing.assert_close(out, x * y)
+
+    def test_masked_tail_tile_vec(self) -> None:
+        """Extent not divisible by the block (but divisible by V): the tail
+        tile is masked per element and the flush is mask-gated."""
+        x = torch.randn(8, 1664, device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn(8, 1664, device=DEVICE, dtype=torch.bfloat16)
+        code, out = code_and_output(
+            _add2d,
+            (x, y),
+            block_sizes=[1, 1024],
+            num_threads=[1, 128],
+            cute_vector_widths=[1, 8],
+        )
+        self.assertIn("ir.VectorType.get([8], cutlass.Uint16.mlir_type)", code)
+        torch.testing.assert_close(out, x + y)
+
+    def test_index_independent_store_keeps_wrapper(self) -> None:
+        """Regression: a store whose VALUE reads no per-lane vars must keep
+        the vec wrapper (its flush IS the store) — previously the wrapper
+        was dropped as dead, losing the store entirely."""
+        for dtype, vec in ((torch.float32, 4), (torch.bfloat16, 8)):
+            x = torch.randn(2**14, device=DEVICE, dtype=dtype)
+            s = torch.full((1,), 3.0, device=DEVICE, dtype=dtype)
+            _, out = code_and_output(
+                _const_store,
+                (x, s),
+                block_sizes=[1024],
+                num_threads=[128],
+                cute_vector_widths=[vec],
+            )
+            torch.testing.assert_close(out, torch.full_like(x, 6.0))
+
+    def test_non_stride1_lane_axis_not_vectorized(self) -> None:
+        """Regression: the lane block sits on dim 0 of ``x`` while dim 1 is
+        contiguous — the hoist (V contiguous elements) must NOT fire."""
+        x = torch.randn(4096, 8, device=DEVICE, dtype=torch.bfloat16)
+        code, out = code_and_output(
+            _col0_gather,
+            (x,),
+            block_sizes=[2048],
+            num_threads=[256],
+            cute_vector_widths=[8],
+        )
+        self.assertNotIn("ir.VectorType.get([8]", code)
+        torch.testing.assert_close(out, x[:, 0] * 2.0)
+
+    def test_cute_fastmath_knob(self) -> None:
+        """``cute_fastmath=True`` routes fastmath=True into cute.math calls;
+        results stay within loose tolerance of the accurate form."""
+        x = torch.randn(2**14, device=DEVICE, dtype=torch.float32)
+        code, out = code_and_output(
+            _tanh1d,
+            (x,),
+            block_sizes=[1024],
+            num_threads=[256],
+            cute_vector_widths=[4],
+            cute_fastmath=True,
+        )
+        self.assertIn("fastmath=True", code)
+        torch.testing.assert_close(out, torch.tanh(x), rtol=1e-4, atol=1e-4)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3560
 * #3559
 * #3558
 * #3557
 * #3556
 * __->__#3555
 * #3554


--- --- ---

[cutedsl] Vectorize grid-level lane loops for pointwise kernels

Pointwise kernels (a grid-level 'for tile in hl.tile(...)') previously
emitted one scalar load/store per thread per element on the cute backend
(~0.4-2.2 TB/s of ~6.6 TB/s attainable on B200): the tile_unroll
vec-hoist protocol (hoisted cute.arch.load(..., V) + one
_cute_store_u*_vec flush per site) only activated inside
codegen_device_loop, never for grid tiles.

- PerThreadNDTileStrategy.codegen_grid and PerThreadFlattenedTileStrategy
  (single-block 1D form) now pre-build the same outer x constexpr-V lane
  partition (VecLaneWrapper) and register the _cute_lane_*_by_block hoist
  dicts; DeviceGridState.wrap_body materializes the pre-built structure
  (and must keep it whenever memory_ops spliced hoists/flushes into it -
  the flush IS the store).
- The vec-load ctx now requires the lane axis to sit on the tensor's
  stride-1 dim (a lane block accepted via the fallback, e.g.
  x[tile_m, 0] with dim 1 contiguous, would vectorize the wrong dim).
- fp32 vec stores: Uint32 carrier + new _cute_store_u32_vec runtime
  helper (tile AND reduction store paths), so fp32 pointwise/reduction
  stores emit ST.128 instead of four scalar stores.
- Grid lane loops honor cute_lane_layouts=strided (scalar and vec forms);
  previously the knob was silently inert on grid tiles.
- Grid vec is disabled for kernels with matmul facts: matmul fallbacks
  can suppress root lane loops after hoists were spliced.
- New CutePointwiseVecHeuristic seeds NT=256 x V(16B) x U=2 on the
  stride-1 axis, keyed on PointwiseElementwiseFact.

Also adds an autotunable cute_fastmath knob (EnumFragment, gated on a
device-IR transcendental scan; routed through inductor's
_CUTEDSL_FAST_MATH contextvar in generate_ast) with a fastmath alternate
seed for SFU-heavy pointwise kernels; the autotuner's baseline accuracy
check self-gates it.

Cold quick-effort autotunes on B200 lift the 16-variant pointwise
benchmark from 0.23-1.0 TB/s (old defaults) / 2.3-5.0 (old full
autotune) to 4.1-6.7 TB/s; gelu_tanh reaches 5.8 TB/s with fastmath
(handwritten CuTe baseline: 5.9).