### PR TITLE
[cutedsl] Flattened multi-dim vec, fastmath-setting rcp, flatten re-registration

### DIFF
--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
@@ -2371,9 +2370,12 @@ class CutePointwiseVecHeuristic(AutotunerHeuristic):
     @classmethod
     def _vec_axis_and_width(
         cls, env: CompileEnvironment
-    ) -> tuple[int, int, int] | None:
-        """Returns (vec_block_id, V, axis size_hint), or None if no axis
-        can host a vec lane loop."""
+    ) -> tuple[int, int, int, bool] | None:
+        """Returns (vec_block_id, V, size_hint, flatten) or None if no axis
+        can host a vec lane loop.  ``flatten`` is True when the innermost
+        extent is not V-divisible but the flattened total is: the seed then
+        flattens the tile (flat V-chunks stay memory-contiguous for
+        full-cover contiguous tensors, odd row length or not)."""
         spec = env.config_spec
         if not spec.pointwise_facts:
             return None
@@ -2393,13 +2395,28 @@ class CutePointwiseVecHeuristic(AutotunerHeuristic):
         if vec_block not in spec.num_threads.valid_block_ids():
             return None
         size_hint = spec.block_sizes.block_id_lookup(vec_block).size_hint
-        vec = 16 // max(1, fact.storage_itemsize)
+        full_vec = 16 // max(1, fact.storage_itemsize)
         # The hoist requires numel % V == 0; shrink V until it divides.
+        vec = full_vec
         while vec > 1 and size_hint % vec != 0:
+            vec //= 2
+        if vec > 1:
+            return vec_block, vec, size_hint, False
+        # Innermost extent is odd: flatten and vectorize the flat space.
+        flatten_group = next(
+            (f for f in spec.flatten_loops if vec_block in f.block_ids), None
+        )
+        if flatten_group is None:
+            return None
+        total = 1
+        for bid in flatten_group.block_ids:
+            total *= spec.block_sizes.block_id_lookup(bid).size_hint
+        vec = full_vec
+        while vec > 1 and total % vec != 0:
             vec //= 2
         if vec <= 1:
             return None
-        return vec_block, vec, size_hint
+        return vec_block, vec, total, True
 
     @classmethod
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
@@ -2413,7 +2430,7 @@ class CutePointwiseVecHeuristic(AutotunerHeuristic):
         picked = cls._vec_axis_and_width(env)
         if picked is None:
             return None
-        vec_block, vec, size_hint = picked
+        vec_block, vec, size_hint, flatten = picked
         bs_high = spec.block_sizes.block_id_lookup(vec_block)._fragment(spec).high
         nt, unroll = cls.NT, cls.UNROLL
         while nt * vec * unroll > bs_high and unroll > 1:
@@ -2432,36 +2449,12 @@ class CutePointwiseVecHeuristic(AutotunerHeuristic):
                 spec.cute_vector_widths, {vec_block: vec}
             ),
         }
+        if flatten:
+            seed["flatten_loops"] = [True for _ in spec.flatten_loops]
         try:
             return Config(**seed)
         except Exception:
             return None
-
-    @classmethod
-    def get_seed_configs(
-        cls, env: CompileEnvironment, device_ir: DeviceIR
-    ) -> list[Config] | None:
-        primary = cls.get_seed_config(env, device_ir)
-        if primary is None:
-            return None
-        spec = env.config_spec
-        seeds = [primary]
-        # Transcendental-heavy pointwise kernels (gelu/silu/...) are often
-        # SFU/ALU-bound with accurate math; plant a fastmath alternate so the
-        # search benchmarks it (the baseline accuracy check drops it where
-        # numerics drift past tolerance).
-        fact = spec.pointwise_facts[0] if spec.pointwise_facts else None
-        if (
-            fact is not None
-            and fact.sfu_ops > 0
-            and spec.cute_has_transcendentals
-            and spec.supports_config_key("cute_fastmath")
-        ):
-            fm_seed: dict[str, Any] = dict(primary.config)
-            fm_seed["cute_fastmath"] = True
-            with contextlib.suppress(Exception):
-                seeds.append(Config(**fm_seed))
-        return seeds
 
 
 class CuteFp8GemmSkinnyMHeuristic(AutotunerHeuristic):

--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -909,7 +909,6 @@ class CuteBackend(Backend):
             or key == "cute_reduction_reloads"
             or key == "cute_cluster_n"
             or key == "cute_min_blocks_per_mp"
-            or key == "cute_fastmath"
             or key.startswith(("tcgen05_", "cute_flash_"))
         ):
             return True
@@ -1216,6 +1215,68 @@ class CuteBackend(Backend):
                         x, "cute.math.exp2({x}, fastmath=True)"
                     )
                 return CuteDSLOpOverrides.exp2(x)
+
+            @staticmethod
+            def _fastmath_on() -> bool:
+                from torch._inductor.codegen.cutedsl.cutedsl_op_overrides import (
+                    _CUTEDSL_FAST_MATH,
+                )
+
+                return _CUTEDSL_FAST_MATH.get()
+
+            @staticmethod
+            # pyrefly: ignore [bad-override]
+            def sigmoid(x: CuteDSLArg) -> CuteDSLArg:
+                # The base lowering divides with an accurate IEEE fp32 div
+                # (a ~20-instruction SASS sequence).  Under fastmath use
+                # RCP.APPROX + EX2.APPROX like quack's sigmoid: at 2
+                # bytes/element these kernels are instruction-throughput
+                # bound and the accurate div costs ~20% of peak.
+                if not HelionCuteDSLOpOverrides._fastmath_on():
+                    return CuteDSLOpOverrides.sigmoid(x)
+                x_cse = CuteDSLOpOverrides._get_cse_var(x)
+                if x_cse is not None:
+                    x_fp32: CuteDSLArg = CuteDSLOpOverrides.to_dtype(
+                        x_cse,
+                        torch.float32,
+                        use_compute_types=False,
+                    )
+                else:
+                    x_fp32 = CuteDSLOpOverrides._cast_expr(str(x), torch.float32)
+                result = CuteDSLOpOverrides._apply_unary_op(
+                    x_fp32,
+                    f"cute.math.rcp(1.0 + cute.math.exp2("
+                    f"-{{x}} * {CuteDSLOpOverrides.LOG2_E}, fastmath=True), "
+                    f"approx=True, ftz=True)",
+                )
+                expected = CuteDSLOpOverrides._expected_tensor_val()
+                expected_dtype = expected.dtype if expected is not None else None
+                if expected_dtype is not None and expected_dtype != torch.float32:
+                    result_cse = CuteDSLOpOverrides._get_cse_var(result)
+                    if result_cse is not None:
+                        return CuteDSLOpOverrides.to_dtype(
+                            result_cse,
+                            expected_dtype,
+                            use_compute_types=False,
+                        )
+                    return CuteDSLOpOverrides._cast_expr(str(result), expected_dtype)
+                return result
+
+            @staticmethod
+            def truediv(a: CuteDSLArg, b: CuteDSLArg) -> CuteDSLArg:
+                # cute.math.div lowers to an NVVM intrinsic that only accepts
+                # fp32 scalars; 16/64-bit operands raise at DSL trace time, so
+                # keep the accurate IEEE path for every other dtype.
+                expected = CuteDSLOpOverrides._expected_tensor_val()
+                if (
+                    HelionCuteDSLOpOverrides._fastmath_on()
+                    and expected is not None
+                    and expected.dtype == torch.float32
+                ):
+                    return CuteDSLOpOverrides._apply_binary_op(
+                        a, b, "cute.math.div({a}, {b}, approx=True, ftz=True)"
+                    )
+                return CuteDSLOpOverrides.truediv(a, b)
 
             @staticmethod
             def floordiv(a: CuteDSLArg, b: CuteDSLArg) -> CuteDSLArg:

--- a/helion/_compiler/cute/memory_ops.py
+++ b/helion/_compiler/cute/memory_ops.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import ast
 import contextlib
+import functools
 import logging
 import operator
 from typing import TYPE_CHECKING
@@ -1947,6 +1948,50 @@ def _cute_load_feeds_sort_or_scan(load_node: object) -> bool:
     return False
 
 
+def _cute_flat_multi_cover_ok(
+    env: CompileEnvironment,
+    strategy: object,
+    tensor: torch.Tensor,
+    subscript: list[object] | tuple[object, ...],
+) -> bool:
+    """True when a flat base pointer equals the per-dim indexed pointer for
+    every element of a flattened multi-dim tile: the tensor is row-major
+    contiguous, its dims match the iteration dims in order, and the
+    strategy's div/mod decomposition follows row-major order."""
+    block_ids = list(strategy.block_ids)  # pyrefly: ignore
+    # reorder[0] (the ``offsets % n`` fastest-varying dim) must be the LAST
+    # block: the identity loop_order reverses into exactly that.
+    if list(getattr(strategy, "loop_order", [])) != list(range(len(block_ids))):
+        return False
+    sub_blocks: list[int | None] = []
+    for idx in subscript:
+        if idx is None:
+            continue
+        sub_blocks.append(
+            env.get_block_id(idx) if isinstance(idx, torch.SymInt) else None
+        )
+    if sub_blocks != block_ids:
+        return False
+    if tensor.ndim != len(block_ids):
+        return False
+    expected_stride = 1
+    for d in reversed(range(tensor.ndim)):
+        stride_d = tensor.stride(d)
+        size_d = tensor.shape[d]
+        if not isinstance(stride_d, int) or not isinstance(size_d, int):
+            return False
+        if stride_d != expected_stride:
+            return False
+        try:
+            block_numel = int(env.block_sizes[block_ids[d]].numel)
+        except (TypeError, ValueError):
+            return False
+        if size_d != block_numel:
+            return False
+        expected_stride *= size_d
+    return True
+
+
 def _cute_vector_load_ctx(
     state: CodegenState,
     tensor: torch.Tensor,
@@ -2182,14 +2227,33 @@ def _cute_vector_load_ctx(
             or inner_block_id not in vec_lane_var_by_block
         ):
             return None
-        # When the per-thread vec base could straddle the tensor edge
-        # (e.g. ``numel`` not a multiple of V), the masked-tail iter
-        # could load garbage in some lanes.  Gate the per-element mask
-        # path correctly by requiring ``numel % V == 0`` so partial-vec
-        # straddles are impossible.
-        numel = env.block_sizes[inner_block_id].numel
-        if not env.known_multiple(numel, vec_width):
-            return None
+        if getattr(strategy, "_cute_flat_multi", False):
+            # Flattened multi-dim tile: the hoist emits FLAT base pointers
+            # (``t.iterator + lane_base``), which is only sound when the
+            # tensor is contiguous and covers the whole iteration space in
+            # iteration order (then a V-chunk that straddles a row boundary
+            # is still memory-contiguous).  Broadcast operands (bias[N])
+            # fail the cover check and stay on per-element scalar loads.
+            if not _cute_flat_multi_cover_ok(env, strategy, tensor, subscript):
+                return None
+            numel = functools.reduce(  # pyrefly: ignore [incompatible-overload-residual]
+                operator.mul,
+                [
+                    env.block_sizes[bid].numel
+                    for bid in strategy.block_ids  # pyrefly: ignore
+                ],
+            )
+            if not env.known_multiple(numel, vec_width):
+                return None
+        else:
+            # When the per-thread vec base could straddle the tensor edge
+            # (e.g. ``numel`` not a multiple of V), the masked-tail iter
+            # could load garbage in some lanes.  Gate the per-element mask
+            # path correctly by requiring ``numel % V == 0`` so partial-vec
+            # straddles are impossible.
+            numel = env.block_sizes[inner_block_id].numel
+            if not env.known_multiple(numel, vec_width):
+                return None
         # Record the index_exprs position of the stride-1 lane axis so the
         # hoist substitutes the per-lane base there.  Row-major lhs loads
         # use the last position; a column-major rhs (K-major ``y``) uses

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -1124,31 +1124,6 @@ class DeviceIR:
         # non-reduction tile slots after them (keeps the rdim slot at index 0).
         if env.backend_name == "cute":
             self._register_cute_tile_vec_slots(env)
-            self._scan_cute_transcendentals(env)
-
-    def _scan_cute_transcendentals(self, env: CompileEnvironment) -> None:
-        """Set ``config_spec.cute_has_transcendentals`` when any device graph
-        contains a transcendental op — gates the ``cute_fastmath`` knob so
-        FMA-only kernels don't grow a dead search dimension."""
-        aten = torch.ops.aten
-        targets = {
-            aten.exp.default,
-            aten.exp2.default,
-            aten.log.default,
-            aten.log2.default,
-            aten.tanh.default,
-            aten.sigmoid.default,
-            aten.rsqrt.default,
-            aten.sqrt.default,
-            aten.sin.default,
-            aten.cos.default,
-            aten.erf.default,
-        }
-        for graph_info in self.graphs:
-            for node in graph_info.graph.nodes:
-                if node.op == "call_function" and node.target in targets:
-                    env.config_spec.cute_has_transcendentals = True
-                    return
 
     def _register_cute_tile_vec_slots(self, env: CompileEnvironment) -> None:
         """Eagerly register cute_vector_widths slots for non-reduction tile blocks.
@@ -3405,6 +3380,24 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
         # reduction/matmul/accumulator fact) so the pointwise seed can size a BW-saturating
         # tile instead of the starved block_size=32 default.
         device_ir.build_pointwise_facts(analysis)
+        # Cute-only: re-register flatten_loops choices dropped by the
+        # vector-model partial-access gate now that the kernel is proven
+        # PURE pointwise (see ``update_allow_flattened``).  Flat V-chunks
+        # are the only way to vectorize odd-row-length pointwise kernels.
+        # Only when NO flatten spec survived: appending next to survivors
+        # would scramble the positional ``flatten_loops`` config semantics
+        # for multi-loop kernels.  Sorted by block id == declaration order.
+        env = CompileEnvironment.current()
+        spec = env.config_spec
+        if (
+            env.backend_name == "cute"
+            and spec.pointwise_facts
+            and not len(spec.flatten_loops)
+        ):
+            for fspec in sorted(
+                spec.cute_reflatten_candidates, key=lambda f: f.block_ids[0]
+            ):
+                spec.flatten_loops.append(fspec)
 
         return device_ir
 

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -1448,12 +1448,10 @@ def generate_ast(
             extra_params=extra_params,
         )
         fast_math_cm: contextlib.AbstractContextManager[None] = contextlib.nullcontext()
-        if env.backend_name == "cute" and (
-            env.settings.fast_math or bool(config.config.get("cute_fastmath", False))
-        ):
-            # Route the ``cute_fastmath`` config knob (or the global
-            # ``fast_math`` setting) into the inductor CuteDSL op overrides:
-            # every cute.math call in this codegen gets ``fastmath=True``.
+        if env.backend_name == "cute" and env.settings.fast_math:
+            # Route the global ``fast_math`` setting into the inductor
+            # CuteDSL op overrides: every cute.math call in this codegen
+            # gets ``fastmath=True``.
             from torch._inductor.codegen.cutedsl.cutedsl_op_overrides import (
                 use_cutedsl_fast_math,
             )

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -3188,17 +3188,31 @@ class FlattenedTileStrategy(BlockSizeTileStrategy):
         flatten_loops = env.config_spec.flatten_loops
         for spec in [*flatten_loops]:
             block_ids = spec.block_ids
-            if not (
+            disable = not (
                 all(x in used_indices for x in block_ids)
                 or all(x not in used_indices for x in block_ids)
-            ):
+            )
+            if not disable:
+                for i, j in itertools.pairwise(block_ids):
+                    if i in used_indices and used_indices[i] + 1 != used_indices[j]:
+                        # The block indices must be contiguous
+                        disable = True
+                        break
+            if disable:
                 flatten_loops.disable_block_id(block_ids[0])
-                continue
-            for i, j in itertools.pairwise(block_ids):
-                if i in used_indices and used_indices[i] + 1 != used_indices[j]:
-                    # The block indices must be contiguous
-                    flatten_loops.disable_block_id(block_ids[0])
-                    break
+                if env.backend_name == "cute":
+                    # This gate exists for vector-model backends, where a
+                    # partial-block access (``bias[tile_n]``) cannot
+                    # broadcast against a flattened [BS] value vector.  The
+                    # cute per-thread SCALAR model recomputes per-dim index
+                    # vars from the flat offset per element, so a PURE
+                    # pointwise kernel can flatten safely — record the spec
+                    # and let device-IR analysis re-register it once the
+                    # PointwiseElementwiseFact (no reductions / matmuls /
+                    # accumulators) is known.
+                    cands = env.config_spec.cute_reflatten_candidates
+                    if all(c.block_ids != block_ids for c in cands):
+                        cands.append(spec)
 
     def compact_shape(self, shapes: list[CompactedShape]) -> list[CompactedShape]:
         # Keep axis structure intact for multi-phase kernels (e.g., barrier) to
@@ -4668,12 +4682,14 @@ class PerThreadFlattenedTileStrategy(FlattenedTileStrategy):
         if num_threads > 0 and isinstance(block_size, int) and num_threads < block_size:
             self._lane_var = self.new_var("lane", dce=False)
         # Vec-partition state for the memory_ops ``tile_unroll`` hoist
-        # protocol (same shape as ``PerThreadNDTileStrategy``).  Only the
-        # single-block (1D) form participates: with multiple flattened
-        # blocks the per-dim index vars are div/mod-derived per element, so
-        # a hoisted base pointer built from ``index_exprs`` would reference
-        # per-element vars that do not exist at the hoist point.
+        # protocol (same shape as ``PerThreadNDTileStrategy``).  The vec
+        # slot lives on the LAST (stride-1) block; for the multi-block
+        # (flattened N-D) form ``_cute_flat_multi`` is set and the hoist
+        # emits FLAT base pointers (``t.iterator + lane_base``) — valid
+        # only for contiguous tensors covering the whole iteration space,
+        # which ``_cute_vector_load_ctx`` gates per tensor.
         self._cute_lane_layout: str = "blocked"
+        self._cute_flat_multi: bool = len(block_ids) > 1
         self._cute_lane_vec_width_by_block: dict[int, int] = {}
         self._cute_vec_lane_var_by_block: dict[int, str] = {}
         self._cute_lane_base_index_var_by_block: dict[int, str] = {}
@@ -4681,9 +4697,9 @@ class PerThreadFlattenedTileStrategy(FlattenedTileStrategy):
         self._cute_lane_vloop_by_block: dict[int, ast.For] = {}
         self._cute_lane_vec_stores_by_block: dict[int, dict] = {}
         self._cute_lane_vec_loads_by_block: dict[int, dict] = {}
-        if self._lane_var is not None and len(block_ids) == 1:
+        if self._lane_var is not None:
             env = CompileEnvironment.current()
-            block_id = block_ids[0]
+            block_id = block_ids[-1]
             cfg = fn.config.config
             if block_id in env.config_spec.cute_lane_layouts.valid_block_ids():
                 layout = env.config_spec.cute_lane_layouts.config_get(
@@ -4784,7 +4800,7 @@ class PerThreadFlattenedTileStrategy(FlattenedTileStrategy):
         vec_wrappers: dict[str, VecLaneWrapper] = {}
         axis = self._flat_thread_axis()
         thread_extent = self._thread_extent()
-        vec_width = self._cute_lane_vec_width_by_block.get(block_ids[0], 1)
+        vec_width = self._cute_lane_vec_width_by_block.get(block_ids[-1], 1)
         lane_strided = self._cute_lane_layout == "strided" and isinstance(
             thread_extent, int
         )
@@ -4796,9 +4812,9 @@ class PerThreadFlattenedTileStrategy(FlattenedTileStrategy):
         if vec_width > 1:
             # Same outer x constexpr-V lane partition as
             # ``PerThreadNDTileStrategy.codegen_grid`` so the memory_ops
-            # tile_unroll vec-hoist protocol applies to flattened (1D)
-            # grid tiles too.
-            block_id = block_ids[0]
+            # tile_unroll vec-hoist protocol applies to flattened grid
+            # tiles too (the multi-block form via flat base pointers).
+            block_id = block_ids[-1]
             vec_lane_var = self.new_var("vec_lane", dce=False)
             self._cute_vec_lane_var_by_block[block_id] = vec_lane_var
             inner_for = cast(

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -819,7 +819,6 @@ BACKEND_SPECIFIC_KEYS: frozenset[str] = (
         "cute_reduction_reloads",
         "cute_cluster_n",
         "cute_min_blocks_per_mp",
-        "cute_fastmath",
         "load_cache_modifiers",
         "store_cache_modifiers",
         "pallas_loop_type",
@@ -863,7 +862,6 @@ VALID_KEYS: frozenset[str] = frozenset(
         "cute_reduction_reloads",
         "cute_cluster_n",
         "cute_min_blocks_per_mp",
-        "cute_fastmath",
         *BACKEND_TUNABLE_KEYS,
         "advanced_controls_file",
         "epilogue_subtile",
@@ -1147,10 +1145,10 @@ class ConfigSpec:
         self.pointwise_facts: list[PointwiseElementwiseFact] = []
         self.store_indices: list[int] = []
         self.memory_op_facts: list[MemoryOpFact] = []
-        # True when the device IR contains transcendental ops (exp/tanh/...);
-        # gates the ``cute_fastmath`` search dimension (device_ir sets it
-        # during cute registration).
-        self.cute_has_transcendentals: bool = False
+        # FlattenLoopSpecs dropped by the vector-model partial-access gate
+        # (``update_allow_flattened``); re-registered for PURE pointwise
+        # kernels on cute once device-IR analysis proves the fact.
+        self.cute_reflatten_candidates: list[FlattenLoopSpec] = []
         self.backend_tunable_fragments = self.backend.tunable_fragments()
         unknown_tunables = set(self.backend_tunable_fragments) - BACKEND_TUNABLE_KEYS
         if unknown_tunables:
@@ -3393,17 +3391,6 @@ class ConfigSpec:
                     fields["cute_min_blocks_per_mp"] = EnumFragment(
                         choices=(0, 1, 2, 3, 4, 6)
                     )
-                # Fast-math transcendentals (MUFU tanh / ex2 / rcp / rsqrt
-                # instead of the accurate SASS expansions).  Only searched
-                # when the kernel actually contains transcendental ops; the
-                # autotuner's baseline accuracy check rejects it wherever
-                # the numerics drift past tolerance, so it is self-gating.
-                if (
-                    self.supports_config_key("cute_fastmath")
-                    and self.cute_has_transcendentals
-                    and not self.matmul_facts
-                ):
-                    fields["cute_fastmath"] = EnumFragment(choices=(False, True))
             if (
                 not self.cute_flash_search_enabled
                 and self.epilogue_subtile_autotune_choices is not None

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import ast
 import dataclasses
+import functools
 import logging
+import operator
 import textwrap
 from typing import TYPE_CHECKING
 
@@ -975,10 +977,15 @@ def _cute_register_tile_unroll_vec_store(
     vloop_by_block = getattr(strategy, "_cute_lane_vloop_by_block", None)
     if not isinstance(vloop_by_block, dict) or vloop_by_block.get(block_id) is None:
         return None
-    lane_pos = _cute_lane_axis_pos(strategy, block_id, index_exprs)
-    base_exprs = list(index_exprs)
-    base_exprs[lane_pos] = base_index_var
-    base_ptr_expr = _cute_scalar_pointer_expr(tensor_name, base_exprs)
+    if getattr(strategy, "_cute_flat_multi", False):
+        # See the flat-multi note in ``_cute_register_tile_unroll_vec_hoist``.
+        index_dtype = CompileEnvironment.current().index_type()
+        base_ptr_expr = f"({tensor_name}.iterator + {index_dtype}({base_index_var}))"
+    else:
+        lane_pos = _cute_lane_axis_pos(strategy, block_id, index_exprs)
+        base_exprs = list(index_exprs)
+        base_exprs[lane_pos] = base_index_var
+        base_ptr_expr = _cute_scalar_pointer_expr(tensor_name, base_exprs)
     sites_by_block = getattr(strategy, "_cute_lane_vec_stores_by_block", None)
     if sites_by_block is None:
         sites_by_block = {}
@@ -1110,14 +1117,25 @@ def _cute_register_tile_unroll_vec_hoist(
     assert isinstance(base_index_var, str)
     assert isinstance(lane_body, list)
     assert isinstance(vec_lane_var, str)
-    # The lane-axis index_expr (stride-1 dim) is swapped with the per-lane
-    # base so the vec load points at the start of the V-wide chunk this
-    # thread owns.  The position is the last entry for a row-major lhs, or
-    # the recorded position for a K-major rhs.
-    lane_pos = _cute_lane_axis_pos(strategy, block_id, index_exprs)
-    base_exprs = list(index_exprs)
-    base_exprs[lane_pos] = base_index_var
-    base_ptr_expr = _cute_scalar_pointer_expr(tensor_name, base_exprs)
+    flat_multi = bool(getattr(strategy, "_cute_flat_multi", False))
+    if flat_multi:
+        # Flattened multi-dim tile: the ctx gate guarantees the tensor is
+        # contiguous and covers the whole iteration space, so the V-wide
+        # chunk starting at flat ``lane_base`` is memory-contiguous even
+        # when it straddles a row boundary.
+        env_flat = CompileEnvironment.current()
+        index_dtype = env_flat.index_type()
+        lane_pos = -1
+        base_ptr_expr = f"({tensor_name}.iterator + {index_dtype}({base_index_var}))"
+    else:
+        # The lane-axis index_expr (stride-1 dim) is swapped with the
+        # per-lane base so the vec load points at the start of the V-wide
+        # chunk this thread owns.  The position is the last entry for a
+        # row-major lhs, or the recorded position for a K-major rhs.
+        lane_pos = _cute_lane_axis_pos(strategy, block_id, index_exprs)
+        base_exprs = list(index_exprs)
+        base_exprs[lane_pos] = base_index_var
+        base_ptr_expr = _cute_scalar_pointer_expr(tensor_name, base_exprs)
     cache_key = (tensor_name, base_ptr_expr)
     cache_by_block = getattr(strategy, "_cute_lane_vec_loads_by_block", None)
     if cache_by_block is None:
@@ -1141,7 +1159,14 @@ def _cute_register_tile_unroll_vec_hoist(
         # fetched bytes are then ignored downstream by the per-lane
         # mask gate that wraps the bitcast result.
         env_local = CompileEnvironment.current()
-        numel = env_local.block_sizes[block_id].numel
+        if flat_multi:
+            # Bounds are in FLAT elements over the whole iteration space.
+            numel = functools.reduce(
+                operator.mul,
+                [env_local.block_sizes[bid].numel for bid in strategy.block_ids],  # pyrefly: ignore
+            )
+        else:
+            numel = env_local.block_sizes[block_id].numel
         numel_expr = state.sympy_expr(numel)
         block_pos = strategy.block_ids.index(block_id)  # pyrefly: ignore
         bs_obj = strategy.block_size  # pyrefly: ignore
@@ -1159,11 +1184,25 @@ def _cute_register_tile_unroll_vec_hoist(
             numel_int = int(numel)
         except (TypeError, ValueError):
             numel_int = None
+        # GRID tiles have no software-pipelined prefetch past the end, so a
+        # mask-free extent that divides evenly into blocks means every
+        # per-thread vec base is provably in-bounds.  (The pipelining pass'
+        # pipeline_inner_loads only matches an outer ``range`` loop wrapping
+        # an inner lane For, which a grid lane loop can never be — if that
+        # ever changes, this elision must learn about it.)
+        from .._compiler.tile_strategy import DeviceGridState
+
+        loops_for_block = state.codegen.active_device_loops.get(block_id)
+        is_grid_state = bool(loops_for_block) and isinstance(
+            loops_for_block[-1], DeviceGridState
+        )
         if (
             mask_elided
             and isinstance(static_bs, int)
             and numel_int is not None
-            and static_bs >= numel_int
+            and (
+                static_bs >= numel_int or (is_grid_state and numel_int % static_bs == 0)
+            )
         ):
             # Single-trip tile loop whose block provably covers the extent
             # (the strategy elided the bounds mask): every per-thread vec
@@ -1171,7 +1210,8 @@ def _cute_register_tile_unroll_vec_hoist(
             # clamp (the software-pipelining pass, which prefetches one
             # tile PAST the loop end, needs the guard on multi-trip
             # loops).  Dropping the pointer select saves ~14 registers per
-            # thread on the resident-row softmax family.
+            # thread on the resident-row softmax family.  Same for exact
+            # grid tilings (numel % block == 0).
             guarded_ptr = base_ptr_expr
         else:
             # Build the "anchor" pointer: same index_exprs but with the
@@ -1179,9 +1219,13 @@ def _cute_register_tile_unroll_vec_hoist(
             # ``tile_offset == 0, lane_var == 0, vec_lane_var == 0`` base
             # for the very first outer-tile iter, which is always
             # in-bounds for any grid block.
-            anchor_exprs = list(index_exprs)
-            anchor_exprs[lane_pos] = "0"
-            anchor_ptr_expr = _cute_scalar_pointer_expr(tensor_name, anchor_exprs)
+            if flat_multi:
+                index_dtype_local = CompileEnvironment.current().index_type()
+                anchor_ptr_expr = f"({tensor_name}.iterator + {index_dtype_local}(0))"
+            else:
+                anchor_exprs = list(index_exprs)
+                anchor_exprs[lane_pos] = "0"
+                anchor_ptr_expr = _cute_scalar_pointer_expr(tensor_name, anchor_exprs)
             guarded_ptr = (
                 f"({base_ptr_expr} if {base_index_var} < {numel_expr} "
                 f"else {anchor_ptr_expr})"

--- a/helion/language/tile_ops.py
+++ b/helion/language/tile_ops.py
@@ -58,6 +58,10 @@ def tile_index(tile: TileInterface) -> torch.Tensor:
 @_decorators.register_fake(tile_index)
 def _(tile: torch.SymInt) -> torch.Tensor:
     assert isinstance(tile, torch.SymInt)
+    # Disable at TRACE time like the other tile ops: the codegen-time
+    # disable alone runs after device-IR analysis, which is too late for
+    # the cute pointwise flatten re-registration to see it.
+    _disable_flatten_get_tile(tile)
     env = CompileEnvironment.current()
     base = torch.empty([tile], dtype=env.index_dtype, device=env.device)
     return env.new_index_result(base, [tile])
@@ -127,6 +131,13 @@ def _disable_flatten_get_tile(tile: object, state: CodegenState | None = None) -
     assert index is not None
     # The functions in this file can't be used in flattened loops.
     env.config_spec.flatten_loops.disable_block_id(index)
+    # Also drop any cute pointwise re-registration candidate for this loop:
+    # a spec disabled HERE must never be resurrected (unlike the
+    # vector-model partial-access gate, this restriction applies to the
+    # cute scalar model too).
+    env.config_spec.cute_reflatten_candidates = [
+        c for c in env.config_spec.cute_reflatten_candidates if index not in c.block_ids
+    ]
     return index
 
 

--- a/test/test_broadcasting.py
+++ b/test/test_broadcasting.py
@@ -11,6 +11,7 @@ from helion._testing import DEVICE
 from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
+from helion._testing import matchesBackends
 from helion._testing import onlyBackends
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
@@ -50,7 +51,19 @@ class TestBroadcasting(RefEagerTestBase, TestCase):
     @skipIfRefEager("Config tests not applicable in ref eager mode")
     def test_broadcast_no_flatten(self):
         args = [torch.randn(512, 512, device=DEVICE), torch.randn(512, device=DEVICE)]
-        assert not broadcast_fn.bind(args).config_spec.flatten_loops
+        flatten_loops = broadcast_fn.bind(args).config_spec.flatten_loops
+        if matchesBackends(["cute"]):
+            # The cute per-thread scalar model recomputes per-dim index vars
+            # from the flat offset, so PURE pointwise kernels keep the
+            # flatten choice even with partial-block (broadcast) accesses
+            # (re-registered after device-IR analysis proves the pointwise
+            # fact) — and flattened codegen must stay correct.
+            assert flatten_loops
+            _check_broadcast_fn(block_sizes=[16, 8], flatten_loops=[True])
+        else:
+            # Vector-model backends cannot mix a flat [BS] value vector with
+            # a partial-block access, so the choice is disabled.
+            assert not flatten_loops
 
     def test_broadcast1(self):
         _check_broadcast_fn(

--- a/test/test_cute_pointwise_vec.py
+++ b/test/test_cute_pointwise_vec.py
@@ -7,7 +7,7 @@ outer x constexpr-V lane partition + hoisted ``cute.arch.load(..., V)`` /
 
 Covers both strategies (``PerThreadNDTileStrategy`` for N-D tiles,
 ``PerThreadFlattenedTileStrategy`` for 1D), fp32 Uint32-carrier stores, the
-``cute_fastmath`` knob, and two regressions found in review:
+``fast_math`` setting on cute, and two regressions found in review:
 
 - an index-independent store value must not drop the vec wrapper (the store
   flush lives inside it),
@@ -69,6 +69,42 @@ def _tanh1d(x: torch.Tensor) -> torch.Tensor:
     out = torch.empty_like(x)
     for tile in hl.tile(out.size()):
         out[tile] = torch.tanh(x[tile])
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=True)
+def _bias_add2d(x: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile_m, tile_n in hl.tile(out.size()):
+        out[tile_m, tile_n] = x[tile_m, tile_n] + b[tile_n]
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=True)
+def _tile_index_bias(x: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile_m, tile_n in hl.tile(x.size()):
+        out[tile_m, tile_n] = (
+            x[tile_m, tile_n]
+            + b[tile_n]
+            + hl.tile_index(tile_m).to(torch.float32)[:, None]
+        )
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=True, fast_math=True)
+def _tanh1d_fastmath(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(out.size()):
+        out[tile] = torch.tanh(x[tile])
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=True, fast_math=True)
+def _div1d_fastmath(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(out.size()):
+        out[tile] = x[tile] / y[tile]
     return out
 
 
@@ -166,20 +202,113 @@ class TestCutePointwiseVec(TestCase):
         self.assertNotIn("ir.VectorType.get([8]", code)
         torch.testing.assert_close(out, x[:, 0] * 2.0)
 
-    def test_cute_fastmath_knob(self) -> None:
-        """``cute_fastmath=True`` routes fastmath=True into cute.math calls;
-        results stay within loose tolerance of the accurate form."""
+    def test_flat_multi_vec_full_cover(self) -> None:
+        """flatten_loops + vec on a 2D kernel: full-cover contiguous tensors
+        get FLAT base-pointer hoists; results match eager."""
+        x = torch.randn(64, 4096, device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn(64, 4096, device=DEVICE, dtype=torch.bfloat16)
+        code, out = code_and_output(
+            _add2d,
+            (x, y),
+            block_sizes=[1, 2048],
+            num_threads=[1, 256],
+            cute_vector_widths=[1, 8],
+            flatten_loops=[True],
+        )
+        self.assertIn("ir.VectorType.get([8], cutlass.Uint16.mlir_type)", code)
+        torch.testing.assert_close(out, x + y)
+
+    def test_flat_multi_vec_odd_row_broadcast(self) -> None:
+        """ODD row length (V does not divide N, but divides the total):
+        x/out vectorize via flat chunks that straddle rows; the broadcast
+        bias fails the full-cover gate and stays scalar per element."""
+        m, n = 64, 4093
+        x = torch.randn(m, n, device=DEVICE, dtype=torch.float16)
+        b = torch.randn(n, device=DEVICE, dtype=torch.float16)
+        code, out = code_and_output(
+            _bias_add2d,
+            (x, b),
+            block_sizes=[1, 4096],
+            num_threads=[1, 512],
+            cute_vector_widths=[1, 8],
+            flatten_loops=[True],
+        )
+        self.assertIn("ir.VectorType.get([8], cutlass.Uint16.mlir_type)", code)
+        torch.testing.assert_close(out, x + b)
+
+    def test_flat_multi_vec_reordered_loops_stays_scalar(self) -> None:
+        """A non-identity loop_order breaks the row-major flat equivalence;
+        the ctx gate must fall back to scalar and stay correct."""
+        x = torch.randn(64, 4096, device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn(64, 4096, device=DEVICE, dtype=torch.bfloat16)
+        code, out = code_and_output(
+            _add2d,
+            (x, y),
+            block_sizes=[1, 2048],
+            num_threads=[1, 256],
+            cute_vector_widths=[1, 8],
+            flatten_loops=[True],
+            loop_orders=[[1, 0]],
+        )
+        self.assertNotIn("ir.VectorType.get([8]", code)
+        torch.testing.assert_close(out, x + y)
+
+    def test_tile_index_disables_flatten_reregistration(self) -> None:
+        """Regression: hl.tile_index only disabled flatten at CODEGEN time,
+        so the pointwise flatten re-registration resurrected it -> wrong
+        results under flatten_loops=[True]."""
+        x = torch.randn(64, 512, device=DEVICE, dtype=torch.float32)
+        b = torch.randn(512, device=DEVICE, dtype=torch.float32)
+        spec = _tile_index_bias.bind((x, b)).config_spec
+        self.assertEqual(len(spec.flatten_loops), 0)
+        _, out = code_and_output(
+            _tile_index_bias, (x, b), block_sizes=[16, 128], num_threads=[1, 64]
+        )
+        ref = (
+            x + b + torch.arange(x.size(0), device=DEVICE, dtype=torch.float32)[:, None]
+        )
+        torch.testing.assert_close(out, ref)
+
+    def test_fast_math_setting_routes_cute_fastmath(self) -> None:
+        """The ``fast_math`` SETTING (user opt-in) routes fastmath=True into
+        cute.math calls; without it the accurate form is emitted.  Numerics
+        changes are never a tunable config knob — only this setting."""
         x = torch.randn(2**14, device=DEVICE, dtype=torch.float32)
+        code, out = code_and_output(
+            _tanh1d_fastmath,
+            (x,),
+            block_sizes=[1024],
+            num_threads=[256],
+            cute_vector_widths=[4],
+        )
+        self.assertIn("fastmath=True", code)
+        torch.testing.assert_close(out, torch.tanh(x), rtol=1e-4, atol=1e-4)
         code, out = code_and_output(
             _tanh1d,
             (x,),
             block_sizes=[1024],
             num_threads=[256],
             cute_vector_widths=[4],
-            cute_fastmath=True,
         )
-        self.assertIn("fastmath=True", code)
-        torch.testing.assert_close(out, torch.tanh(x), rtol=1e-4, atol=1e-4)
+        self.assertNotIn("fastmath=True", code)
+        torch.testing.assert_close(out, torch.tanh(x))
+
+    def test_fastmath_div_non_fp32_keeps_accurate_path(self) -> None:
+        """Regression: ``cute.math.div`` lowers to fp32-only NVVM intrinsics,
+        so under ``fast_math`` a 16-bit division must keep the accurate IEEE
+        path instead of raising at DSL trace time; fp32 still gets the
+        approx+ftz form."""
+        for dtype in (torch.float16, torch.bfloat16):
+            x = torch.randn(2**14, device=DEVICE, dtype=dtype)
+            y = torch.rand(2**14, device=DEVICE, dtype=dtype) + 0.5
+            code, out = code_and_output(_div1d_fastmath, (x, y), block_sizes=[1024])
+            self.assertNotIn("cute.math.div", code)
+            torch.testing.assert_close(out, x / y)
+        x = torch.randn(2**14, device=DEVICE, dtype=torch.float32)
+        y = torch.rand(2**14, device=DEVICE, dtype=torch.float32) + 0.5
+        code, out = code_and_output(_div1d_fastmath, (x, y), block_sizes=[1024])
+        self.assertIn("cute.math.div", code)
+        torch.testing.assert_close(out, x / y, rtol=1e-4, atol=1e-4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3560
 * #3559
 * #3558
 * #3557
 * __->__#3556
 * #3555
 * #3554


--- --- ---

[cutedsl] Flattened multi-dim vec, fastmath-setting rcp, flatten re-registration

Extends the grid lane-loop vectorization to FLATTENED multi-dim tiles
and hardens the fast_math path:

- Flat V-chunks starting at lane_base are memory-contiguous even across
  a row boundary, so the hoist/flush emit FLAT base pointers
  (t.iterator + lane_base), gated per tensor on row-major full-cover
  contiguity + identity loop_order + total%V==0
  (_cute_flat_multi_cover_ok).  Broadcast operands (bias[N]) fail the
  cover gate and stay scalar per element.  This is the only way to
  vectorize odd-row-length pointwise kernels (bias_add 4096x50257 fp16:
  1.4 -> 4.9 TB/s pinned on B200).
- update_allow_flattened's partial-access gate exists for vector-model
  backends; on cute it records the dropped FlattenLoopSpecs and
  device-IR analysis re-registers them once the kernel is proven PURE
  pointwise — only when no spec survived (positional config semantics)
  and in declaration order.  hl.tile_index now disables flattening at
  TRACE time (its codegen-time disable ran too late and the
  re-registration could resurrect a flatten choice it cannot support);
  _disable_flatten_get_tile also prunes the re-registration candidates.
- The fast_math SETTING now routes into the inductor CuteDSL op
  overrides (_CUTEDSL_FAST_MATH) during cute codegen, and sigmoid /
  fp32 truediv under it lower through RCP.APPROX (cute.math.rcp/div
  approx+ftz, quack's formulation) instead of the accurate
  ~20-instruction IEEE fp32 division: fp16 sigmoid 4.7 -> 5.4 TB/s,
  silu 5.1 -> 6.0 TB/s (parity with the handwritten baseline).
  Deliberately gated ONLY on the user-facing setting, never a tunable
  config knob: tuned configs must not change numerics.
- The vec-load OOB guard select is elided for exact grid tilings
  (numel % block == 0, mask elided): grid tiles have no software
  pipelining, so every per-thread base is provably in-bounds.