### PR TITLE
[cutedsl] Gate the dense flash softmax lowering on its schedule, not a seed match

### DIFF
--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -63,6 +63,7 @@ from .flash_schedule import FlashStatReleaseMapping
 from .flash_schedule import build_fa4_schedule
 from .flash_schedule import max_fa4_kv_depth
 from .flash_schedule import verify_flash_schedule
+from .flash_tuning import FLASH_FLOAT16_MAX_LOG2
 from .flash_tuning import FlashCausalSeedTemplate
 from .flash_tuning import FlashPackedExp2Mode
 from .flash_tuning import FlashSoftmaxLowering
@@ -3785,19 +3786,67 @@ def _flash_config_matches_tuning_values(
     return all(actual.get(key) == value for key, value in expected.items())
 
 
-def _flash_dense_target_seed_matches(
+def _flash_fitted_probability_log2_shift(shift: int, rescale_threshold: float) -> int:
+    """Return the largest legal probability shift at ``rescale_threshold``.
+
+    The specialized dense bodies store probabilities pre-scaled by
+    ``2**shift``, and alpha-pinning lets a stored probability reach
+    ``2**(shift + rescale_threshold)``, which has to stay inside fp16. Shrink
+    the shift to fit instead of abandoning the lowering: a shift of 0 is the
+    original unshifted body, so every threshold stays expressible.
+    """
+    headroom = int(math.floor(FLASH_FLOAT16_MAX_LOG2 - rescale_threshold))
+    return max(0, min(shift, headroom))
+
+
+def _flash_dense_lowering_schedule_supported(
     cfg: FlashAttentionConfig,
     policy: FlashDenseTuningPolicy | None,
 ) -> bool:
-    """Return whether ``cfg`` is the validated target-promoted dense seed."""
+    """Return whether ``cfg``'s schedule can host the policy's dense lowering.
+
+    The specialized dense bodies (resident value graph, packed f16x2 exp2)
+    replace the whole per-KV softmax value graph, so they need the surrounding
+    FA4 schedule to supply exactly the barrier protocol, TMEM repetitions and
+    statistics handoff they were written against. Only those structural
+    requirements belong here.
+
+    In particular this must NOT require ``cfg`` to equal the promoted seed
+    field for field. Doing that turns every neighbour of the seed into a
+    silent fallback to the standard body, which measured ~14% slower on
+    ``2x32x32768x64`` fp16 -- a cliff the autotuner cannot climb out of, so the
+    search converges back onto the seed no matter how long it runs.
+    """
     if policy is None:
         return False
-    return _flash_config_matches_tuning_values(
-        cfg,
-        {
-            **_flash_dense_tuning_overrides(policy),
-            FLASH_Q_TILE_COUNT_KEY: 2,
-        },
+    lowering = policy.softmax_lowering
+    packed = policy.packed_exp2_mode
+    if (
+        lowering is FlashSoftmaxLowering.STANDARD
+        and packed is FlashPackedExp2Mode.DISABLED
+    ):
+        return False
+    if not (
+        cfg.pipeline_family == "fa4_2cta"
+        and not cfg.persistent
+        and cfg.q_tile_count == 2
+        and cfg.split_p_arrive
+        and cfg.exp2_impl == "split"
+        # Both bodies are whole-row value graphs; the chunked ("disc") body
+        # runs a different barrier protocol.
+        and not cfg.softmax_disc
+        and cfg.sp_row_sum == "whole"
+        and cfg.e2e_schedule != "xu"
+        # Both bodies pin alpha, so the rescale-skip lever must be armed.
+        and cfg.rescale_threshold > 0.0
+    ):
+        return False
+    if lowering is FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH:
+        # The resident value graph acknowledges the statistics slot per KV
+        # tile, which is the ``single`` transport's protocol.
+        return cfg.stat_transport == "single"
+    return cfg.stat_transport in ("single", "single_final") and (
+        cfg.exp2_packet in _FLASH_DEG1_EXP2_PACKETS
     )
 
 
@@ -7112,7 +7161,9 @@ def emit_flash_fa4_device_body(
     probability_log2_shift = (
         dense_tuning.probability_log2_shift if dense_tuning is not None else 0
     )
-    dense_seed_matches = _flash_dense_target_seed_matches(cfg, dense_tuning)
+    dense_lowering_schedule_ok = _flash_dense_lowering_schedule_supported(
+        cfg, dense_tuning
+    )
     dense_softmax_lowering = (
         dense_tuning.softmax_lowering
         if dense_tuning is not None
@@ -7125,9 +7176,11 @@ def emit_flash_fa4_device_body(
     )
     dense_target_lowering_applies = (
         dense_tuning is not None
-        and dense_seed_matches
+        and dense_lowering_schedule_ok
         and not is_causal
         and not has_lse
+        # Both bodies read the score tile through the whole-row TMEM reduction.
+        and use_tmem_row_reduce
         and cfg.use_2cta_instrs
         and not cfg.separate_kv_rings
         and not cfg.softmax_disc
@@ -7210,7 +7263,9 @@ def emit_flash_fa4_device_body(
         and cfg.exp2_packet in _FLASH_DEG1_EXP2_PACKETS
     )
     effective_probability_log2_shift = (
-        probability_log2_shift
+        _flash_fitted_probability_log2_shift(
+            probability_log2_shift, cfg.rescale_threshold
+        )
         if use_packed_f16x2_xu or dense_resident_value_graph_candidate
         else 0
     )

--- a/helion/_compiler/cute/flash_tuning.py
+++ b/helion/_compiler/cute/flash_tuning.py
@@ -52,7 +52,8 @@ _FLASH_POLICY_FP16_HD64_PIPELINE_FAMILIES = frozenset(
 _FLASH_POLICY_ROLE_MAPS = frozenset({"helion", "fa4"})
 _FLASH_POLICY_BASE_EXP2_PACKETS = frozenset({"1x1", "4x1", "4x2", "8x1", "8x2"})
 _FLASH_POLICY_DEGREE1_EXP2_PACKETS = frozenset({"deg1_16x8", "deg1_8x2_corr10"})
-_FLASH_FLOAT16_MAX_LOG2 = math.log2(65504.0)
+FLASH_FLOAT16_MAX_LOG2 = math.log2(65504.0)
+_FLASH_FLOAT16_MAX_LOG2 = FLASH_FLOAT16_MAX_LOG2
 
 
 def _validate_policy_choice(name: str, value: str, choices: frozenset[str]) -> None:

--- a/test/test_cute_flash_exp2.py
+++ b/test/test_cute_flash_exp2.py
@@ -929,8 +929,24 @@ def test_degree2_packet_emits_exact_causal_pass2_arguments() -> None:
         )
 
 
-def test_sm103_packed_f16x2_rewrite_requires_exact_promoted_seed() -> None:
-    intermediate_source = _emit_dense_resident_value_graph_source(
+def test_sm103_packed_f16x2_rewrite_follows_the_schedule_not_the_seed() -> None:
+    """The packed rewrite tracks the schedule's preconditions, not a seed match.
+
+    It survives a config that walks off the promoted seed in a field the
+    lowering does not depend on, and it turns off when the config breaks a
+    field it does depend on. A KV size the policy does not name still gets the
+    standard body, because the lowering choice itself is still policy-owned.
+    """
+    promoted_source = _emit_dense_resident_value_graph_source(num_kv=2048)
+    off_seed_source = _emit_dense_resident_value_graph_source(
+        num_kv=2048,
+        config_overrides={cute_flash.FLASH_E2E_OFFSET0_KEY: 9},
+    )
+    broken_precondition_source = _emit_dense_resident_value_graph_source(
+        num_kv=2048,
+        config_overrides={cute_flash.FLASH_SP_ROW_SUM_KEY: "fragment"},
+    )
+    unseeded_source = _emit_dense_resident_value_graph_source(
         num_kv=384,
         config_overrides={
             cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_2cta",
@@ -939,25 +955,28 @@ def test_sm103_packed_f16x2_rewrite_requires_exact_promoted_seed() -> None:
             cute_flash.FLASH_Q_TILE_COUNT_KEY: 2,
         },
     )
-    manual_source = _emit_dense_resident_value_graph_source(
-        num_kv=2048,
-        config_overrides={cute_flash.FLASH_E2E_OFFSET0_KEY: 9},
-    )
-    promoted_source = _emit_dense_resident_value_graph_source(num_kv=2048)
 
-    assert "f16x2_xu=True" not in intermediate_source
-    assert "f16x2_xu=True" not in manual_source
     assert "f16x2_xu=True" in promoted_source
+    assert "f16x2_xu=True" in off_seed_source
+    assert "f16x2_xu=True" not in broken_precondition_source
+    assert "f16x2_xu=True" not in unseeded_source
 
 
-def test_sm103_scaled_all_xu_codegen_requires_exact_rescale_threshold() -> None:
+def test_sm103_scaled_all_xu_probability_shift_fits_the_rescale_threshold() -> None:
+    """The stored probability shift shrinks to fit fp16 instead of bailing out.
+
+    A pinned probability reaches ``2**(shift + rescale_threshold)``, so the
+    policy's shift of 7 only fits up to a threshold of 8. Raising the threshold
+    lowers the shift and keeps the packed body; it must not silently drop back
+    to the standard body, which costs ~14% on GB300.
+    """
     all_xu_source = _emit_dense_resident_value_graph_source(num_kv=2048)
-    overflow_source = _emit_dense_resident_value_graph_source(
+    raised_source = _emit_dense_resident_value_graph_source(
         num_kv=2048,
-        config_overrides={cute_flash.FLASH_RESCALE_THRESHOLD_KEY: 9.0},
+        config_overrides={cute_flash.FLASH_RESCALE_THRESHOLD_KEY: 12.0},
     )
     all_xu_module = ast.parse(all_xu_source)
-    overflow_module = ast.parse(overflow_source)
+    raised_module = ast.parse(raised_source)
 
     def _pass2_calls(module: ast.Module) -> list[ast.Call]:
         return [
@@ -969,9 +988,9 @@ def test_sm103_scaled_all_xu_codegen_requires_exact_rescale_threshold() -> None:
         ]
 
     all_xu_calls = _pass2_calls(all_xu_module)
-    overflow_calls = _pass2_calls(overflow_module)
-    assert len(all_xu_calls) == len(overflow_calls) == 2
-    for call in all_xu_calls:
+    raised_calls = _pass2_calls(raised_module)
+    assert len(all_xu_calls) == len(raised_calls) == 2
+    for call in all_xu_calls + raised_calls:
         assert [ast.literal_eval(call.args[index]) for index in (6, 7, 8)] == [
             16,
             0,
@@ -984,10 +1003,14 @@ def test_sm103_scaled_all_xu_codegen_requires_exact_rescale_threshold() -> None:
     assert (
         "cutlass.Float32(7.0) - flash_row_max_safe * _flash_scale_log2" in all_xu_source
     )
-    for call in overflow_calls:
-        assert [ast.literal_eval(call.args[index]) for index in (6, 7)] == [16, 8]
-        assert not any(keyword.arg == "f16x2_xu" for keyword in call.keywords)
-    assert "cutlass.Float32(7.0)" not in overflow_source
+    # 3 + 12 == 15 < log2(65504); 7 + 12 would not fit.
+    assert (
+        "cutlass.Float32(3.0) - flash_row_max_safe * _flash_scale_log2" in raised_source
+    )
+    assert cute_flash._flash_fitted_probability_log2_shift(7, 12.0) == 3
+    assert cute_flash._flash_fitted_probability_log2_shift(7, 8.0) == 7
+    assert cute_flash._flash_fitted_probability_log2_shift(7, 0.0) == 7
+    assert cute_flash._flash_fitted_probability_log2_shift(7, 16.0) == 0
 
 
 def test_dense_target_seed_match_ignores_conflicting_environment() -> None:
@@ -1008,7 +1031,7 @@ def test_dense_target_seed_match_ignores_conflicting_environment() -> None:
         )
         policy = get_flash_target_policy((10, 3)).tuning.dense_policy(256)
         assert dense_cfg.wait_hint == 10000000
-        assert cute_flash._flash_dense_target_seed_matches(dense_cfg, policy)
+        assert cute_flash._flash_dense_lowering_schedule_supported(dense_cfg, policy)
 
 
 def test_dense_resident_value_graph_codegen_and_barrier_protocol() -> None:
@@ -1130,13 +1153,40 @@ def test_dense_resident_value_graph_gate_preserves_fallbacks() -> None:
         _emit_dense_resident_value_graph_source(num_kv=2048),
         _emit_dense_resident_value_graph_source(has_lse=True),
         _emit_dense_resident_value_graph_source(score_plan=modified_plan),
+        # Schedule fields the resident body depends on.
         _emit_dense_resident_value_graph_source(
-            config_overrides={cute_flash.FLASH_E2E_OFFSET_KEY: 4}
+            config_overrides={cute_flash.FLASH_SPLIT_P_ARRIVE_KEY: False}
+        ),
+        _emit_dense_resident_value_graph_source(
+            config_overrides={cute_flash.FLASH_RESCALE_THRESHOLD_KEY: 0.0}
         ),
     )
     for fallback_source in fallback_sources:
         assert "resident_softmax_value_graph" not in fallback_source
         assert "fa4_sp_exp_convert_store_whole_rowsum" in fallback_source
+
+    # The whole-row statistics protocol is also a dependency, but selecting the
+    # fragment row sum picks a different pass-2 body, not the whole-row one.
+    fragment_source = _emit_dense_resident_value_graph_source(
+        config_overrides={cute_flash.FLASH_SP_ROW_SUM_KEY: "fragment"}
+    )
+    assert "resident_softmax_value_graph" not in fragment_source
+    assert "fa4_sp_exp_convert_store_whole_rowsum" not in fragment_source
+
+    # A field the resident body does NOT depend on must keep the lowering: the
+    # exact-seed gate this replaced made every such neighbour ~14% slower and
+    # pinned the autotuner to the seed.
+    for neighbour in (
+        {cute_flash.FLASH_E2E_OFFSET_KEY: 4},
+        {cute_flash.FLASH_KV_STAGE_KEY: 5},
+        {cute_flash.FLASH_CORR_TILE_SIZE_KEY: 16},
+        {cute_flash.FLASH_SOFTMAX_REGS_KEY: 184},
+        {cute_flash.FLASH_ROLE_MAP_KEY: "fa4"},
+    ):
+        neighbour_source = _emit_dense_resident_value_graph_source(
+            config_overrides=neighbour
+        )
+        assert "resident_softmax_value_graph" in neighbour_source, neighbour
 
 
 def test_dense_resident_softmax_lowering_dispatch_is_exhaustive() -> None:


### PR DESCRIPTION
Stacked PRs:
 * #3579
 * #3578
 * #3577
 * #3576
 * #3575
 * #3574
 * __->__#3573
 * #3572
 * #3571


--- --- ---

### [cutedsl] Gate the dense flash softmax lowering on its schedule, not a seed match


The resident-value-graph dense softmax was enabled by comparing the config
against a byte-exact copy of the shipped seed. Any knob the autotuner moved --
even one the lowering does not depend on -- silently dropped it back to the
standard lowering, so the search saw a cliff instead of a gradient and could
never explore around the seed.

Replace the seed match with the preconditions the lowering actually has: the
fa4/fa4_2cta family, non-persistent, two query tiles, a split P arrive, the
split exp2 implementation, whole-row softmax, a non-xu end-to-end schedule and
a live rescale threshold. Everything else is now free for the autotuner.

The probability shift was likewise pinned to the seed's literal value. Fit it
to the rescale threshold instead, so a config that moves the threshold gets
the shift that threshold implies rather than one that no longer matches it.