### PR TITLE
[cutedsl] Lower sigmoid through the triton-parity rcp.approx/ex2 sequence

### DIFF
--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -1228,13 +1228,18 @@ class CuteBackend(Backend):
             @staticmethod
             # pyrefly: ignore [bad-override]
             def sigmoid(x: CuteDSLArg) -> CuteDSLArg:
-                # The base lowering divides with an accurate IEEE fp32 div
-                # (a ~20-instruction SASS sequence).  Under fastmath use
-                # RCP.APPROX + EX2.APPROX like quack's sigmoid: at 2
-                # bytes/element these kernels are instruction-throughput
-                # bound and the accurate div costs ~20% of peak.
-                if not HelionCuteDSLOpOverrides._fastmath_on():
-                    return CuteDSLOpOverrides.sigmoid(x)
+                # RCP.APPROX + EX2.APPROX, the same sequence triton's default
+                # tl.sigmoid compiles to (one MUFU.EX2 + one MUFU.RCP).  The
+                # base lowering's accurate IEEE div is a ~20-instruction
+                # BRANCHY SASS expansion (BSSY/BSYNC reconvergence per
+                # element) that buys no accuracy here: sigmoid's error is
+                # dominated by the shared x*log2e argument rounding, and both
+                # forms measure max 64 ulp / mean 3.5 ulp vs an fp64
+                # reference on [-87, 87] (identical distributions), with
+                # specials preserved (nan->nan, +-inf->1/0, saturation->0).
+                # Only denormal OUTPUTS differ: this form flushes them to
+                # zero, as triton kernels do by default.  fp16 sigmoid
+                # 67108864: 4943 -> 5805 GB/s (B200, cold autotune).
                 x_cse = CuteDSLOpOverrides._get_cse_var(x)
                 if x_cse is not None:
                     x_fp32: CuteDSLArg = CuteDSLOpOverrides.to_dtype(

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -16900,7 +16900,11 @@ class TestCuteLowerings(unittest.TestCase):
             bound.set_config(config)
             actual = bound(*args)
         self.assertIn("for tcgen05_epi_position", code)
-        self.assertIn("1.0 /", code)
+        # The default sigmoid lowering is the triton-parity RCP.APPROX +
+        # EX2.APPROX sequence (same accuracy class as the IEEE-div form it
+        # replaced); strict math means the fragment-level ftz HELPER —
+        # which skips the epilogue pipeline entirely — stays fastmath-only.
+        self.assertIn("cute.math.rcp", code)
         self.assertNotIn("_cute_sigmoid_approx_ftz_f32", code)
         acc = torch.einsum("mk,hkd->hmd", args[0].float(), args[1].float())
         pairs = acc.view(1, 128, 32, 2)

--- a/test/test_cute_pointwise_vec.py
+++ b/test/test_cute_pointwise_vec.py
@@ -92,6 +92,14 @@ def _tile_index_bias(x: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     return out
 
 
+@helion.kernel(backend="cute", static_shapes=True)
+def _sigmoid1d(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(out.size()):
+        out[tile] = torch.sigmoid(x[tile])
+    return out
+
+
 @helion.kernel(backend="cute", static_shapes=True, fast_math=True)
 def _tanh1d_fastmath(x: torch.Tensor) -> torch.Tensor:
     out = torch.empty_like(x)
@@ -398,6 +406,27 @@ class TestCutePointwiseVec(TestCase):
         config_gen = spec.create_config_generation()
         for seed in seeds:
             config_gen.canonicalize_flat(config_gen.flatten(seed))
+
+    def test_default_sigmoid_rcp_approx(self) -> None:
+        """Default (no fast_math) sigmoid lowers through the triton-parity
+        RCP.APPROX + EX2.APPROX sequence: same accuracy class as the branchy
+        IEEE-div form it replaces (both are dominated by the x*log2e
+        argument rounding; max 64 ulp / mean 3.5 ulp vs fp64 on [-87, 87])
+        and ~20% faster on fp16 streams.  Specials must be preserved."""
+        x = torch.randn(2**14, device=DEVICE, dtype=torch.float16)
+        code, out = code_and_output(_sigmoid1d, (x,), block_sizes=[1024])
+        self.assertIn("cute.math.rcp", code)
+        self.assertNotIn("1.0 / ", code)
+        torch.testing.assert_close(
+            out, torch.sigmoid(x.to(torch.float32)).to(torch.float16)
+        )
+        xs = torch.tensor(
+            [0.0, -0.0, float("inf"), float("-inf"), float("nan"), -200.0, 200.0, 30.0],
+            device=DEVICE,
+            dtype=torch.float32,
+        )
+        _, out32 = code_and_output(_sigmoid1d, (xs,), block_sizes=[8])
+        torch.testing.assert_close(out32, torch.sigmoid(xs), equal_nan=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__#3560
 * #3559
 * #3558
 * #3557
 * #3556
 * #3555
 * #3554


--- --- ---

[cutedsl] Lower sigmoid through the triton-parity rcp.approx/ex2 sequence

The default (strict-math) cute sigmoid lowered through an accurate IEEE
fp32 division — a ~20-instruction BRANCHY SASS expansion with BSSY/BSYNC
reconvergence per element (~25 instr/element total vs triton's 14 for
the same tl.sigmoid math).  That cost bought no accuracy: sigmoid's
error is dominated by the x*log2e argument rounding both forms share.
Measured against an fp64 reference over [-87, 87] (16.7M points + edge
specials), old and new distributions are identical — max 64 vs 63 ulp
(at deep saturation where outputs are ~1e-14), mean 3.50 ulp both, core
range |x|<=15 max 15 ulp — and specials are preserved (nan->nan,
+-inf->1/0, deep saturation->0).  Only denormal OUTPUTS differ: the new
form flushes them to zero, as triton kernels do by default.

The replacement is the exact sequence triton's default tl.sigmoid
compiles to — one MUFU.EX2 plus one MUFU.RCP — so helion-cute now
matches helion-triton's default sigmoid numerics class.  A Newton
refinement on the reciprocal was evaluated and rejected: it returns NaN
at saturation (rcp(inf)=0 feeds fma(-inf, 0, 1)) and measured zero
speedup.

fp16 sigmoid 67108864 on B200 750W (cold full autotunes, strict math):
4943 -> 5695 GB/s, ahead of strict-math helion-triton (5574); bf16 silu
16384x11008 (sigmoid-dominated): 4602 -> 6021 GB/s, ahead of strict-math
helion-triton (5553), torch.compile (4922), and the fastmath handwritten
CuTe baseline (5969) — silu no longer needs a fast_math opt-in at all.

The tcgen05 fragment-epilogue strict-math test now asserts the new
default sequence; the fragment-level ftz HELPER it guards
(_cute_sigmoid_approx_ftz_f32, which bypasses the epilogue pipeline)
remains gated on the fast_math setting.