### PR TITLE
[cutedsl] Add an 'l2_last' load eviction policy (L2::evict_last)

### DIFF
--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -7,6 +7,7 @@ from typing import cast
 
 import torch
 
+from ...autotuner.config_spec import get_valid_eviction_policies
 from ...runtime.config import Config
 from ..cute.cutedsl_compat import tcgen05_runtime_n_ptx_compatible
 from ..cute.cutedsl_compat import warn_tcgen05_runtime_n_ptx_fallback
@@ -2452,6 +2453,21 @@ class CutePointwiseVecHeuristic(AutotunerHeuristic):
         }
         if flatten:
             seed["flatten_loops"] = [True for _ in spec.flatten_loops]
+        # Streamed-once pointwise inputs benefit from L2::evict_last on the
+        # hoisted vec loads (triton's pointwise winners routinely carry
+        # evict_last; measured +1.7% on fp32 mul under do_bench's flush).
+        # Seed-only: this heuristic never promotes to the autotune-off
+        # default, and a plain-policy alternate is planted alongside.
+        # Sized from the live spec, not memory_op_facts: loads carrying an
+        # explicit ``hl.load(..., eviction_policy=...)`` get no config slot,
+        # so the fact count can exceed the list the search space expects.
+        n_evict = (
+            spec.load_eviction_policies.length
+            if spec.supports_config_key("load_eviction_policies")
+            else 0
+        )
+        if n_evict and "l2_last" in get_valid_eviction_policies("cute"):
+            seed["load_eviction_policies"] = ["l2_last"] * n_evict
         try:
             return Config(**seed)
         except Exception:
@@ -2492,6 +2508,14 @@ class CutePointwiseVecHeuristic(AutotunerHeuristic):
                     with contextlib.suppress(Exception):
                         seeds.append(Config(**flat_seed))
                         base_variants.append(flat_seed)
+        # Plain-eviction alternate of the primary (which seeds l2_last on
+        # every load): keeps a no-hint starting point in the population for
+        # regimes where the L2 policy is a wash.
+        if primary.config.get("load_eviction_policies"):
+            plain_seed: dict[str, Any] = dict(primary.config)
+            plain_seed.pop("load_eviction_policies", None)
+            with contextlib.suppress(Exception):
+                seeds.append(Config(**plain_seed))
         return seeds
 
 

--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -1169,6 +1169,7 @@ class CuteBackend(Backend):
             "_cute_bfloat16_x16_to_float16": "from helion._compiler.cute.quantized_helpers import bfloat16_x16_to_float16 as _cute_bfloat16_x16_to_float16",
             "_cute_store_u16_vec": "from helion._compiler.cute.vec_utils import store_u16_vec as _cute_store_u16_vec",
             "_cute_store_u32_vec": "from helion._compiler.cute.vec_utils import store_u32_vec as _cute_store_u32_vec",
+            "_cute_load_l2_evict_last": "from helion._compiler.cute.l2_policy import load_v16b_l2_evict_last as _cute_load_l2_evict_last",
             "_cute_grid_barrier": "from helion._compiler.cute.grid_barrier import grid_barrier as _cute_grid_barrier",
             "_cute_atomic_max_float32": "from helion._compiler.cute.atomic_helpers import atomic_max_float32 as _cute_atomic_max_float32",
             "_cute_atomic_min_float32": "from helion._compiler.cute.atomic_helpers import atomic_min_float32 as _cute_atomic_min_float32",

--- a/helion/_compiler/cute/l2_policy.py
+++ b/helion/_compiler/cute/l2_policy.py
@@ -1,0 +1,67 @@
+# pyrefly: ignore-errors
+"""L2 cache-policy load helpers for CuTe codegen.
+
+``cute.arch.load`` exposes L1 eviction priorities and the ``.cs`` cache
+operator, but not L2 policy-descriptor hints.  Triton's ``evict_last``
+lowers to ``createpolicy.fractional.L2::evict_last`` + a cache-hint load,
+which keeps up to ~L2-size of a streaming input resident across other
+traffic (including do_bench's flush) — measured worth ~1.7% on an fp32
+elementwise mul on B200.  This emits the same PTX via inline asm.
+
+Called during ``@cute.kernel`` tracing (plain Python building MLIR),
+like ``vec_utils``.
+"""
+
+from __future__ import annotations
+
+import cutlass
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import llvm
+from cutlass._mlir.dialects import vector as _vector_dialect
+from cutlass.cutlass_dsl import dsl_user_op
+
+_ASM_V4_B32_L2_EVICT_LAST = (
+    "{\n"
+    ".reg .b64 pol;\n"
+    "createpolicy.fractional.L2::evict_last.b64 pol, 1.0;\n"
+    "ld.global.L2::cache_hint.v4.b32 {$0,$1,$2,$3}, [$4], pol;\n"
+    "}"
+)
+
+
+@dsl_user_op
+def load_v16b_l2_evict_last(
+    ptr: object,
+    vec_type: ir.VectorType,
+    *,
+    loc: ir.Location | None = None,
+    ip: ir.InsertionPoint | None = None,
+) -> ir.Value:
+    """16-byte vector load with an ``L2::evict_last`` cache-hint policy.
+
+    Returns a raw ``ir.Value`` of ``vec_type`` (any 16-byte vector shape),
+    matching what ``cute.arch.load`` returns for vector dtypes.
+    """
+    addr = ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)
+    u32 = cutlass.Uint32.mlir_type
+    res_ty = llvm.StructType.get_literal([u32] * 4)
+    res = llvm.inline_asm(
+        res_ty,
+        [addr],
+        _ASM_V4_B32_L2_EVICT_LAST,
+        "=r,=r,=r,=r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    vals = [
+        llvm.extractvalue(u32, res, [i], loc=loc, ip=ip)  # pyrefly: ignore
+        for i in range(4)
+    ]
+    v4_ty = ir.VectorType.get([4], u32)
+    v4 = _vector_dialect.from_elements(v4_ty, vals, loc=loc, ip=ip)
+    if str(vec_type) == str(v4_ty):
+        return v4
+    return _vector_dialect.bitcast(vec_type, v4, loc=loc, ip=ip)

--- a/helion/_compiler/cute/memory_ops.py
+++ b/helion/_compiler/cute/memory_ops.py
@@ -22,6 +22,7 @@ from torch.fx.node import map_arg
 
 from ... import exc
 from ...language import _decorators
+from ...language.memory_ops import _CUTE_L2_LAST_SUFFIX
 from ...language.memory_ops import _CUTE_VECTOR_DTYPES
 from ...language.memory_ops import _CUTE_VECTOR_UNROLL_CARRIER
 from ...language.memory_ops import _CUTE_VECTOR_UNROLL_DTYPES
@@ -40,6 +41,7 @@ from ...language.memory_ops import _cute_scalar_load_expr
 from ...language.memory_ops import _cute_scalar_pointer_expr
 from ...language.memory_ops import _cute_tensor_dim_size_expr
 from ...language.memory_ops import _cute_unique_graph_block_id
+from ...language.memory_ops import _cute_unroll_vec_load_expr
 from ...language.memory_ops import _matching_block_ids
 from ...language.memory_ops import _maybe_codegen_cute_packed_affine_lhs_load
 from ...language.memory_ops import load
@@ -183,6 +185,10 @@ def _cute_vector_load_expr(
 ) -> str:
     elem_str, _ = _CUTE_VECTOR_DTYPES[dtype]
     ptr = _cute_scalar_pointer_expr(tensor_name, index_exprs)
+    if eviction_suffix == _CUTE_L2_LAST_SUFFIX:
+        # Explicit-vec ("vec" mode) loads return FLOAT vectors, not the
+        # carrier form the L2 helper produces; drop the hint here.
+        eviction_suffix = ""
     return (
         f"cute.arch.load({ptr}, "
         f"ir.VectorType.get([{vec_width}], {elem_str}.mlir_type)"
@@ -252,9 +258,8 @@ def _cute_register_unroll_vec_hoist(
         )
         cache[cache_key] = (hoist_var, tensor.dtype)
         hoist_stmt = statement_from_string(
-            f"{hoist_var} = cute.arch.load({base_ptr_expr}, "
-            f"ir.VectorType.get([{vec_width}], {carrier}.mlir_type)"
-            f"{eviction_suffix})"
+            f"{hoist_var} = "
+            f"{_cute_unroll_vec_load_expr(base_ptr_expr, tensor.dtype, vec_width, eviction_suffix)}"
         )
         # Insert the hoist just BEFORE the constexpr V-loop.
         lane_body.insert(lane_body.index(constexpr_loop), hoist_stmt)
@@ -2414,6 +2419,10 @@ def _(state: CodegenState) -> object:
             policy = policies[load_idx]
             if policy == "streaming":
                 eviction_suffix = ", cop='cs'"
+            elif policy == "l2_last":
+                # L2::evict_last policy loads (inline PTX; only the 16-byte
+                # unroll-hoist form honors it — see _CUTE_L2_LAST_SUFFIX).
+                eviction_suffix = _CUTE_L2_LAST_SUFFIX
             elif mapped := _CUTE_EVICTION_POLICY_MAP.get(policy, ""):
                 eviction_suffix = f", level1_eviction_priority={mapped!r}"
     vec_ctx = _cute_vector_load_ctx(state, tensor, subscript, index_exprs, extra_mask)

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -934,7 +934,12 @@ def get_valid_eviction_policies(backend_name: str) -> tuple[str, ...]:
         # 57.3us -> 47.1us on cross-entropy 32768x2048 fp32 on B200
         # under do_bench's dirty-L2 flush; triton's evict_first hints L2
         # too, so this closes a structural gap vs the triton backend).
-        return ("", "first", "last", "streaming")
+        # "l2_last" emits createpolicy.fractional.L2::evict_last +
+        # ld.global.L2::cache_hint (inline PTX) on 16-byte hoisted vec
+        # loads only — triton's evict_last equivalent, which keeps up to
+        # ~L2-size of a streaming input resident across other traffic
+        # (+1.7% on fp32 elementwise mul on B200).
+        return ("", "first", "last", "streaming", "l2_last")
     return ("",)
 
 

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -784,6 +784,9 @@ def _cute_scalar_load_expr(
             f"cute.arch.load({_cute_scalar_pointer_expr(tensor_name, index_exprs)}, "
             "cutlass.Uint8)"
         )
+    if eviction_suffix == _CUTE_L2_LAST_SUFFIX:
+        # The L2 policy helper only exists in 16-byte vector form.
+        eviction_suffix = ""
     if eviction_suffix and dtype.itemsize >= 4 and dtype is not torch.bool:
         # ``(ptr).load()`` has no cache-hint kwargs; route hinted scalar
         # sites through ``cute.arch.load`` instead.  Sub-32-bit dtypes stay
@@ -892,10 +895,26 @@ def _cute_lane_axis_pos(strategy: object, block_id: int, index_exprs: list[str])
     return len(index_exprs) - 1
 
 
+# Sentinel eviction "suffix" for the ``l2_last`` policy: not a kwarg on
+# ``cute.arch.load`` (which has no L2 policy support) but a marker that the
+# 16-byte unroll-hoist load should go through the inline-PTX
+# ``createpolicy.fractional.L2::evict_last`` helper.  Non-16-byte or scalar
+# sites silently drop the hint.
+_CUTE_L2_LAST_SUFFIX = "__l2_last__"
+
+
 def _cute_unroll_vec_load_expr(
     ptr_expr: str, dtype: torch.dtype, vec_width: int, eviction_suffix: str = ""
 ) -> str:
     """Build the ``cute.arch.load(...)`` RHS for an unroll-mode hoist."""
+    if eviction_suffix == _CUTE_L2_LAST_SUFFIX:
+        if not _cute_is_byte_packed(dtype) and vec_width * dtype.itemsize == 16:
+            return (
+                f"_cute_load_l2_evict_last({ptr_expr}, "
+                f"ir.VectorType.get([{vec_width}], "
+                f"{_cute_unroll_vec_elem_type(dtype)}.mlir_type))"
+            )
+        eviction_suffix = ""
     if _cute_is_byte_packed(dtype):
         pack = _cute_unroll_vec_elem_type(dtype, vec_width)
         return f"cute.arch.load({ptr_expr}, {pack}{eviction_suffix})"

--- a/test/test_cute_pointwise_vec.py
+++ b/test/test_cute_pointwise_vec.py
@@ -108,6 +108,15 @@ def _div1d_fastmath(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     return out
 
 
+@helion.kernel(backend="cute", static_shapes=True)
+def _add_explicit_evict(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size(0)):
+        a = hl.load(x, [tile], eviction_policy="evict_last")
+        out[tile] = a + y[tile]
+    return out
+
+
 @onlyBackends(["cute"])
 class TestCutePointwiseVec(TestCase):
     def test_nd_grid_vec_bf16(self) -> None:
@@ -290,6 +299,22 @@ class TestCutePointwiseVec(TestCase):
         self.assertIn("block=(64, 1, 1)", code)
         torch.testing.assert_close(out, x + y)
 
+    def test_l2_last_eviction_policy(self) -> None:
+        """``load_eviction_policies=["l2_last", ...]`` routes 16-byte vec
+        hoists through the inline-PTX L2::evict_last cache-hint load."""
+        x = torch.randn(2**16, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(2**16, device=DEVICE, dtype=torch.float32)
+        code, out = code_and_output(
+            _mul1d,
+            (x, y),
+            block_sizes=[1024],
+            num_threads=[256],
+            cute_vector_widths=[4],
+            load_eviction_policies=["l2_last", "l2_last"],
+        )
+        self.assertIn("_cute_load_l2_evict_last", code)
+        torch.testing.assert_close(out, x * y)
+
     def test_fast_math_setting_routes_cute_fastmath(self) -> None:
         """The ``fast_math`` SETTING (user opt-in) routes fastmath=True into
         cute.math calls; without it the accurate form is emitted.  Numerics
@@ -330,6 +355,31 @@ class TestCutePointwiseVec(TestCase):
         code, out = code_and_output(_div1d_fastmath, (x, y), block_sizes=[1024])
         self.assertIn("cute.math.div", code)
         torch.testing.assert_close(out, x / y, rtol=1e-4, atol=1e-4)
+
+    def test_seed_eviction_list_sized_from_spec_slots(self) -> None:
+        """Regression: a load carrying an explicit ``hl.load(...,
+        eviction_policy=...)`` gets no config slot, so the l2_last seed must
+        size ``load_eviction_policies`` from the spec (not the load count) or
+        the flat search surface rejects it (`Expected list of length 1`)."""
+        x = torch.randn(2**14, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(2**14, device=DEVICE, dtype=torch.float32)
+        bound = _add_explicit_evict.bind((x, y))
+        spec = bound.env.config_spec
+        n_slots = spec.load_eviction_policies.length
+        self.assertEqual(n_slots, 1)
+        seeds = spec.compiler_seed_configs
+        self.assertTrue(seeds)
+        seeded_policies = [
+            s.config["load_eviction_policies"]
+            for s in seeds
+            if s.config.get("load_eviction_policies")
+        ]
+        self.assertTrue(seeded_policies)
+        for policies in seeded_policies:
+            self.assertEqual(list(policies), ["l2_last"] * n_slots)
+        config_gen = spec.create_config_generation()
+        for seed in seeds:
+            config_gen.canonicalize_flat(config_gen.flatten(seed))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3560
 * #3559
 * __->__#3558
 * #3557
 * #3556
 * #3555
 * #3554


--- --- ---

[cutedsl] Add an 'l2_last' load eviction policy (L2::evict_last)

cute.arch.load only exposes L1 eviction priorities and the .cs cache
operator; triton's evict_last lowers to an L2 policy-descriptor load
(createpolicy.fractional.L2::evict_last + ld.global.L2::cache_hint),
which keeps up to ~L2-size of a streaming input resident across other
traffic.  ABAB on B200 showed this is the entire 1.6% helion-triton
edge on fp32 elementwise mul (triton 6711 -> 6605 GB/s with the hint
stripped, cute at 6602; hand-edited cute kernel with the PTX form:
6663).  New l2_policy.load_v16b_l2_evict_last emits the same PTX via
inline asm; the 'l2_last' choice applies it to 16-byte hoisted vec
loads (tile and reduction unroll paths) and silently degrades to an
unhinted load elsewhere.

The pointwise PRIMARY seed carries l2_last on every load (a joint
all-loads flip is a narrow basin random mutation rarely lands on), with
a plain-policy alternate planted alongside; this heuristic never
promotes to the autotune-off default.