### PR TITLE
[cutedsl] Run the dense resident softmax on the one-CTA FA4 pipeline

### DIFF
--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -3799,6 +3799,16 @@ def _flash_fitted_probability_log2_shift(shift: int, rescale_threshold: float) -
     return max(0, min(shift, headroom))
 
 
+# FA4 pipeline families whose barrier graph the specialized dense softmax
+# bodies can run under. The bodies themselves are CTA-count agnostic -- the
+# causal resident lowering already runs on a one-CTA pipeline -- so the only
+# requirement is the plain FA4 topology without a separate K/V ring, CGA2
+# pairing or the CLC scheduler.
+_FLASH_DENSE_LOWERING_FAMILIES = frozenset(
+    {"fa4", "fa4_2cta", "fa4_tma_4d", "fa4_2cta_tma_4d"}
+)
+
+
 def _flash_dense_lowering_schedule_supported(
     cfg: FlashAttentionConfig,
     policy: FlashDenseTuningPolicy | None,
@@ -3827,7 +3837,7 @@ def _flash_dense_lowering_schedule_supported(
     ):
         return False
     if not (
-        cfg.pipeline_family == "fa4_2cta"
+        cfg.pipeline_family in _FLASH_DENSE_LOWERING_FAMILIES
         and not cfg.persistent
         and cfg.q_tile_count == 2
         and cfg.split_p_arrive
@@ -7181,7 +7191,6 @@ def emit_flash_fa4_device_body(
         and not has_lse
         # Both bodies read the score tile through the whole-row TMEM reduction.
         and use_tmem_row_reduce
-        and cfg.use_2cta_instrs
         and not cfg.separate_kv_rings
         and not cfg.softmax_disc
         and cfg.p_store_repetition == 16
@@ -9465,7 +9474,7 @@ if warp_idx == 15:
                 f""",
                 pfor_peer_cta_rank=cutlass.Int32(0),
                 pfor_self_cta_rank={pfor_self_cta_rank}"""
-                if dense_resident_value_graph_candidate
+                if dense_resident_value_graph_candidate and use_2cta_instrs
                 else ""
             )
             sp_exp_block = f"""            flash_row_sum = _helion_flash_rt.resident_softmax_value_graph(

--- a/test/test_cute_flash_exp2.py
+++ b/test/test_cute_flash_exp2.py
@@ -1189,6 +1189,41 @@ def test_dense_resident_value_graph_gate_preserves_fallbacks() -> None:
         assert "resident_softmax_value_graph" in neighbour_source, neighbour
 
 
+def test_dense_resident_value_graph_runs_on_the_one_cta_pipeline() -> None:
+    """The resident body is CTA-count agnostic, like the causal one already is.
+
+    Restricting it to fa4_2cta left the whole one-CTA family on the standard
+    body, which measured 16.4 ms against 13.4 ms on GB300 dense
+    2x32x32768x64 fp16. The peer-rank handshake is the only two-CTA detail and
+    must drop out for one CTA.
+    """
+    two_cta = _emit_dense_resident_value_graph_source()
+    one_cta = _emit_dense_resident_value_graph_source(
+        config_overrides={cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4"}
+    )
+
+    assert "resident_softmax_value_graph" in two_cta
+    assert "resident_softmax_value_graph" in one_cta
+    assert "pfor_peer_cta_rank" in two_cta
+    assert "pfor_peer_cta_rank" not in one_cta
+
+    # The 4D tensor-map variants only change how TMA descriptors are built.
+    for family in ("fa4_tma_4d", "fa4_2cta_tma_4d"):
+        source = _emit_dense_resident_value_graph_source(
+            config_overrides={cute_flash.FLASH_PIPELINE_FAMILY_KEY: family}
+        )
+        assert "resident_softmax_value_graph" in source, family
+
+    # Families whose barrier graph the body was not written against keep the
+    # standard lowering. (fa4_clc is not in this list: with a nonpersistent
+    # config the resolver canonicalizes it back to plain fa4.)
+    for family in ("fa4_deep_1cta", "fa4_cga2_local"):
+        source = _emit_dense_resident_value_graph_source(
+            config_overrides={cute_flash.FLASH_PIPELINE_FAMILY_KEY: family}
+        )
+        assert "resident_softmax_value_graph" not in source, family
+
+
 def test_dense_resident_softmax_lowering_dispatch_is_exhaustive() -> None:
     policy = get_flash_target_policy((10, 3)).tuning
     shape_policy = policy.dense_policy(256)


### PR DESCRIPTION
Stacked PRs:
 * #3579
 * #3578
 * #3577
 * #3576
 * #3575
 * __->__#3574
 * #3573
 * #3572
 * #3571


--- --- ---

### [cutedsl] Run the dense resident softmax on the one-CTA FA4 pipeline


The resident-value-graph dense lowering was reachable only under CtaGroup.TWO,
because that is what the seed happened to use. Nothing in the lowering needs
the 2-CTA MMA: the value graph is per-CTA. Allow it on the one-CTA pipeline
too, which is what the dense shapes actually want on sm_103 -- the 2-CTA
pipeline pays a cluster barrier per KV tile that the dense schedule cannot
hide.