### PR TITLE
[cutedsl] Autotuner search-surface fixes for the pointwise family

### DIFF
--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -2516,6 +2516,33 @@ class CutePointwiseVecHeuristic(AutotunerHeuristic):
             plain_seed.pop("load_eviction_policies", None)
             with contextlib.suppress(Exception):
                 seeds.append(Config(**plain_seed))
+        # Wide-thread sibling (NT*2, one vector per thread): kernels whose
+        # per-element pipeline is ALU-heavier (e.g. a broadcast gather's
+        # per-element div/mod) prefer more threads over per-thread unroll
+        # (bias_add 4096x50257: 3.0 -> 4.9 TB/s on B200).
+        if picked is not None:
+            vec_block, vec = picked[0], picked[1]
+            nt_ids = [s.block_id for s in spec.num_threads]
+            if vec_block in nt_ids:
+                nt_pos = nt_ids.index(vec_block)
+                for base in [*base_variants]:
+                    nt_list = list(base.get("num_threads") or [])
+                    if nt_pos >= len(nt_list):
+                        continue
+                    nt2 = int(nt_list[nt_pos]) * 2
+                    block_list = base.get("block_sizes") or []
+                    bs_pos = [s.block_id for s in spec.block_sizes].index(vec_block)
+                    block = int(block_list[bs_pos]) if bs_pos < len(block_list) else 0
+                    if nt2 <= 0 or nt2 > 1024 or block % (nt2 * vec) != 0:
+                        continue
+                    wide_seed: dict[str, Any] = dict(base)
+                    wide_seed["num_threads"] = [
+                        *nt_list[:nt_pos],
+                        nt2,
+                        *nt_list[nt_pos + 1 :],
+                    ]
+                    with contextlib.suppress(Exception):
+                        seeds.append(Config(**wide_seed))
         return seeds
 
 

--- a/helion/_compiler/cute/memory_ops.py
+++ b/helion/_compiler/cute/memory_ops.py
@@ -2206,6 +2206,13 @@ def _cute_vector_load_ctx(
         # vectorize along the wrong dim and read garbage.
         if not lane_on_stride1:
             return None
+        # Epilogue subtiling stages stores through smem with sync_threads
+        # inside the per-element pipeline; the vec hoist/flush protocol
+        # silently corrupts that form — stay scalar (matches pre-vec
+        # behavior, which is correct under subtiling).
+        subtile = state.config.config.get("epilogue_subtile")
+        if isinstance(subtile, int) and subtile > 1:
+            return None
         vec_by_block = getattr(strategy, "_cute_lane_vec_width_by_block", None)
         if not isinstance(vec_by_block, dict):
             return None

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -1920,6 +1920,12 @@ class ForiLoopState(DeviceLoopOrGridState):
     )
 
 
+def _cute_epilogue_subtile_active(config: object) -> bool:
+    """True when the config requests epilogue subtiling (>= 2)."""
+    value = getattr(config, "config", {}).get("epilogue_subtile")
+    return isinstance(value, int) and value > 1
+
+
 @dataclasses.dataclass
 class VecLaneWrapper:
     """Pre-built outer x constexpr-V lane structure for a GRID lane loop.
@@ -4262,6 +4268,12 @@ class PerThreadNDTileStrategy(NDTileStrategy):
                     # request_root_lane_loop_suppression), which would strand
                     # the hoists; keep grid vec to matmul-free kernels.
                     and not env.config_spec.matmul_facts
+                    # Epilogue subtiling stages stores through smem with a
+                    # sync_threads INSIDE the per-element pipeline, which the
+                    # vec store-collection protocol silently corrupts (50%
+                    # wrong output measured); keep such configs on the
+                    # (correct) scalar form.
+                    and not _cute_epilogue_subtile_active(self.fn.config)
                 ):
                     # Same outer x constexpr-V lane partition as
                     # ``codegen_device_loop`` (see the comments there), so
@@ -4806,8 +4818,12 @@ class PerThreadFlattenedTileStrategy(FlattenedTileStrategy):
             thread_extent, int
         )
 
-        if vec_width > 1 and env.config_spec.matmul_facts:
-            # See the matmul-fallback lane-loop-suppression note in
+        if vec_width > 1 and (
+            env.config_spec.matmul_facts
+            or _cute_epilogue_subtile_active(self.fn.config)
+        ):
+            # See the matmul-fallback lane-loop-suppression and the
+            # epilogue-subtile smem-staging notes in
             # ``PerThreadNDTileStrategy.codegen_grid``.
             vec_width = 1
         if vec_width > 1:

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -1878,14 +1878,24 @@ class PopulationBasedSearch(BaseSearch):
     def _final_rebenchmark_use_isolated(self) -> bool:
         from ..runtime.settings import _env_get_bool
 
+        # Default to ISOLATED finalist timing on cute: the interleaved bench
+        # lets L2 cache-POLICY state leak between candidates that read the
+        # same input tensors (an ``l2_last`` candidate pins its inputs in L2
+        # and every rival free-rides on the hits, so the config CAUSING the
+        # speedup can never out-measure the others).  Isolated mode times
+        # each finalist in its own steady window — the same regime the
+        # deployment-style do_bench measures — with suspicious-result
+        # confirmation guarding against thermal drift between windows.
+        backend_name = getattr(getattr(self, "config_spec", None), "backend_name", None)
+        default = backend_name == "cute"
         try:
-            return _env_get_bool(_FINAL_REBENCHMARK_ISOLATED_ENV, False)
+            return _env_get_bool(_FINAL_REBENCHMARK_ISOLATED_ENV, default)
         except ValueError:
             self.log.warning(
                 f"Ignoring invalid {_FINAL_REBENCHMARK_ISOLATED_ENV}="
-                f"{os.getenv(_FINAL_REBENCHMARK_ISOLATED_ENV)!r}; using False."
+                f"{os.getenv(_FINAL_REBENCHMARK_ISOLATED_ENV)!r}; using {default}."
             )
-            return False
+            return default
 
     def _final_rebenchmark_pinned_tolerance(self) -> float:
         raw = os.getenv(_FINAL_REBENCHMARK_PINNED_TOLERANCE_ENV)

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -3318,6 +3318,18 @@ class ConfigSpec:
                 )
             elif self.supports_config_key("num_threads"):
                 fields["num_threads"] = self.num_threads
+                # Loop flattening is a real codegen choice on the SIMT path
+                # (flattened multi-dim tiles vectorize odd-row-length
+                # pointwise kernels via flat base pointers).  Without this
+                # entry the flat form was unreachable: seeds carrying
+                # ``flatten_loops=[True]`` silently lost the flag in the
+                # flat-config round trip and were benchmarked as their
+                # (much slower) N-D counterparts.
+                if (
+                    self.supports_config_key("flatten_loops")
+                    and len(self.flatten_loops) > 0
+                ):
+                    fields["flatten_loops"] = self.flatten_loops
                 # Rolled-reduction loop chunks are tunable on the SIMT path
                 # (LoopedReductionStrategy lane lattices).  Without this
                 # entry the chunk silently pins to its default and neither

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -11428,13 +11428,16 @@ class TestCuteAutotuner(TestCase):
         # surface. ``cute_vector_widths`` is the per-axis vec width slot
         # registered for non-reduction tile blocks.
         # ``load_eviction_policies`` carries per-load-site L1 eviction
-        # hints (lowered on the vectorized load forms). The set still
-        # excludes Triton-style knobs that the CuTe path does not consume.
+        # hints (lowered on the vectorized load forms). ``flatten_loops``
+        # selects the flattened multi-dim tile form (flat base-pointer
+        # vectorization). The set still excludes Triton-style knobs that
+        # the CuTe path does not consume.
         self.assertEqual(
             flat_keys,
             {
                 "block_sizes",
                 "num_threads",
+                "flatten_loops",
                 "loop_orders",
                 "cute_vector_widths",
                 "cute_lane_layouts",
@@ -11458,6 +11461,7 @@ class TestCuteAutotuner(TestCase):
                 {
                     "block_sizes",
                     "num_threads",
+                    "flatten_loops",
                     "loop_orders",
                     "cute_vector_widths",
                     "cute_lane_layouts",

--- a/test/test_cute_pointwise_vec.py
+++ b/test/test_cute_pointwise_vec.py
@@ -315,6 +315,24 @@ class TestCutePointwiseVec(TestCase):
         self.assertIn("_cute_load_l2_evict_last", code)
         torch.testing.assert_close(out, x * y)
 
+    def test_epilogue_subtile_disables_vec(self) -> None:
+        """Regression: epilogue_subtile stages stores through smem with a
+        sync inside the per-element pipeline; combined with the vec
+        hoist/flush protocol it silently corrupted ~50% of the output.
+        Subtiled configs must stay on the scalar form."""
+        x = torch.randn(64, 2048, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(64, 2048, device=DEVICE, dtype=torch.float32)
+        code, out = code_and_output(
+            _add2d,
+            (x, y),
+            block_sizes=[1, 2048],
+            num_threads=[1, 256],
+            cute_vector_widths=[1, 4],
+            epilogue_subtile=2,
+        )
+        self.assertNotIn("ir.VectorType.get(", code)
+        torch.testing.assert_close(out, x + y)
+
     def test_fast_math_setting_routes_cute_fastmath(self) -> None:
         """The ``fast_math`` SETTING (user opt-in) routes fastmath=True into
         cute.math calls; without it the accurate form is emitted.  Numerics


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3560
 * __->__#3559
 * #3558
 * #3557
 * #3556
 * #3555
 * #3554


--- --- ---

[cutedsl] Autotuner search-surface fixes for the pointwise family

Four fixes that let cold full autotunes actually FIND the configs the
new pointwise codegen can express (each verified by a cold search that
previously plateaued below the baseline and passes it after):

- Expose flatten_loops in the cute SIMT flat-config branch: the
  flattened tile form was unreachable — seeds carrying
  flatten_loops=[True] silently lost the flag in the flat round trip
  and benchmarked as their much slower N-D counterparts (bias_add's
  flat+l2_last seed measures 5.0 TB/s pinned, its de-flattened ghost
  3.0; searches returned 2.7-2.9 scalar configs).  With the dimension
  live, a cold search finds a flattened config at 5.3 TB/s (baseline
  4.4).
- Default cute finalist verification to ISOLATED subprocess timing:
  the interleaved bench lets L2 cache-POLICY state leak between
  candidates reading the same input tensors — an l2_last candidate
  pins its inputs in L2 and every rival free-rides on the hits, so the
  config CAUSING the speedup can never out-measure the others.
  HELION_AUTOTUNE_FINAL_REBENCHMARK_ISOLATED still overrides; other
  backends keep the interleaved default.
- Keep epilogue-subtiled configs on the scalar pointwise form:
  subtiling stages stores through smem with a sync_threads inside the
  per-element pipeline, which the vec hoist/flush protocol silently
  corrupted (~50% wrong output, caught by the accuracy gate — and the
  rejects were poisoning the mutation neighborhoods of good seeds).
- Wide-thread (NT*2, one vector per thread) pointwise seed sibling:
  ALU-heavier per-element pipelines (a broadcast gather's div/mod)
  prefer more threads over per-thread unroll (bias_add: 3.0 TB/s at
  NT=256/U=2 vs 4.9-5.0 at NT=512/U=1+l2_last).