### PR TITLE
[metal] Honor begin/step for 1-D root grids

### DIFF
--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -37,6 +37,7 @@ from .program_id import PIDInfo
 from .program_id import ProgramIDs
 from .program_id import Tcgen05PersistentProgramIDs
 from .program_id import XYZProgramIDs
+from .variable_origin import GridOrigin
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -4673,6 +4674,29 @@ class PerThreadNDTileStrategy(NDTileStrategy):
         return False
 
 
+def _is_noncanonical_scalar_grid(block_ids: list[int]) -> bool:
+    """Whether ``block_ids`` is a lone root ``hl.grid`` with a begin or a step.
+
+    Such a loop yields a scalar index (``GridOrigin``) rather than a tile, and
+    ``device_ir.noncanonical_task_origin_block_ids`` marks the ones whose index
+    is not simply ``0, 1, 2, ...``.  ``grid_block_ids`` also lists root
+    ``hl.tile`` loops, so the ``GridOrigin`` check is what separates the two.
+    """
+    if len(block_ids) != 1:
+        return False
+    (block_id,) = block_ids
+    host_fn = HostFunction.current()
+    device_ir = host_fn.device_ir
+    if block_id not in device_ir.noncanonical_task_origin_block_ids:
+        return False
+    if not any(block_id in ids for ids in device_ir.grid_block_ids):
+        return False
+    return any(
+        type(origin.origin) is GridOrigin and origin.origin.block_id == block_id
+        for origin in host_fn.expr_to_origin.values()
+    )
+
+
 class PerThreadFlattenedTileStrategy(FlattenedTileStrategy):
     """Flattened tiling with one scalar index per thread.
 
@@ -4694,6 +4718,16 @@ class PerThreadFlattenedTileStrategy(FlattenedTileStrategy):
         self._lane_var: str | None = None
         if num_threads > 0 and isinstance(block_size, int) and num_threads < block_size:
             self._lane_var = self.new_var("lane", dce=False)
+        # ``hl.grid(begin, end, step)`` registers its block with block size ==
+        # step (a stride, not a tile width) and a ``GridOrigin`` symbol that
+        # ``DeviceFunction.sympy_expr`` renders as ``offset_var``.  Here
+        # ``offset_var`` is the raw ``pid * block_size + tid`` thread offset, so
+        # ``begin``/``step`` would be silently dropped.  Flag the shape so
+        # ``codegen_grid`` emits the one-thread-per-trip form ``NDTileStrategy``
+        # uses for the same loop.
+        self._scalar_grid_offsets = _is_noncanonical_scalar_grid(block_ids)
+        if self._scalar_grid_offsets:
+            self._lane_var = None
         # Vec-partition state for the memory_ops ``tile_unroll`` hoist
         # protocol (same shape as ``PerThreadNDTileStrategy``).  The vec
         # slot lives on the LAST (stride-1) block; for the multi-block
@@ -4752,6 +4786,10 @@ class PerThreadFlattenedTileStrategy(FlattenedTileStrategy):
         return self.block_size // self._num_threads
 
     def _thread_extent(self) -> SymIntLike:
+        if self._scalar_grid_offsets:
+            # ``block_size`` is the grid's step, not a tile width: the loop runs
+            # one thread per trip (see ``_codegen_scalar_grid``).
+            return 1
         if self._num_threads == 0:
             return self.block_size
         backend_name = CompileEnvironment.current().backend.name
@@ -4798,7 +4836,70 @@ class PerThreadFlattenedTileStrategy(FlattenedTileStrategy):
         thread_extent = self._thread_extent()
         return not (isinstance(thread_extent, int) and thread_extent == 1)
 
+    def _codegen_scalar_grid(self, state: CodegenState) -> DeviceGridState:
+        """Emit ``offsets = begin + pid * step`` for a scalar root ``hl.grid``.
+
+        ``offset_var`` is what the loop's ``GridOrigin`` symbol renders as, so it
+        has to hold the logical index.  Launching one thread per trip (rather
+        than ``cdiv(trip_count, step)`` groups of ``step`` threads) keeps the
+        launch exact, so the surplus threads a partial last group would create
+        -- which the scalar subscript path has no mask to guard -- never exist.
+        This mirrors ``NDTileStrategy.codegen_grid``, which pins
+        ``block_size_var`` to ``1`` for a stepped grid.
+        """
+        (begin,), (end,), (step,) = self._extract_root_bounds(state)
+        (block_id,) = self.block_ids
+        offsets_var = self._offsets_var
+        trip_count = self._range_trip_count(begin, end, step)
+
+        pid_var = state.device_function.new_var("pid_flat", dce=True)
+        pids = self.select_pid_strategy()
+        if isinstance(state.device_function.pid, ForEachProgramID):
+            pids.shared_pid_var = state.device_function.pid.shared_pid_var
+        pids.append(PIDInfo(pid_var, "1", trip_count, block_id))
+
+        env = CompileEnvironment.current()
+        dtype = env.index_type()
+
+        def bound_expr(value: object) -> str:
+            # Non-literal bounds arrive as kernel arguments whose scalar type is
+            # not the index type (a float scalar tensor on Metal), so cast the
+            # way ``NDTileStrategy.codegen_grid`` does before doing index math.
+            rendered = self._expr_str(value)
+            if isinstance(value, int):
+                return rendered
+            return env.backend.ast_to_dtype_expr(rendered, dtype)
+
+        expr = pid_var
+        if step not in (None, 1):
+            expr = f"({expr}) * ({bound_expr(step)})"
+        if begin != 0:
+            expr = f"({bound_expr(begin)}) + ({expr})"
+        state.add_statement(f"{offsets_var} = {expr}")
+        state.add_statement(f"{self.index_var(block_id)} = {offsets_var}")
+        mask_var = self.mask_var(-1)
+        if mask_var is not None:
+            state.add_statement(
+                f"{mask_var} = {pid_var} < ({self._numel_str(state, trip_count)})"
+            )
+
+        pids.codegen(state)
+        if isinstance(state.device_function.pid, ForEachProgramID):
+            shared_pid = state.device_function.pid
+            shared_pid.cases.append(pids)
+            shared_pid.codegen(state)
+        else:
+            state.device_function.set_pid(pids)
+        return DeviceGridState(
+            self,
+            block_id_to_info=self._create_block_id_info_dict(
+                state, ends_override=[end]
+            ),
+        )
+
     def codegen_grid(self, state: CodegenState) -> DeviceGridState:
+        if self._scalar_grid_offsets:
+            return self._codegen_scalar_grid(state)
         if self._lane_var is None:
             return super().codegen_grid(state)
 

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -165,7 +165,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         )
         torch.testing.assert_close(result, grid_2d_pytorch(args[0], args[1]))
 
-    @skipIfMetal("BUG: hl.grid begin/end broken with PerThreadNDTileStrategy on Metal")
     def test_grid_begin_end(self):
         @helion.kernel(autotune_effort="none")
         def grid_begin_end(x: torch.Tensor) -> torch.Tensor:
@@ -186,7 +185,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(grid_begin_end, (x,))
         torch.testing.assert_close(result, grid_begin_end_pytorch(x))
 
-    @skipIfMetal("BUG: hl.grid begin/end broken with PerThreadNDTileStrategy on Metal")
     def test_grid_begin_end_step(self):
         @helion.kernel(autotune_effort="none")
         def grid_begin_end_step(x: torch.Tensor) -> torch.Tensor:
@@ -207,7 +205,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(grid_begin_end_step, (x,))
         torch.testing.assert_close(result, grid_begin_end_step_pytorch(x))
 
-    @skipIfMetal("BUG: hl.grid begin/end broken with PerThreadNDTileStrategy on Metal")
     def test_grid_end_step_kwarg(self):
         @helion.kernel(autotune_effort="none")
         def grid_end_step_kwarg(x: torch.Tensor) -> torch.Tensor:
@@ -227,6 +224,38 @@ class TestGrid(RefEagerTestBase, TestCase):
         x = torch.randn([16], device=DEVICE, dtype=torch.float32)
         code, result = code_and_output(grid_end_step_kwarg, (x,))
         torch.testing.assert_close(result, grid_end_step_kwarg_pytorch(x))
+
+    def test_grid_step_indivisible_trip_count(self):
+        # The trip count is not a multiple of the step, so a launch that groups
+        # `step` threads per program leaves surplus threads whose index runs
+        # past `end`.
+        @helion.kernel(autotune_effort="none")
+        def grid_step_10_4(x: torch.Tensor) -> torch.Tensor:
+            out = torch.zeros_like(x)
+            for i in hl.grid(0, 10, 4):
+                out[i] = x[i] * 2
+            return out
+
+        @helion.kernel(autotune_effort="none")
+        def grid_step_3_17_5(x: torch.Tensor) -> torch.Tensor:
+            out = torch.zeros_like(x)
+            for i in hl.grid(3, 17, 5):
+                out[i] = x[i] * 2
+            return out
+
+        def pytorch_ref(x: torch.Tensor, begin: int, end: int, step: int):
+            out = torch.zeros_like(x)
+            for i in range(begin, end, step):
+                out[i] = x[i] * 2
+            return out
+
+        x = torch.randn([10], device=DEVICE, dtype=torch.float32)
+        _code, result = code_and_output(grid_step_10_4, (x,))
+        torch.testing.assert_close(result, pytorch_ref(x, 0, 10, 4))
+
+        x = torch.randn([17], device=DEVICE, dtype=torch.float32)
+        _code, result = code_and_output(grid_step_3_17_5, (x,))
+        torch.testing.assert_close(result, pytorch_ref(x, 3, 17, 5))
 
     def test_grid_multidim_begin_end(self):
         @helion.kernel(autotune_effort="none")
@@ -293,7 +322,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(tile_begin_end, (x,), block_size=4)
         torch.testing.assert_close(result, tile_begin_end_pytorch(x))
 
-    @skipIfMetal("Metal does not support loop_index_expr for grid loops")
     def test_range_as_grid_basic(self):
         """Test that range() works as an alias for hl.grid() in device code."""
 
@@ -314,7 +342,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(range_kernel, (x,))
         torch.testing.assert_close(result, expected)
 
-    @skipIfMetal("Metal does not support loop_index_expr for grid loops")
     def test_range_with_begin_end(self):
         """Test that range(begin, end) works as alias for hl.grid(begin, end)."""
 
@@ -335,7 +362,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(range_begin_end_kernel, (x,))
         torch.testing.assert_close(result, expected)
 
-    @skipIfMetal("Metal does not support loop_index_expr for grid loops")
     @xfailIfPallas(
         "range(begin, end, step) lowers to _for_loop_step which has no "
         "emit_pipeline codegen"
@@ -362,7 +388,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(range_step_kernel, (x,))
         torch.testing.assert_close(result, expected)
 
-    @skipIfMetal("Metal does not support loop_index_expr for grid loops")
     def test_range_with_tensor_size(self):
         """Test that range(tensor.size(dim)) works with dynamic tensor dimensions."""
 


### PR DESCRIPTION
## Problem

On the Metal backend a 1-D root `hl.grid` silently ignores `begin` and `step`
and produces wrong results — no error, no warning, just the wrong indices.

```python
@helion.kernel(autotune_effort="none")
def grid_begin_end(x):
    n = x.size(0)
    out = torch.zeros_like(x)
    for i in hl.grid(2, n - 2):
        out[i] = x[i] * 2
    return out

x = torch.arange(16, device="mps", dtype=torch.float32)
grid_begin_end(x)
# got:      [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 0, 0, 0, 0]   # indices 0..11
# expected: [0, 0, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 0, 0] # indices 2..13
```

`hl.grid(0, n, 2)` on the same input walks indices 0..7 instead of 0, 2, ..., 14.

The N-D twins (`hl.grid([1, 1], [m - 1, n - 1])`, `hl.tile(begin, end)`) are all
correct on Metal — only the 1-D root grid is broken.

## Root cause

Three things line up:

1. `hl.grid(..., step)` registers its block with **block size == step**
   (`GridIndexType.allocate` → `FixedBlockSizeSource(step)`), i.e. for a grid
   the "block size" is a stride, not a tile width.
2. A `GridOrigin` symbol used as a subscript renders as the strategy's
   **`offset_var`** (`DeviceFunction.sympy_expr`), and the scalar subscript path
   attaches no mask to it.
3. Metal (via `CuteBackend.create_loop_strategy`) picks
   `PerThreadFlattenedTileStrategy` for a 1-D root grid, and its `offset_var` is
   the raw linear thread offset `pid_flat * BLOCK_SIZE + tid[0]` — no `begin`,
   no `* step`.

So the correct `indices_0 = begin + offsets_0 * step` that
`FlattenedTileStrategy.codegen_grid` does emit is never read, gets DCE'd, and
the kernel indexes with the bare thread offset:

```python
_BLOCK_SIZE_0 = 1
@metal_jit
def _helion_grid_begin_end(x, out):
    pid_flat = tgid[0]
    offsets_0 = pid_flat * _BLOCK_SIZE_0 + tid[0]   # begin dropped
    load = tl.load(x + offsets_0 * 1, None)
    ...
```

`NDTileStrategy.codegen_grid` (what Triton uses for grids) gets this right
because it writes `offset_var = begin + pid * step` directly.

## Fix

`PerThreadFlattenedTileStrategy` now detects a lone root `hl.grid` whose index is
not simply `0, 1, 2, ...` and emits the same one-thread-per-trip form
`NDTileStrategy` uses, writing the logical index into `offset_var`:

```python
pid_flat = tgid[0]
offsets_0 = 2 + pid_flat        # hl.grid(2, n - 2)
offsets_0 = pid_flat * 4        # hl.grid(0, 10, 4)
```

Two details worth calling out:

- **Surplus threads.** Because block size == step, the old launch is
  `cdiv(trip_count, step)` groups of `step` threads, so when
  `trip_count % step != 0` there are threads whose index lands past `end` —
  `hl.grid(0, 10, 4)` launches 4 threads for 3 trips, and thread 3 would compute
  index 12 on a length-10 tensor. The scalar subscript path has no mask to guard
  that, so instead the launch is made exact (`block_size_var == "1"`, one thread
  per trip), exactly as `NDTileStrategy` does for a stepped grid. New test
  `test_grid_step_indivisible_trip_count` covers `hl.grid(0, 10, 4)` and
  `hl.grid(3, 17, 5)`; it is backend-neutral so it runs on Triton CI too.
- **Non-literal bounds** reach the kernel as arguments whose scalar type is not
  the index type (a float scalar tensor on Metal), so they are cast before index
  math, the same way `NDTileStrategy.codegen_grid` does via `_to_ast(...,
  to_dtype=...)`. Without this, `hl.grid(begin, n, step)` with `step` as a kernel
  argument fails to compile with `array subscript is not an integer` once the
  step is actually used.

The gate is deliberately narrow — a single block id that is a root grid, is in
`device_ir.noncanonical_task_origin_block_ids`, and has a `GridOrigin` symbol.
`grid_block_ids` also lists root `hl.tile` loops, where block size really is a
tile width, so the `GridOrigin` check is what keeps tiles on the existing path.
`DeviceFunction.sympy_expr`'s `GridOrigin → offset_var` rule is untouched.

## Un-skipped tests

Three `@skipIfMetal("BUG: hl.grid begin/end broken with PerThreadNDTileStrategy
on Metal")` markers in `test/test_grid.py` are removed — those are the bug above:

- `test_grid_begin_end`
- `test_grid_begin_end_step`
- `test_grid_end_step_kwarg`

Four more `@skipIfMetal("Metal does not support loop_index_expr for grid loops")`
markers are **stale** — those tests are device loops inside `hl.tile`, not root
grids, and they pass on Metal today, both before and after this change:

- `test_range_as_grid_basic`
- `test_range_with_begin_end`
- `test_range_with_step`
- `test_range_with_tensor_size`

`@skipIfMetal("aten.addmm not yet registered for Metal backend")` on
`test_grid_2d_idx_nested` is left alone — that is a separate gap (no scalar
`aten.mm`/`aten.addmm` Metal codegen outside the MPP K-loop rewrite), worth its
own PR.

## Testing

Apple M1, macOS 26.6.2, torch nightly, MPS available:

```
HELION_BACKEND=metal pytest . --ignore=test/test_examples_dist.py
  before: 1693 passed, 3285 skipped
  after:  1701 passed, 3278 skipped     # +7 un-skipped, +1 new test
```

`test/test_grid.py` + `test/test_metal.py` go from `68 passed, 11 skipped` to
`76 passed, 4 skipped`. `./lint.sh` is clean on the changed files.

## CuTe

CuTe shares `PerThreadFlattenedTileStrategy`, so it almost certainly has the same
bug and this should fix it there too — but I have no CuTe hardware, so I have not
verified that. Happy to have the b200 job run against this if that is useful.

cc @aditvenk

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQCDcaHkEoZaGsSFwdn94t
