### PR TITLE
[cutedsl] Make the flash KV tile width a real dimension

### DIFF
--- a/helion/_compiler/cute/_flash_runtime.py
+++ b/helion/_compiler/cute/_flash_runtime.py
@@ -84,6 +84,7 @@ def flash_fa4_shared_storage(
     use_clc_scheduler: bool = False,
     clc_stages: int = 1,
     separate_kv: bool = False,
+    kv_tile_n: int = 128,
 ) -> type:
     """FA4-topology SharedStorage (faithful port of the spike struct).
 
@@ -130,10 +131,10 @@ def flash_fa4_shared_storage(
                 cute.struct.MemRange[dtype, 128 * head_dim * q_stage], 1024
             ]
             sK: cute.struct.Align[
-                cute.struct.MemRange[dtype, 128 * head_dim * kv_stage], 1024
+                cute.struct.MemRange[dtype, kv_tile_n * head_dim * kv_stage], 1024
             ]
             sV: cute.struct.Align[
-                cute.struct.MemRange[dtype, 128 * head_dim * kv_stage], 1024
+                cute.struct.MemRange[dtype, kv_tile_n * head_dim * kv_stage], 1024
             ]
             sO: cute.struct.Align[cute.struct.MemRange[dtype, separate_o_size], 1024]
 
@@ -171,7 +172,7 @@ def flash_fa4_shared_storage(
                 cute.struct.MemRange[dtype, 128 * head_dim * q_stage], 1024
             ]
             sK: cute.struct.Align[
-                cute.struct.MemRange[dtype, 128 * head_dim * kv_stage], 1024
+                cute.struct.MemRange[dtype, kv_tile_n * head_dim * kv_stage], 1024
             ]
             sO: cute.struct.Align[cute.struct.MemRange[dtype, 128 * head_dim * 2], 1024]
 
@@ -206,7 +207,7 @@ def flash_fa4_shared_storage(
             cute.struct.MemRange[dtype, 128 * head_dim * q_stage], 1024
         ]
         sK: cute.struct.Align[
-            cute.struct.MemRange[dtype, 128 * head_dim * kv_stage], 1024
+            cute.struct.MemRange[dtype, kv_tile_n * head_dim * kv_stage], 1024
         ]
 
     return SharedStorage

--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -1631,6 +1631,54 @@ class FlashAttentionConfig:
     # Causal descending KV can run the short masked diagonal prefix separately
     # from the hot unmasked suffix, removing a per-KV branch from most tiles.
     causal_loop_split: bool = False
+    # KV tile width for the FA4 score/probability tile. 128 is the historical
+    # fixed value. A wider tile amortizes the per-KV-tile softmax correction --
+    # which sits on the critical path -- over more columns; FA4's tuned sm_103
+    # plans all use 160 and gain ~9.6% from it. Legality: a multiple of 32 that
+    # keeps two S buffers plus two O buffers inside 512 TMEM columns, and (until
+    # the masked tail tile lands) one that divides the sequence.
+    kv_tile_n: int = 128
+
+
+# TMEM is 512 columns. The FA4 score pipeline holds ``s_stage`` score buffers of
+# ``kv_tile_n`` columns plus two ``head_dim``-wide output accumulators.
+FLASH_TMEM_COLUMNS = 512
+FLASH_KV_TILE_N_CHOICES = (128, 160, 192)
+
+
+def _flash_kv_tile_n_fits_tmem(kv_tile_n: int, head_dim: int, s_stage: int) -> bool:
+    """Return whether the score and output accumulators fit in TMEM."""
+    return s_stage * kv_tile_n + 2 * head_dim <= FLASH_TMEM_COLUMNS
+
+
+def _flash_kv_tile_n_supported(
+    kv_tile_n: int,
+    *,
+    head_dim: int,
+    num_kv: int,
+    topology: str,
+    is_causal: bool,
+    s_stage: int,
+    desc_kv: bool = True,
+) -> bool:
+    """Return whether a non-default KV tile width is legal for this shape.
+
+    ``kv_tile_n`` must be a tcgen05-legal MMA N and must leave the score and
+    output accumulators inside TMEM. A width that does not divide the sequence
+    is allowed: the trailing partial tile is masked, which needs the descending
+    KV order that puts it first. Causal keeps the default width because its
+    diagonal masking is written against 128-column tiles.
+    """
+    if kv_tile_n == 128:
+        return True
+    if kv_tile_n not in FLASH_KV_TILE_N_CHOICES or kv_tile_n % 32:
+        return False
+    if is_causal or topology != "fa4":
+        return False
+    if not _flash_kv_tile_n_fits_tmem(kv_tile_n, head_dim, s_stage):
+        return False
+    sequence_extent = num_kv * 128
+    return sequence_extent % kv_tile_n == 0 or desc_kv
 
 
 def _flash_bool_env(name: str, default: bool) -> bool:
@@ -3190,6 +3238,21 @@ def resolve_flash_config(
     if epi_tma_setup not in ("shared", "role_local") or not epi_tma_setup_eligible:
         epi_tma_setup = "shared"
 
+    kv_tile_n = int(_flash_env_get("HELION_CUTE_FLASH_KV_TILE_N", "128") or "128")
+    kv_tile_n_cfg = _cfg(FLASH_KV_TILE_N_KEY)
+    if kv_tile_n_cfg is not None:
+        kv_tile_n = int(cast("int", kv_tile_n_cfg))
+    if not _flash_kv_tile_n_supported(
+        kv_tile_n,
+        head_dim=head_dim,
+        num_kv=num_kv,
+        topology=topology,
+        is_causal=is_causal,
+        s_stage=s_stage,
+        desc_kv=kv_order == "descending",
+    ):
+        kv_tile_n = 128
+
     if exp2_packet in _FLASH_CAUSAL_HD128_RESIDENT_EXP2_PACKETS and (
         pipeline_family != "fa4" or not causal_loop_split
     ):
@@ -3268,6 +3331,7 @@ def resolve_flash_config(
         local_tma_partition=local_tma_partition,
         tensor_4d_tma=tensor_4d_tma,
         causal_loop_split=causal_loop_split,
+        kv_tile_n=kv_tile_n,
     )
 
 
@@ -3345,6 +3409,7 @@ FLASH_CAUSAL_LOOP_SPLIT_KEY = "cute_flash_causal_loop_split"
 FLASH_PERSISTENT_LOOP_KEY = "cute_flash_persistent_loop"
 FLASH_SP_ROW_SUM_KEY = "cute_flash_sp_row_sum"
 FLASH_SOFTMAX_SETUP_KEY = "cute_flash_softmax_setup"
+FLASH_KV_TILE_N_KEY = "cute_flash_kv_tile_n"
 FLASH_EPI_TMA_SETUP_KEY = "cute_flash_epi_tma_setup"
 
 
@@ -3438,6 +3503,7 @@ FLASH_AUTOTUNE_CONFIG_KEYS: tuple[str, ...] = (
     FLASH_SP_ROW_SUM_KEY,
     FLASH_SOFTMAX_SETUP_KEY,
     FLASH_EPI_TMA_SETUP_KEY,
+    FLASH_KV_TILE_N_KEY,
 )
 
 FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS: tuple[str, ...] = (
@@ -3519,6 +3585,7 @@ def flash_effective_config_values(
         FLASH_SP_ROW_SUM_KEY: config.sp_row_sum,
         FLASH_SOFTMAX_SETUP_KEY: config.softmax_setup,
         FLASH_EPI_TMA_SETUP_KEY: config.epi_tma_setup,
+        FLASH_KV_TILE_N_KEY: config.kv_tile_n,
     }
 
 
@@ -4987,7 +5054,17 @@ def flash_autotune_fragments(
         else ("shared",),
     )
 
+    # A wider KV tile amortizes the per-tile softmax correction over more
+    # columns. The choice set is deliberately length-independent: which widths
+    # are *legal* depends on the sequence (a width that does not divide it needs
+    # the masked tail tile), and letting that leak into the search surface would
+    # make the surface length-dependent, which this design forbids. The resolver
+    # clamps an illegal width back to 128. Only 128 is searched until the masked
+    # tail lands; a wider tile is reachable now through an explicit config.
+    kv_tile_n = enum(defaults.kv_tile_n, FLASH_KV_TILE_N_CHOICES, (128,))
+
     fragments: dict[str, ConfigSpecFragment] = {
+        FLASH_KV_TILE_N_KEY: kv_tile_n,
         FLASH_S_STAGE_KEY: s_stage,
         FLASH_KV_STAGE_KEY: kv_stage,
         FLASH_PERSISTENT_KEY: persistent,
@@ -7165,6 +7242,17 @@ def emit_flash_fa4_device_body(
         split_range_proof=causal_split_proof,
         query_slots_per_cta=q_stage,
     )
+    # KV tile width for the score/probability tile. The resolver already
+    # clamped an illegal request back to the historical 128. A width that does
+    # not divide the sequence leaves a partial trailing tile whose out-of-range
+    # columns must be masked to -inf before the row max.
+    kv_n = cfg.kv_tile_n
+    # ``num_kv`` counts default-width tiles and is the shape key the tuning
+    # policy is indexed by; the actual trip count follows the configured width.
+    kv_tile_count = -(-sequence_extent // kv_n)
+    kv_tail_cols = sequence_extent - (kv_tile_count - 1) * kv_n
+    assert 0 < kv_tail_cols <= kv_n
+    has_kv_tail = kv_tail_cols != kv_n
     dense_tuning = (
         tuning_policy.dense_policy(num_kv) if tuning_policy is not None else None
     )
@@ -7336,6 +7424,7 @@ def emit_flash_fa4_device_body(
                     stat_depth=1 if fa4_stat_handoff else 2,
                     pipelined_stat_handoff=acknowledged_stat_pipeline,
                     final_only_stat_handoff=final_only_stat_pipeline,
+                    kv_tile_n=kv_n,
                 )
             )
         )
@@ -7360,6 +7449,7 @@ def emit_flash_fa4_device_body(
                     stat_depth=1 if fa4_stat_handoff else 2,
                     pipelined_stat_handoff=acknowledged_stat_pipeline,
                     final_only_stat_handoff=final_only_stat_pipeline,
+                    kv_tile_n=kv_n,
                 )
             )
         )
@@ -7509,8 +7599,7 @@ def emit_flash_fa4_device_body(
     epi_smem = cfg.epi_tma or cfg.epi_stg
     role_chain = cfg.role_chain
     storage_extra_args = f", {epi_smem!s}, {use_clc_scheduler!s}, {cfg.clc_stages}"
-    if separate_kv_rings:
-        storage_extra_args += ", True"
+    storage_extra_args += f", {separate_kv_rings!s}, {kv_n}"
     prefetch_epi_tma = (
         "\n    cute_cpasync_flash.prefetch_descriptor(_flash_tma_o)"
         if cfg.epi_tma
@@ -7771,9 +7860,9 @@ flash_P_STORE32_CHUNKS = cute.size(tST32tS0, mode=[2])"""
         ""
         if use_local_tma_partition
         else f"""
-gQ = cute.flat_divide(_flash_mQt, cute.select(({mma_m}, 128, {hd}), mode=[0, 2]))
-gK = cute.flat_divide(_flash_mKt, cute.select(({mma_m}, 128, {hd}), mode=[1, 2]))
-gV = cute.flat_divide(_flash_mVt, cute.select(({mma_m}, {hd}, 128), mode=[1, 2]))
+gQ = cute.flat_divide(_flash_mQt, cute.select(({mma_m}, {kv_n}, {hd}), mode=[0, 2]))
+gK = cute.flat_divide(_flash_mKt, cute.select(({mma_m}, {kv_n}, {hd}), mode=[1, 2]))
+gV = cute.flat_divide(_flash_mVt, cute.select(({mma_m}, {hd}, {kv_n}), mode=[1, 2]))
 tSgQ = flash_qkt.partition_A(gQ)
 tSgK = flash_qkt.partition_B(gK)
 tOgV = flash_pvt.partition_B(gV)
@@ -7897,7 +7986,7 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
 {setup_tma_partitions}
     """
 
-    tmem_fragment_setup = f"""    flash_qk_acc_shape = flash_qkt.partition_shape_C(({mma_m}, 128))
+    tmem_fragment_setup = f"""    flash_qk_acc_shape = flash_qkt.partition_shape_C(({mma_m}, {kv_n}))
     tStS = flash_qkt.make_fragment_C(flash_qk_acc_shape)
     flash_pv_acc_shape = flash_pvt.partition_shape_C(({mma_m}, {hd}))
     tOtO = flash_pvt.make_fragment_C(flash_pv_acc_shape)
@@ -7906,9 +7995,9 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
         2, 13 * 32)
     flash_tmem_ptr = flash_tmem.retrieve_ptr(cutlass.Float32)
     tStS0_full = cute.make_tensor(flash_tmem_ptr, tStS.layout)
-    tStS1_full = cute.make_tensor(flash_tmem_ptr + 128, tStS.layout)
-    tOtO0_full = cute.make_tensor(flash_tmem_ptr + 256, tOtO.layout)
-    tOtO1_full = cute.make_tensor(flash_tmem_ptr + {256 + hd}, tOtO.layout)
+    tStS1_full = cute.make_tensor(flash_tmem_ptr + {kv_n}, tStS.layout)
+    tOtO0_full = cute.make_tensor(flash_tmem_ptr + {2 * kv_n}, tOtO.layout)
+    tOtO1_full = cute.make_tensor(flash_tmem_ptr + {2 * kv_n + hd}, tOtO.layout)
 {textwrap.indent(tmem_local_views.strip(), "    ")}
 """
     tmem_mma_setup = (
@@ -7952,7 +8041,7 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
     )
     tmem_softmax_setup = (
         tmem_base_setup
-        + f"""    cS = cute.make_identity_tensor((128, 128))
+        + f"""    cS = cute.make_identity_tensor((128, {kv_n}))
     tScS = flash_qkt.partition_C(cS)
     flash_ld_atom = cute.make_copy_atom(
         cute_tcgen05_flash.{flash_ld_op}(cute_tcgen05_flash.Repetition({
@@ -7970,7 +8059,7 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
 
     # Staged-P store atom repetition is autotuned. Rep16 preserves the original
     # 4-chunk FA4 granularity; Rep32 halves the P r2t chunk count on hd64.
-    flash_tilePlikeFP32 = 128 // cutlass.Float32.width * {io_dtype}.width
+    flash_tilePlikeFP32 = {kv_n} // cutlass.Float32.width * {io_dtype}.width
     flash_P_layout = cute.composition(
         tStS.layout, cute.make_layout((128, flash_tilePlikeFP32)))
     tStS0_P = cute.make_tensor({p0_store_iter}, flash_P_layout)
@@ -8008,7 +8097,7 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
     ) and not mixed_p_store
 
     def _tmem_softmax_setup_stage(stage: str) -> str:
-        ptr_expr = "flash_tmem_ptr" if stage == "0" else "flash_tmem_ptr + 128"
+        ptr_expr = "flash_tmem_ptr" if stage == "0" else f"flash_tmem_ptr + {kv_n}"
         p_store_iter = p0_store_iter if stage == "0" else p1_store_iter
         stage_score_store_setup = ""
         if score_store_needed:
@@ -8044,10 +8133,10 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
         return f"""    _helion_flash_rt.named_barrier_wait_unaligned(
         2, 13 * 32)
     flash_tmem_ptr = flash_tmem.retrieve_ptr(cutlass.Float32)
-    flash_qk_acc_shape = flash_qkt.partition_shape_C(({mma_m}, 128))
+    flash_qk_acc_shape = flash_qkt.partition_shape_C(({mma_m}, {kv_n}))
     tStS = flash_qkt.make_fragment_C(flash_qk_acc_shape)
     tStS{stage} = cute.make_tensor({ptr_expr}, tStS.layout)
-    cS = cute.make_identity_tensor((128, 128))
+    cS = cute.make_identity_tensor((128, {kv_n}))
     tScS = flash_qkt.partition_C(cS)
     flash_ld_atom = cute.make_copy_atom(
         cute_tcgen05_flash.{flash_ld_op}(cute_tcgen05_flash.Repetition({
@@ -8063,7 +8152,7 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
 
     # Staged-P store atom repetition is autotuned. Rep16 preserves the original
     # 4-chunk FA4 granularity; Rep32 halves the P r2t chunk count on hd64.
-    flash_tilePlikeFP32 = 128 // cutlass.Float32.width * {io_dtype}.width
+    flash_tilePlikeFP32 = {kv_n} // cutlass.Float32.width * {io_dtype}.width
     flash_P_layout = cute.composition(
         tStS.layout, cute.make_layout((128, flash_tilePlikeFP32)))
     tStS{stage}_P = cute.make_tensor({p_store_iter}, flash_P_layout)
@@ -8965,18 +9054,21 @@ if warp_idx == 15:
     else:
         sp_minus_max_scale = "(0.0 - flash_row_max_safe) * _flash_scale_log2"
     if cfg.rescale_threshold > 0.0:
-        sp_pin_condition = (
-            f"({softmax_not_first}) & (flash_acc_log >= -{cfg.rescale_threshold})"
-        )
-        _sp_alpha_pre = f"""            flash_acc_log = _flash_scale_log2 * (flash_old_row_max - flash_row_max_safe)
+
+        def _sp_alpha_pre_for(not_first: str) -> str:
+            pin = f"({not_first}) & (flash_acc_log >= -{cfg.rescale_threshold})"
+            return f"""            flash_acc_log = _flash_scale_log2 * (flash_old_row_max - flash_row_max_safe)
             flash_alpha = cute.math.exp2(flash_acc_log, fastmath=True)
-            if {sp_pin_condition}:
+            if {pin}:
                 flash_row_max = flash_old_row_max
                 flash_row_max_safe = flash_old_row_max
                 flash_alpha = cutlass.Float32(1.0)
             flash_minus_max_scale = {sp_minus_max_scale}"""
+
+        _sp_alpha_pre = _sp_alpha_pre_for(softmax_not_first)
         _sp_alpha_post = ""
     else:
+        _sp_alpha_pre_for = None  # type: ignore[assignment]
         _sp_alpha_pre = f"            flash_minus_max_scale = {sp_minus_max_scale}"
         _sp_alpha_post = """            flash_alpha = cute.math.exp2(
                 _flash_scale_log2 * (flash_old_row_max - flash_row_max_safe), fastmath=True)"""
@@ -9563,23 +9655,22 @@ if warp_idx == 15:
         else:
             sp_exp_block = softmax_exp_block
             sp_p_store_block = p_store_block
-        if not cfg.skip_rescale_stats:
+
+        def _sp_corr_publish_alpha_for(not_first: str) -> str:
+            if cfg.skip_rescale_stats:
+                return ""
             if acknowledged_stat_pipeline:
-                sp_corr_publish_alpha = f"""            if {softmax_not_first}:
+                return f"""            if {not_first}:
 {corr_publish_alpha}
             else:
 {corr_publish_dummy}"""
-            else:
-                sp_corr_publish_alpha = f"""            if {softmax_not_first}:
+            return f"""            if {not_first}:
 {corr_publish_alpha}"""
+
+        if not cfg.skip_rescale_stats:
+            sp_corr_publish_alpha = _sp_corr_publish_alpha_for(softmax_not_first)
         fa4_publish_alpha_before_exp = fa4_stat_handoff and (
             cfg.rescale_threshold > 0.0 or fa4_stat_pipeline
-        )
-        sp_alpha_publish_pre = (
-            sp_corr_publish_alpha if fa4_publish_alpha_before_exp else ""
-        )
-        sp_alpha_publish_post = (
-            "" if fa4_publish_alpha_before_exp else sp_corr_publish_alpha
         )
         fa4_entry_stat_acquire = (
             f"""        _helion_flash_rt.mbar_spin_wait(
@@ -9806,25 +9897,99 @@ if warp_idx == 15:
             if dense_resident_value_graph_candidate
             else _FLASH_ONLINE_STATISTICS_UPDATE
         )
-        iteration = _FlashOnlineSoftmaxIteration(
-            load_and_reduce=f"""            tLDrS = cute.make_rmem_tensor(tLDcS.shape, cutlass.Float32)
-{sp_score_load}
-{sp_rowmax}""",
-            alpha_pre_probability=_sp_alpha_pre,
-            alpha_publish_pre_probability=sp_alpha_publish_pre,
-            probability_update=sp_exp_block,
-            alpha_post_probability=_sp_alpha_post,
-            alpha_publish_post_probability=sp_alpha_publish_post,
-            statistics_acquire=post_p_stat_acquire,
-            statistics_update=statistics_update,
-            post_statistics=sp_p_store_block,
-        )
-        loop = _format_fa4_online_softmax_loop(
-            softmax_segment,
-            iteration,
-            stage=stage,
-            wait_hint=cfg.wait_hint,
-        )
+        # A KV tile width that does not divide the sequence leaves one partial
+        # trailing tile. Its out-of-range columns arrive as zeros (TMA
+        # zero-fills past the tensor extent), and a zero score is not a
+        # no-op: exp2(0 - max) contributes to the row sum. Mask them to -inf.
+        # The hardware TMEM row-reduce folds the max into the load, so the
+        # masked tile must use the plain load and reduce in software -- the
+        # same pair the causal diagonal already uses. Descending KV order puts
+        # the partial tile first, so it peels off as a one-iteration prefix.
+        if has_kv_tail:
+            assert desc_kv
+            # Reuse the ordinary load. When it carries the hardware row
+            # reduction the max it produces covers the out-of-range columns, so
+            # it is discarded and the row max is recomputed in software from
+            # the masked fragment.
+            tail_score_load = (
+                f"{sp_score_load}\n"
+                "            _helion_flash_rt.mask_r2p_sm100_rank1(\n"
+                f"                tLDrS, cutlass.Int32({kv_tail_cols}))"
+            )
+            tail_rowmax = (
+                "            flash_row_max = "
+                "_helion_flash_rt.fmax_reduce_packed(tLDrS, flash_row_max)"
+            )
+            tail_segment = _FlashSoftmaxLoopSegment(
+                loop_var="flash_kv_tail_iter",
+                loop_bound="cutlass.Int32(1)",
+                kv_expr=f"{kv_loop_bound} - cutlass.Int32(1)",
+            )
+            body_segment = _FlashSoftmaxLoopSegment(
+                loop_var="flash_kv_iter",
+                loop_bound=f"{kv_loop_bound} - cutlass.Int32(1)",
+                kv_expr=f"{kv_loop_bound} - cutlass.Int32(2) - flash_kv_iter",
+                continues_previous_segment=True,
+            )
+
+        def _dense_iteration(
+            score_load: str,
+            rowmax: str,
+            segment: _FlashSoftmaxLoopSegment | None = None,
+        ) -> _FlashOnlineSoftmaxIteration:
+            # A split loop has a different "is this the first KV tile" proof per
+            # segment, and both the alpha pin and the alpha publish depend on it.
+            not_first = None if segment is None else segment.not_first_condition
+            alpha_pre = (
+                _sp_alpha_pre
+                if not_first is None or _sp_alpha_pre_for is None
+                else _sp_alpha_pre_for(not_first)
+            )
+            publish = (
+                sp_corr_publish_alpha
+                if not_first is None
+                else _sp_corr_publish_alpha_for(not_first)
+            )
+            return _FlashOnlineSoftmaxIteration(
+                load_and_reduce=(
+                    "            tLDrS = cute.make_rmem_tensor("
+                    "tLDcS.shape, cutlass.Float32)\n"
+                    f"{score_load}\n{rowmax}"
+                ),
+                alpha_pre_probability=alpha_pre,
+                alpha_publish_pre_probability=(
+                    publish if fa4_publish_alpha_before_exp else ""
+                ),
+                probability_update=sp_exp_block,
+                alpha_post_probability=_sp_alpha_post,
+                alpha_publish_post_probability=(
+                    "" if fa4_publish_alpha_before_exp else publish
+                ),
+                statistics_acquire=post_p_stat_acquire,
+                statistics_update=statistics_update,
+                post_statistics=sp_p_store_block,
+            )
+
+        if has_kv_tail:
+            loop = "\n".join(
+                _format_fa4_online_softmax_loop(
+                    segment,
+                    _dense_iteration(score_load, rowmax, segment),
+                    stage=stage,
+                    wait_hint=cfg.wait_hint,
+                )
+                for segment, score_load, rowmax in (
+                    (tail_segment, tail_score_load, tail_rowmax),
+                    (body_segment, sp_score_load, sp_rowmax),
+                )
+            )
+        else:
+            loop = _format_fa4_online_softmax_loop(
+                softmax_segment,
+                _dense_iteration(sp_score_load, sp_rowmax),
+                stage=stage,
+                wait_hint=cfg.wait_hint,
+            )
         return f"""{
             fa4_entry_stat_acquire
         }        flash_row_max = cutlass.Float32(-cutlass.Float32.inf)
@@ -10971,6 +11136,7 @@ def codegen_attention_flash(cg: GenerateAST) -> bool:
         "batch": batch,
         "scale_log2": scale_log2,
         "kv_stage": cfg.kv_stage,
+        "kv_tile_n": cfg.kv_tile_n,
         "s_stage": cfg.s_stage,
         "persistent": cfg.persistent,
         "persistent_ctas_per_sm": cfg.persistent_ctas_per_sm,

--- a/helion/_compiler/cute/flash_schedule.py
+++ b/helion/_compiler/cute/flash_schedule.py
@@ -73,6 +73,9 @@ class FlashScheduleSpec:
     final_only_stat_handoff: bool = False
     stat_release_mapping: FlashStatReleaseMapping = FlashStatReleaseMapping.CROSS_SLOT
     query_slots_have_equal_kv_iterations: bool = False
+    # KV tile width. Only the K/V staging rings scale with it; the query and
+    # output tiles stay 128 rows wide.
+    kv_tile_n: int = 128
 
 
 @dataclasses.dataclass(frozen=True)
@@ -174,9 +177,10 @@ def _kv_node_name(kind: str, cta_rank: int, multicast: bool) -> str:
 
 def _shared_memory_bytes(spec: FlashScheduleSpec) -> int:
     tile_bytes = 128 * spec.head_dim * spec.dtype_bytes
+    kv_tile_bytes = spec.kv_tile_n * spec.head_dim * spec.dtype_bytes
     q_bytes = spec.query_slots_per_cta * tile_bytes
     kv_rings = 2 if spec.separate_kv else 1
-    kv_bytes = kv_rings * spec.kv_depth * tile_bytes
+    kv_bytes = kv_rings * spec.kv_depth * kv_tile_bytes
     output_bytes = spec.query_slots_per_cta * tile_bytes if spec.stage_output else 0
     # Scale/stat transport plus aligned barrier storage in the current FA4 layout.
     return q_bytes + kv_bytes + output_bytes + 3072

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -2106,15 +2106,18 @@ class PopulationBasedSearch(BaseSearch):
         )
         if warmup_ms <= 0:
             return
-        fn = next(
-            (member.fn for member in finalists if math.isfinite(member.perf)), None
+        member = next(
+            (member for member in finalists if math.isfinite(member.perf)), None
         )
-        if fn is None:
+        if member is None:
             return
+        # A member's ``fn`` is the compiled kernel, which still takes the
+        # kernel arguments; the benchmark paths bind them the same way.
+        run = functools.partial(member.fn, *self.args)
         deadline = time.perf_counter() + warmup_ms / 1000.0
         try:
             while time.perf_counter() < deadline:
-                fn()
+                run()
             synchronize_device()
         except Exception as warmup_error:
             self.log.warning(f"Final-verification warmup skipped: {warmup_error}")

--- a/helion/runtime/cute/launcher.py
+++ b/helion/runtime/cute/launcher.py
@@ -488,7 +488,11 @@ def _append_cute_wrapper_plan(
         use_cga2_local_cta = bool(plan.get("use_cga2_local_cta"))
         use_clc_scheduler = bool(plan.get("use_clc_scheduler"))
         cluster_m = 2 if use_2cta_instrs or use_cga2_local_cta else 1
-        num_kv = (seq + 127) // 128
+        # KV tile width. 128 is the historical fixed value; a wider tile
+        # amortizes the per-tile softmax correction over more columns, which is
+        # where FA4's tuned plans get their edge on sm_103.
+        kv_n = plan_int("kv_tile_n", default=128)
+        num_kv = (seq + kv_n - 1) // kv_n
         # Static-persistent scheduler: total_tiles = num_bh * num_m_tiles (the
         # flat tile-id space the device-body strided while loop walks). When
         # persistent, the host clamps grid_x down to min(total_tiles, num_SMs)
@@ -511,8 +515,8 @@ def _append_cute_wrapper_plan(
         # (S, D, H, Z), matching FA4's tensor-map rank for contiguous q[z,h,s,d].
         bw = "cutlass.utils.blackwell_helpers"
         mma_m = 256 if use_2cta_instrs else 128
-        qkd = f"({mma_m}, 128, {hd})"
-        pvd = f"({mma_m}, {hd}, 128)"
+        qkd = f"({mma_m}, {kv_n}, {hd})"
+        pvd = f"({mma_m}, {hd}, {kv_n})"
         if use_tensor_4d_tma:
             bh_stride = seq * hd
             batch_stride = tensor_4d_heads * bh_stride
@@ -549,7 +553,7 @@ def _append_cute_wrapper_plan(
             # V is MN-major: (D, S, B).
             f"_flash_mV = cute.make_tensor(arg{v_idx}.iterator, {dsb})",
             f"_flash_mO = cute.make_tensor(arg{o_idx}.iterator, {sdb})",
-            f"_flash_qk_mma = {bw}.make_trivial_tiled_mma({dtype}, {dtype}, {majk}, {majk}, cutlass.Float32, {cg}, ({mma_m}, 128))",
+            f"_flash_qk_mma = {bw}.make_trivial_tiled_mma({dtype}, {dtype}, {majk}, {majk}, cutlass.Float32, {cg}, ({mma_m}, {kv_n}))",
             f"_flash_pv_mma = {bw}.make_trivial_tiled_mma({dtype}, {dtype}, {majk}, cute.nvgpu.OperandMajorMode.MN, cutlass.Float32, {cg}, ({mma_m}, {hd}), cute.nvgpu.tcgen05.OperandSource.TMEM)",
             f"_flash_cluster_layout_vmnk = cute.tiled_divide(cute.make_layout(({2 if use_2cta_instrs else 1}, 1, 1)), (_flash_qk_mma.thr_id.shape,))",
             f"_flash_qsl = {bw}.make_smem_layout_a(_flash_qk_mma, {qkd}, {dtype}, {q_stage})",

--- a/test/test_cute_flash_exp2.py
+++ b/test/test_cute_flash_exp2.py
@@ -1224,6 +1224,85 @@ def test_dense_resident_value_graph_runs_on_the_one_cta_pipeline() -> None:
         assert "resident_softmax_value_graph" not in source, family
 
 
+def test_kv_tile_width_is_legalized_against_tmem_and_the_sequence() -> None:
+    """A wider KV tile is accepted only where it can actually be emitted.
+
+    FA4's tuned sm_103 plans all use a 160-wide KV tile and gain ~9.6% from it,
+    so the width has to be a real dimension rather than a constant. It is legal
+    only when it is a tcgen05 N, leaves the score and output accumulators inside
+    512 TMEM columns, and divides the sequence -- the masked tail tile is not
+    implemented, so an indivisible width would silently drop KV blocks.
+    """
+    fits = cute_flash._flash_kv_tile_n_fits_tmem
+    assert fits(160, 64, 2)  # 2*160 + 2*64 = 448
+    assert fits(192, 64, 2)  # 2*192 + 2*64 = 512
+    assert not fits(224, 64, 2)  # 2*224 + 2*64 = 576
+
+    supported = cute_flash._flash_kv_tile_n_supported
+    common = {"head_dim": 64, "topology": "fa4", "is_causal": False, "s_stage": 2}
+    # num_kv counts default-width tiles, so the sequence is num_kv * 128.
+    assert supported(160, num_kv=1280, **common)  # 163840 % 160 == 0
+    # An indivisible width is fine: the trailing partial tile is masked, which
+    # needs the descending order that visits it first.
+    assert supported(160, num_kv=256, **common)  # 32768 % 160 != 0
+    assert not supported(160, num_kv=256, **{**common, "desc_kv": False})
+    assert not supported(224, num_kv=1280, **common)  # will not fit TMEM
+    assert not supported(160, num_kv=1280, **{**common, "is_causal": True})
+    assert not supported(160, num_kv=1280, **{**common, "topology": "ws_overlap"})
+    # The default width is always available.
+    assert supported(128, num_kv=256, **common)
+    assert supported(128, num_kv=1280, **{**common, "is_causal": True})
+
+
+def test_kv_tile_width_reaches_the_emitted_tile_shapes() -> None:
+    """The emitted MMA/TMEM shapes follow the configured KV tile width."""
+    default_source = _emit_dense_resident_value_graph_source(num_kv=1280)
+    wide_source = _emit_dense_resident_value_graph_source(
+        num_kv=1280,
+        config_overrides={cute_flash.FLASH_KV_TILE_N_KEY: 160},
+    )
+
+    assert "partition_shape_C((128, 128))" in default_source
+    assert "partition_shape_C((128, 160))" in wide_source
+    assert "cute.make_identity_tensor((128, 128))" in default_source
+    assert "cute.make_identity_tensor((128, 160))" in wide_source
+    # S1 sits one score tile past S0, and the two O accumulators follow both:
+    # 128 -> 256, 320 becomes 160 -> 320, 384.
+    for offset in ("+ 128", "+ 256", "+ 320"):
+        assert f"flash_tmem_ptr {offset}" in default_source, offset
+    for offset in ("+ 160", "+ 320", "+ 384"):
+        assert f"flash_tmem_ptr {offset}" in wide_source, offset
+    assert "flash_tmem_ptr + 128" not in wide_source
+
+
+def test_indivisible_kv_tile_masks_the_trailing_partial_tile() -> None:
+    """A width that does not divide the sequence peels a masked tail tile.
+
+    TMA zero-fills past the tensor extent, and a zero score is not a no-op:
+    exp2(0 - max) would contribute to the row sum. The partial tile's
+    out-of-range columns must be forced to -inf, and because the hardware TMEM
+    row reduction folds the max into the load, that tile's row max has to be
+    recomputed in software from the masked fragment.
+    """
+    divisible = _emit_dense_resident_value_graph_source(
+        num_kv=1280,
+        config_overrides={cute_flash.FLASH_KV_TILE_N_KEY: 160},
+    )
+    # 32768 = 204 * 160 + 128, so the last tile carries 128 valid columns.
+    ragged = _emit_dense_resident_value_graph_source(
+        num_kv=256,
+        config_overrides={cute_flash.FLASH_KV_TILE_N_KEY: 160},
+    )
+
+    assert "mask_r2p_sm100_rank1" not in divisible
+    assert "flash_kv_tail_iter" not in divisible
+    assert "mask_r2p_sm100_rank1(tLDrS, cutlass.Int32(128))" in ragged
+    assert "flash_kv_tail_iter" in ragged
+    # The masked tile reduces in software; the rest keep the hardware reduction.
+    assert ragged.count("fmax_reduce_packed") >= 1
+    assert "flash_hw_row_max" in ragged
+
+
 def test_dense_resident_softmax_lowering_dispatch_is_exhaustive() -> None:
     policy = get_flash_target_policy((10, 3)).tuning
     shape_policy = policy.dense_policy(256)

--- a/test/test_cute_flash_length_invariance.py
+++ b/test/test_cute_flash_length_invariance.py
@@ -1925,7 +1925,9 @@ def test_ws_search_has_bounded_effective_active_value_coverage(
     assert _active_choices(
         enum_fragments[cute_flash.FLASH_PIPELINE_FAMILY_KEY]
     ) == frozenset(("ws_overlap",))
-    assert len(active_values) <= 52
+    # 53: the ws surface pins every dimension it cannot vary to one value,
+    # including the KV tile width.
+    assert len(active_values) <= 53
     for key, value in active_values:
         requested = {**base, key: value}
         resolved = cute_flash.resolve_flash_config(


### PR DESCRIPTION
Stacked PRs:
 * #3579
 * #3578
 * #3577
 * #3576
 * __->__#3575
 * #3574
 * #3573
 * #3572
 * #3571


--- --- ---

### [cutedsl] Make the flash KV tile width a real dimension


The KV tile width was hardwired to 128 everywhere in the FA4 emitter: the
MMA tiler, the flat_divide tilers, partition_shape_C, the identity tensor,
the TMEM column offsets, the shared-memory ring sizing and the launcher's
trip count all spelled the literal. Every tuned FA4 plan for these shapes
uses 160 instead, which is worth 8.3% to FA4 on dense attention, and Helion
could not express it at all.

Thread the width through as `cute_flash_kv_tile_n`: FlashAttentionConfig,
FlashDenseTuningPolicy, FlashScheduleSpec, the shared-storage variants and
the launch plan. The staging ring and the FA4 depth cap now size their K/V
slots as `kv_tile_n * head_dim`, since a wider tile fits fewer stages and
overrunning the budget fails the launch with cudaErrorInvalidValue rather
than falling back. The TMEM budget check is strict: 160 fits alongside the
score and output accumulators, 192 exactly saturates the 512 columns and
produces NaNs, so it is rejected.

A width that does not divide the sequence is legal too. The trailing partial
tile is masked with mask_r2p_sm100_rank1 and takes a software row-max instead
of the hardware TMEM reduce, which needs the descending KV order that visits
the partial tile first. Splitting the dense loop into a tail segment and a
body segment keeps the mask off the steady-state iterations.