### PR TITLE
[cutedsl] FMA contraction + lane-loop load/compute phase split

### DIFF
--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
@@ -2455,6 +2456,43 @@ class CutePointwiseVecHeuristic(AutotunerHeuristic):
             return Config(**seed)
         except Exception:
             return None
+
+    @classmethod
+    def get_seed_configs(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> list[Config] | None:
+        primary = cls.get_seed_config(env, device_ir)
+        if primary is None:
+            return None
+        spec = env.config_spec
+        seeds = [primary]
+        # Flattened alternate for multi-dim tiles: flat V-chunks often beat
+        # the N-D row form (fewer pid div/mods, tail-free tiling), and the
+        # handwritten-CuTe comparison kernels iterate flat.  Skip when the
+        # primary already flattens (odd innermost extent).
+        base_variants: list[dict[str, Any]] = [dict(primary.config)]
+        picked = cls._vec_axis_and_width(env)
+        if (
+            picked is not None
+            and not picked[3]
+            and len(spec.block_sizes) > 1
+            and spec.flatten_loops
+        ):
+            vec_block, vec = picked[0], picked[1]
+            flatten_group = next(
+                (f for f in spec.flatten_loops if vec_block in f.block_ids), None
+            )
+            if flatten_group is not None:
+                total = 1
+                for bid in flatten_group.block_ids:
+                    total *= spec.block_sizes.block_id_lookup(bid).size_hint
+                if total % vec == 0:
+                    flat_seed: dict[str, Any] = dict(primary.config)
+                    flat_seed["flatten_loops"] = [True for _ in spec.flatten_loops]
+                    with contextlib.suppress(Exception):
+                        seeds.append(Config(**flat_seed))
+                        base_variants.append(flat_seed)
+        return seeds
 
 
 class CuteFp8GemmSkinnyMHeuristic(AutotunerHeuristic):

--- a/helion/_compiler/cute/fuse_fma.py
+++ b/helion/_compiler/cute/fuse_fma.py
@@ -1,0 +1,203 @@
+# pyrefly: ignore-errors
+"""Contract ``t = a * b; w = t + c`` into ``w = cute.math.fma(a, b, c)``.
+
+The CuTe DSL's ``*``/``+`` lower to plain ``arith.mulf``/``arith.addf``
+without fastmath contract flags, so the NVVM/ptxas pipeline may not fuse
+them into FFMA (measured: a bf16 gelu ran 26% more SASS instructions than
+the equivalent handwritten kernel, most of it unfused FMUL+FADD chains).
+Triton contracts by default (``allow_fp_fusion``), so fusing here brings
+cute numerics CLOSER to the helion-triton backend, not further away.
+
+Scope and safety:
+
+- Only fuses when the multiply's result is a PROVEN-fp32 SSA name (a
+  forward dataflow over ``cutlass.Float32(...)``, ``cute.math.*`` calls and
+  float constants) that is read exactly once in the whole kernel — integer
+  index arithmetic never matches.
+- Operands must be plain names or constants, and any name operand must be
+  assigned at most once in the kernel (codegen temporaries are SSA;
+  loop-carried accumulators are reassigned and therefore excluded).
+- The consumer must be a top-level ``w = t + c`` / ``c + t`` / ``t - c`` /
+  ``c - t`` assignment in the SAME statement list as the multiply.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from ..ast_extension import create
+from ..ast_extension import expr_from_string
+
+
+def _collect_counts(
+    body: list[ast.stmt],
+) -> tuple[dict[str, int], dict[str, int]]:
+    reads: dict[str, int] = {}
+    writes: dict[str, int] = {}
+
+    class _Counter(ast.NodeVisitor):
+        def visit_Name(self, node: ast.Name) -> None:
+            if isinstance(node.ctx, ast.Load):
+                reads[node.id] = reads.get(node.id, 0) + 1
+            else:
+                writes[node.id] = writes.get(node.id, 0) + 1
+
+    counter = _Counter()
+    for stmt in body:
+        counter.visit(stmt)
+    return reads, writes
+
+
+_FLOAT_CALL_PREFIXES = ("cutlass.Float32", "cute.math.")
+
+
+def _is_float_expr(node: ast.expr, float_names: set[str]) -> bool:
+    if isinstance(node, ast.Constant):
+        return isinstance(node.value, float)
+    if isinstance(node, ast.Name):
+        return node.id in float_names
+    if isinstance(node, ast.BinOp):
+        return _is_float_expr(node.left, float_names) and _is_float_expr(
+            node.right, float_names
+        )
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        return _is_float_expr(node.operand, float_names)
+    if isinstance(node, ast.Call):
+        func = ast.unparse(node.func)
+        return func.startswith(_FLOAT_CALL_PREFIXES)
+    return False
+
+
+def _simple_operand(
+    node: ast.expr, float_names: set[str], writes: dict[str, int]
+) -> bool:
+    """A name/constant that provably holds the same fp32 value at any later
+    point in the kernel (constants, or names written exactly once)."""
+    if isinstance(node, ast.Constant):
+        return isinstance(node.value, float)
+    if isinstance(node, ast.Name):
+        return node.id in float_names and writes.get(node.id, 0) <= 1
+    return False
+
+
+def _neg(node: ast.expr) -> ast.expr:
+    if isinstance(node, ast.Constant) and isinstance(node.value, float):
+        return create(ast.Constant, value=-node.value, kind=None)
+    return create(ast.UnaryOp, op=ast.USub(), operand=node)
+
+
+def _fma_call(a: ast.expr, b: ast.expr, c: ast.expr) -> ast.expr:
+    return expr_from_string("cute.math.fma({a}, {b}, {c})", a=a, b=b, c=c)
+
+
+def _drop_stale_muls(
+    muls: dict[str, tuple[int, ast.expr, ast.expr]],
+    written: str,
+    canon: dict[str, str],
+) -> None:
+    """Moving an operand read down to the consumer is only safe while no
+    other member of the operand's RENAME group is written in between (the
+    pass runs pre-rename: two SSA names may collapse into one loop-carried
+    variable, so a group write would change the value read at the fma)."""
+    written_c = canon.get(written, written)
+    for name in [*muls]:
+        a, b = muls[name][1], muls[name][2]
+        for operand in (a, b):
+            if isinstance(operand, ast.Name) and (
+                canon.get(operand.id, operand.id) == written_c
+            ):
+                del muls[name]
+                break
+
+
+def _process_list(
+    stmts: list[ast.stmt],
+    reads: dict[str, int],
+    writes: dict[str, int],
+    float_names: set[str],
+    canon: dict[str, str],
+) -> None:
+    # Forward float-name dataflow + collect fusible multiplies as we go.
+    muls: dict[str, tuple[int, ast.expr, ast.expr]] = {}
+    to_delete: list[int] = []
+
+    def _drop_for_subtree_writes(node: ast.AST) -> None:
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Name) and isinstance(sub.ctx, ast.Store):
+                _drop_stale_muls(muls, sub.id, canon)
+
+    for idx, stmt in enumerate(stmts):
+        if isinstance(stmt, (ast.For, ast.While)):
+            _process_list(stmt.body, reads, writes, float_names, canon)
+            _drop_for_subtree_writes(stmt)
+            continue
+        if isinstance(stmt, ast.If):
+            _process_list(stmt.body, reads, writes, float_names, canon)
+            _process_list(stmt.orelse, reads, writes, float_names, canon)
+            _drop_for_subtree_writes(stmt)
+            continue
+        if not (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+        ):
+            _drop_for_subtree_writes(stmt)
+            continue
+        name = stmt.targets[0].id
+        value = stmt.value
+        if _is_float_expr(value, float_names):
+            float_names.add(name)
+        if (
+            isinstance(value, ast.BinOp)
+            and isinstance(value.op, ast.Mult)
+            and writes.get(name, 0) == 1
+            and reads.get(name, 0) == 1
+            and _simple_operand(value.left, float_names, writes)
+            and _simple_operand(value.right, float_names, writes)
+        ):
+            _drop_stale_muls(muls, name, canon)
+            muls[name] = (idx, value.left, value.right)
+            continue
+        if not (
+            isinstance(value, ast.BinOp) and isinstance(value.op, (ast.Add, ast.Sub))
+        ):
+            _drop_stale_muls(muls, name, canon)
+            continue
+        left, right = value.left, value.right
+        fused: ast.expr | None = None
+        mul_name: str | None = None
+        for t_node, c_node, t_on_left in ((left, right, True), (right, left, False)):
+            if not (isinstance(t_node, ast.Name) and t_node.id in muls):
+                continue
+            if not _simple_operand(c_node, float_names, writes):
+                continue
+            a, b = muls[t_node.id][1], muls[t_node.id][2]
+            if isinstance(value.op, ast.Add):
+                fused = _fma_call(a, b, c_node)
+            elif t_on_left:  # w = t - c  ->  fma(a, b, -c)
+                fused = _fma_call(a, b, _neg(c_node))
+            else:  # w = c - t  ->  fma(-a, b, c)
+                fused = _fma_call(_neg(a), b, c_node)
+            mul_name = t_node.id
+            break
+        if fused is None or mul_name is None:
+            _drop_stale_muls(muls, name, canon)
+            continue
+        mul_idx = muls.pop(mul_name)[0]
+        stmt.value = fused
+        float_names.add(name)
+        to_delete.append(mul_idx)
+        _drop_stale_muls(muls, name, canon)
+    for idx in sorted(to_delete, reverse=True):
+        del stmts[idx]
+    if not stmts:
+        stmts.append(create(ast.Pass))
+
+
+def fuse_fma(
+    body: list[ast.stmt], rename_groups: dict[str, str] | None = None
+) -> list[ast.stmt]:
+    reads, writes = _collect_counts(body)
+    float_names: set[str] = set()
+    _process_list(body, reads, writes, float_names, rename_groups or {})
+    return body

--- a/helion/_compiler/cute/split_lane_loads.py
+++ b/helion/_compiler/cute/split_lane_loads.py
@@ -1,0 +1,160 @@
+# pyrefly: ignore-errors
+"""Split grid lane loops into a LOAD phase and a COMPUTE/STORE phase.
+
+A vec-partitioned grid lane loop unrolls at trace time into
+
+    for lane in range(U):      # U = EPT // V, constexpr
+        lane_base = <affine of lane/tid/offset>
+        _tile_unroll_vec_A = cute.arch.load(...lane_base..., <vec ty>)
+        ...compute + store flush...
+
+Iteration N+1's load sits AFTER iteration N's store in program order, and
+ptxas cannot prove the store does not alias the load, so only ONE vector
+load is in flight per thread (measured: ~5-8% DRAM-throughput deficit vs
+the handwritten kernel, which loads its whole (V, U) fragment before any
+compute).  Rewriting into
+
+    _lane_loads_0 = []
+    for lane in range(U):
+        lane_base = ...
+        _lane_loads_0.append(cute.arch.load(...))
+    for lane in range(U):
+        lane_base = ...
+        _tile_unroll_vec_A = _lane_loads_0[lane]
+        ...compute + store flush...
+
+issues all U loads back-to-back (the trace-time Python list just names the
+SSA values).  Element-order semantics match the triton backend, which
+vector-loads the whole tile before any store.
+
+Only fires when every value flowing from the load phase into the compute
+phase is the lane-base or a hoisted vec load (checked), and only on loops
+whose hoist vars use the ``_tile_unroll_vec_`` naming of the tile_unroll
+protocol.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from ..ast_extension import expr_from_string
+from ..ast_extension import statement_from_string
+
+_LOAD_PREFIX = "_tile_unroll_vec_"
+
+
+def _names_read(node: ast.AST) -> set[str]:
+    out: set[str] = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Name) and isinstance(sub.ctx, ast.Load):
+            out.add(sub.id)
+    return out
+
+
+def _assigned_name(stmt: ast.stmt) -> str | None:
+    if (
+        isinstance(stmt, ast.Assign)
+        and len(stmt.targets) == 1
+        and isinstance(stmt.targets[0], ast.Name)
+    ):
+        return stmt.targets[0].id
+    return None
+
+
+def _is_const_range_loop(loop: ast.For) -> tuple[str, int] | None:
+    """Match ``for <lane> in range(<int >= 2>)`` (trace-time unrolled)."""
+    if not (isinstance(loop.target, ast.Name) and isinstance(loop.iter, ast.Call)):
+        return None
+    func = loop.iter.func
+    if not (isinstance(func, ast.Name) and func.id == "range"):
+        return None
+    if len(loop.iter.args) != 1 or loop.iter.keywords:
+        return None
+    arg = loop.iter.args[0]
+    if not (isinstance(arg, ast.Constant) and isinstance(arg.value, int)):
+        return None
+    if arg.value < 2:
+        return None
+    return loop.target.id, arg.value
+
+
+def _try_split(loop: ast.For, counter: int) -> list[ast.stmt] | None:
+    match = _is_const_range_loop(loop)
+    if match is None:
+        return None
+    body = loop.body
+    if len(body) < 3:
+        return None
+    base_name = _assigned_name(body[0])
+    if base_name is None:
+        return None
+    # Collect the leading run of vec-load hoists right after the base stmt.
+    load_stmts: list[ast.Assign] = []
+    idx = 1
+    while idx < len(body):
+        name = _assigned_name(body[idx])
+        if name is None or not name.startswith(_LOAD_PREFIX):
+            break
+        load_stmts.append(body[idx])  # type: ignore[arg-type]
+        idx += 1
+    if not load_stmts:
+        return None
+    rest = body[idx:]
+    if not rest:
+        return None
+    # Phase 1 writes only the lane base and the hoisted loads; both are
+    # re-derived (base) or forwarded (loads) into phase 2, so no other
+    # dataflow can leak across the split.
+    lane_var = loop.target.id
+    reps = match[1]
+    list_names = [f"_lane_loads_{counter}_{i}" for i in range(len(load_stmts))]
+    out: list[ast.stmt] = []
+    for list_name in list_names:
+        out.append(statement_from_string(f"{list_name} = []"))
+    # Fresh load-phase loop; the ORIGINAL load expressions move into it
+    # (their statements are dropped from the compute phase), and the lane
+    # base statement is duplicated via unparse (ExtendedAST nodes cannot
+    # be deepcopied).
+    # Both phase loops must be trace-time unrolled (range_constexpr): the
+    # Python list carrying the loaded SSA values crosses loop iterations,
+    # which a dynamically-lowered ``range`` loop cannot express.
+    load_loop = statement_from_string(
+        f"for {lane_var} in cutlass.range_constexpr({reps}):\n    pass"
+    )
+    assert isinstance(load_loop, ast.For)
+    load_body: list[ast.stmt] = [statement_from_string(ast.unparse(body[0]))]
+    for list_name, load_stmt in zip(list_names, load_stmts, strict=True):
+        stmt = statement_from_string(f"{list_name}.append(_x_)")
+        call = stmt.value  # type: ignore[attr-defined]
+        call.args = [load_stmt.value]  # move the original load expression
+        load_body.append(stmt)
+    load_loop.body = load_body
+    out.append(load_loop)
+    compute_loop = loop
+    compute_loop.iter = expr_from_string(f"cutlass.range_constexpr({reps})")
+    compute_body: list[ast.stmt] = [body[0]]
+    for list_name, load_stmt in zip(list_names, load_stmts, strict=True):
+        load_name = _assigned_name(load_stmt)
+        compute_body.append(
+            statement_from_string(f"{load_name} = {list_name}[{lane_var}]")
+        )
+    compute_body.extend(rest)
+    compute_loop.body = compute_body
+    out.append(compute_loop)
+    return out
+
+
+def split_lane_loads(body: list[ast.stmt]) -> list[ast.stmt]:
+    counter = 0
+    new_body: list[ast.stmt] = []
+    for stmt in body:
+        if isinstance(stmt, ast.For):
+            split = _try_split(stmt, counter)
+            if split is not None:
+                counter += 1
+                new_body.extend(split)
+                continue
+            # Grid lane loops sit at the top level of the kernel body;
+            # nested tile loops keep their own (rolled-reduction) passes.
+        new_body.append(stmt)
+    return new_body

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -1161,6 +1161,26 @@ class DeviceFunction:
             kernel_body = hoist_loop_invariant_recips(
                 kernel_body, rename_groups=rename_groups
             )
+            # Contract single-use fp32 ``t = a*b; w = t + c`` chains into
+            # ``cute.math.fma`` (the DSL's arith ops carry no contract
+            # flag, so NVVM won't fuse them itself).  Triton contracts by
+            # default, so this brings cute numerics closer to the triton
+            # backend.
+            from .cute.fuse_fma import fuse_fma
+
+            # Skipped for matmul kernels: tcgen05 scheduling passes pin
+            # exact statement sequences, and the MMA path gains nothing
+            # from contracting stray scalar epilogue math.
+            if not env.config_spec.matmul_facts:
+                kernel_body = fuse_fma(kernel_body, rename_groups=rename_groups)
+            # Issue all of a grid lane loop's vec loads before its first
+            # store (ptxas cannot prove the store doesn't alias the next
+            # iteration's load, so unsplit loops keep only ONE load in
+            # flight per thread; the triton backend and handwritten CuTe
+            # kernels both load the whole tile fragment first).
+            from .cute.split_lane_loads import split_lane_loads
+
+            kernel_body = split_lane_loads(kernel_body)
             # P18: software-pipeline the per-iteration vec load by one
             # stage.  Pre-issue iter 0's load above the loop and, inside
             # the body, issue iter N+1's load BEFORE iter N's compute

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -4315,15 +4315,16 @@ class PerThreadNDTileStrategy(NDTileStrategy):
                         base_index_var=base_index_var,
                     )
                     idx_expr = f"{base_index_var} + cutlass.Int32({vec_lane_var})"
-                elif lane_strided:
-                    # ``idx = offset + tid + lane * NT`` — consecutive
-                    # threads touch consecutive elements each lane iter.
-                    idx_expr = (
-                        f"{offset_var} + {env.backend.thread_index_expr(axis=axis)}"
-                        f" + {env.backend.lane_offset_expr(lane_var)}"
-                        f" * {static_extent}"
-                    )
                 else:
+                    # NOTE: no SCALAR strided form here — the launch-dim
+                    # recovery regex (cute/backend.py ``indices_line_re``)
+                    # reads the thread extent from the ``thread_idx()[a] *
+                    # epT`` multiplier on ``indices_*`` lines; an ``offset
+                    # + tid + lane*NT`` line parses as epT=1 and inflates
+                    # the launch to block_size, sending surplus threads
+                    # out of bounds.  ``cute_lane_layouts`` affects grid
+                    # tiles only in the vec-partitioned form (whose index
+                    # lines never mention thread_idx directly).
                     idx_expr = f"{idx_expr} + {env.backend.lane_offset_expr(lane_var)}"
                 target = lane_setup_statements
             else:

--- a/test/test_cute_hoist_loop_invariant_recip.py
+++ b/test/test_cute_hoist_loop_invariant_recip.py
@@ -283,8 +283,10 @@ class TestCuteFMAScaleHoist(TestCase):
         self.assertNotIn("v_10 = v_9 - mi", code)
         # Same for the inner reduce V-loop ``v_6 = v_5 - v_1``.
         self.assertNotIn("v_6 = v_5 - v_1", code)
-        # But statements that ARE read MUST NOT be DCE'd.
-        self.assertIn("di = v_4 + sum_1", code)
+        # But statements that ARE read MUST NOT be DCE'd (the surviving
+        # ``di = v_4 + sum_1`` update is subsequently contracted by the
+        # fuse_fma pass into a single FMA).
+        self.assertIn("di = cute.math.fma(di, v_3, sum_1)", code)
 
     def test_invariance_canonicalization_does_not_break_consume(self) -> None:
         """The pass must use the post-rename canonical name map for

--- a/test/test_cute_pointwise_vec.py
+++ b/test/test_cute_pointwise_vec.py
@@ -269,6 +269,27 @@ class TestCutePointwiseVec(TestCase):
         )
         torch.testing.assert_close(out, ref)
 
+    def test_scalar_strided_lane_keeps_launch_width(self) -> None:
+        """Regression: a SCALAR lane loop with cute_lane_layouts=strided
+        must not change the launch width.  The launch-dim recovery regex
+        derives the thread extent from the ``thread_idx()[a] * epT``
+        multiplier of ``indices_*`` lines; an ``offset + tid + lane*NT``
+        form parsed as epT=1 and inflated the launch to block_size,
+        sending surplus threads out of bounds (cudaErrorIllegalAddress
+        during autotuning)."""
+        x = torch.randn(1024, 512, device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn(1024, 512, device=DEVICE, dtype=torch.bfloat16)
+        code, out = code_and_output(
+            _add2d,
+            (x, y),
+            block_sizes=[128, 512],
+            num_threads=[64, 1],
+            cute_vector_widths=[1, 1],
+            cute_lane_layouts=["strided", "strided"],
+        )
+        self.assertIn("block=(64, 1, 1)", code)
+        torch.testing.assert_close(out, x + y)
+
     def test_fast_math_setting_routes_cute_fastmath(self) -> None:
         """The ``fast_math`` SETTING (user opt-in) routes fastmath=True into
         cute.math calls; without it the accurate form is emitted.  Numerics

--- a/test/test_cute_softmax_perf.py
+++ b/test/test_cute_softmax_perf.py
@@ -525,7 +525,9 @@ class TestCuteCanonicalSoftmaxArtifact(TestCase):
         # ``di``) must survive.
         self.assertNotIn("v_10 = v_9 - mi", code)
         self.assertNotIn("v_6 = v_5 - v_1", code)
-        self.assertIn("di = v_4 + sum_1", code)
+        # The online-softmax rescale update contracts to a single FMA
+        # (``di = di*exp(mi-mi_next) + sum`` — same fusion quack applies).
+        self.assertIn("di = cute.math.fma(di, v_3, sum_1)", code)
         # P17 invariance canonicalization: the ``mi`` scale hoist for
         # the consume sweep lives BETWEEN the two outer for-loops
         # (after the reduce loop finishes mutating ``mi`` via the


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3560
 * #3559
 * #3558
 * __->__#3557
 * #3556
 * #3555
 * #3554


--- --- ---

[cutedsl] FMA contraction + lane-loop load/compute phase split

Two general instruction-stream optimizations found by SASS-diffing
generated pointwise kernels against the handwritten CuTe baseline
(bf16 gelu ran 26% more warp instructions for identical DRAM bytes):

- fuse_fma: contract single-use fp32 t = a*b; w = t +/- c SSA chains
  into cute.math.fma after codegen.  The DSL's arith ops carry no
  contract flag so NVVM cannot fuse them itself; triton contracts by
  default, so this converges cute numerics toward the triton backend.
  Rename-group aware (an operand read may not move across a write to
  any alias of the same loop-carried variable); float-proven operands
  only (integer index math never matches); skipped for matmul kernels
  (tcgen05 passes pin exact statement sequences).  Also contracts the
  online-softmax di = di*exp(mi-mi_next) + sum update (two artifact
  tests updated for the fused form).
- split_lane_loads: a vec-partitioned grid lane loop issues iteration
  N+1's vector load only after iteration N's store (ptxas cannot prove
  they don't alias), leaving ONE load in flight per thread.  Split the
  constexpr lane loop into a load phase (all U vec loads back-to-back
  into a trace-time list) and a compute/store phase — element order
  matches triton, which vector-loads the whole tile before any store.

Also drops the scalar strided grid lane form: the launch-dim recovery
regex (cute/backend.py indices_line_re) derives each axis's thread
extent from the thread_idx()[a] * epT multiplier on indices_*
lines, and the scalar strided form (offset + tid + lane*NT, no
multiplier) parsed as epT=1 — inflating the launch to block_size
threads, every surplus thread indexing past its tile with no mask
(cudaErrorIllegalAddress; reproduced + memchecked).  cute_lane_layouts
affects grid tiles only in the vec-partitioned form, whose index lines
never reference thread_idx directly.

Measured on B200 (750W): gelu 5630 -> 6026 GB/s, cast 5538 -> 6232
(beats torch.compile's 6052), copy 6166 -> 6321 (beats the handwritten
baseline), silu flat+fastmath 5375 -> 6348 (baseline 5969).