### PR TITLE
Reject Metal tile thread axes whose extent is not static

### DIFF
--- a/helion/_compiler/metal/backend.py
+++ b/helion/_compiler/metal/backend.py
@@ -257,7 +257,47 @@ class MetalBackend(Backend):
         """
         config = self._config_with_mpp_thread_budget(fn, block_ids, config)
         # pyrefly: ignore[bad-argument-type]
-        return CuteBackend.create_loop_strategy(self, fn, block_ids, config)
+        strategy = CuteBackend.create_loop_strategy(self, fn, block_ids, config)
+        self._reject_dynamic_thread_extents(strategy)
+        return strategy
+
+    def _reject_dynamic_thread_extents(self, strategy: TileStrategy) -> None:
+        """Reject a thread axis whose extent Helion cannot resolve statically.
+
+        A dropped extent launches the axis one thread wide while its index stays
+        ``offset + tid``, leaving most of the output silently wrong.  Removable
+        once ``launcher_keyword_args`` takes the launch shape from the shared
+        ``thread_block_dim_exprs`` rather than baking literal ``_block_dims``.
+        """
+        from ..tile_strategy import PerThreadFlattenedTileStrategy
+        from ..tile_strategy import PerThreadNDTileStrategy
+
+        if isinstance(strategy, PerThreadNDTileStrategy):
+            dynamic = [
+                block_size
+                for block_id, block_size in zip(
+                    strategy.block_ids, strategy.block_size, strict=True
+                )
+                if strategy._uses_thread_axis_for_block(block_id, block_size)
+                and strategy._static_thread_extent_for_block(block_id, block_size)
+                is None
+            ]
+        elif isinstance(strategy, PerThreadFlattenedTileStrategy):
+            dynamic = []
+            if strategy._uses_thread_axis() and not isinstance(
+                strategy._thread_extent(), int
+            ):
+                dynamic.append(strategy.block_size)
+        else:
+            return
+        if dynamic:
+            raise exc.BackendUnsupported(
+                self.name,
+                f"thread extent {dynamic[0]} is not known until the kernel "
+                "runs, and Helion fixes the Metal threadgroup shape at codegen "
+                "time; give the tile a block_size the config can resolve, or "
+                "compile the kernel with static_shapes=True",
+            )
 
     def _config_with_mpp_thread_budget(
         self, fn: DeviceFunction, block_ids: list[int], config: Config

--- a/test/test_metal.py
+++ b/test/test_metal.py
@@ -416,6 +416,62 @@ class TestMetalBoundsMasking(unittest.TestCase):
         self.assertIn("(tid[0] < _BLOCK_SIZE_0)", msl)
         self.assertIn("(tid[1] < _BLOCK_SIZE_1)", msl)
 
+    def test_a_dynamic_tile_thread_extent_is_rejected(self) -> None:
+        """A threadgroup is shaped at launch, so its extents must be known then.
+
+        ``thread_block_sizes`` reports only the extents it can resolve, and the
+        launcher turns those into the literal ``_block_dims``.  An extent it
+        drops leaves the axis one thread wide while the index expression stays
+        ``offset + tid``, so each tile is computed in its first row alone and
+        the rest of the output keeps whatever ``empty_like`` handed back.
+
+        Only a block size read off a tensor under ``static_shapes=False`` gets
+        here; a config-chosen one is an ``int``.  Three ways in, one per
+        strategy: flattened, ND, and the ND lane path -- the last being the one
+        whose thread mask skips an axis it cannot bound, on the strength of the
+        axis never reaching codegen.
+        """
+
+        @helion.kernel(backend="metal", autotune_effort="none", static_shapes=False)
+        def flat(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tm in hl.tile(x.size(0), block_size=x.size(0) // 2):
+                out[tm] = x[tm] * 2.0
+            return out
+
+        @helion.kernel(backend="metal", autotune_effort="none", static_shapes=False)
+        def nd_kernel(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tm, tn in hl.tile(
+                [x.size(0), x.size(1)], block_size=[x.size(0) // 2, 16]
+            ):
+                out[tm, tn] = x[tm, tn] * 2.0
+            return out
+
+        # ``num_threads`` below the (static) block size gives axis 0 a lane
+        # loop, which is what routes this through
+        # ``PerThreadNDTileStrategy.codegen_grid`` rather than the base ND path.
+        @helion.kernel(
+            backend="metal",
+            static_shapes=False,
+            configs=[helion.Config(block_sizes=[64], num_threads=[16])],
+        )
+        def nd_lane(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tm, tn in hl.tile(
+                [x.size(0), x.size(1)], block_size=[None, x.size(1) // 2]
+            ):
+                out[tm, tn] = x[tm, tn] * 2.0
+            return out
+
+        x = torch.randn(128, 32, device=DEVICE)
+        for kernel in (flat, nd_kernel, nd_lane):
+            with (
+                self.subTest(kernel=kernel.fn.__name__),
+                self.assertRaisesRegex(exc.BackendUnsupported, "not known until"),
+            ):
+                kernel(x[:, 0] if kernel is flat else x)
+
 
 # ---------------------------------------------------------------------------
 # Tests – arithmetic


### PR DESCRIPTION
Stacked PRs:
 * #3580
 * __->__#3564


--- --- ---

### Reject Metal tile thread axes whose extent is not static


thread_block_sizes records an extent only when it is an int, and
launcher_keyword_args turns what it recorded into the literal _block_dims. An
extent it could not resolve is dropped rather than reported, so the axis is
launched one thread wide while its index expression is still offset + tid, and
every tile is computed in its first row alone. Measured with this rejection
removed: 98% and 94% of the output wrong, silently, on the two ND shapes the
new test covers.

This is a gap in Helion's Metal codegen, not a Metal limitation. A threadgroup
shape is a runtime MTLSize and default_metal_launcher already accepts one; the
shared TileStrategyDispatch already computes the host-side expressions in
thread_block_dim_exprs, which CuTe consumes and Metal does not. Wiring that
through would lift most of this restriction, so reject rather than silently
miscompile until it is done. Reduction-tier selection and MPP tile shapes need
static extents either way, being chosen during Python codegen rather than
printed into the shader.

Only a block size taken from a tensor extent under static_shapes=False reaches
this; a config-chosen one is always an int, which is why no existing kernel
changes.
