### PR TITLE
[cutedsl] Gate the causal resident softmax on its schedule, and close two KV-width holes

### DIFF
--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -1256,13 +1256,20 @@ def _flash_deep_1cta_kv_stage_cap(head_dim: int) -> int:
     return 0
 
 
-def _flash_aliased_kv_stage_cap(head_dim: int, *, stage_output: bool) -> int:
-    """Largest legal aliased K/V depth for the requested output storage."""
+def _flash_aliased_kv_stage_cap(
+    head_dim: int, *, stage_output: bool, kv_tile_n: int = 128
+) -> int:
+    """Largest legal aliased K/V depth for the requested output storage.
+
+    A wider KV tile makes each staging slot proportionally larger, so the depth
+    that fits in shared memory drops with it.
+    """
     return max_fa4_kv_depth(
         FlashScheduleSpec(
             head_dim=head_dim,
             kv_depth=2,
             stage_output=stage_output,
+            kv_tile_n=kv_tile_n,
         )
     )
 
@@ -1643,12 +1650,16 @@ class FlashAttentionConfig:
 # TMEM is 512 columns. The FA4 score pipeline holds ``s_stage`` score buffers of
 # ``kv_tile_n`` columns plus two ``head_dim``-wide output accumulators.
 FLASH_TMEM_COLUMNS = 512
-FLASH_KV_TILE_N_CHOICES = (128, 160, 192)
+# Validated KV tile widths. 192 exactly saturates TMEM at head-dim 64 with two
+# score buffers (2*192 + 2*64 == 512) and produces NaN, so the budget check
+# below demands headroom rather than a fit; it is also slower than 160 on every
+# part measured, so nothing is lost by leaving it out of the choice set.
+FLASH_KV_TILE_N_CHOICES = (128, 160)
 
 
 def _flash_kv_tile_n_fits_tmem(kv_tile_n: int, head_dim: int, s_stage: int) -> bool:
-    """Return whether the score and output accumulators fit in TMEM."""
-    return s_stage * kv_tile_n + 2 * head_dim <= FLASH_TMEM_COLUMNS
+    """Return whether the score and output accumulators leave TMEM headroom."""
+    return s_stage * kv_tile_n + 2 * head_dim < FLASH_TMEM_COLUMNS
 
 
 def _flash_kv_tile_n_supported(
@@ -1660,6 +1671,7 @@ def _flash_kv_tile_n_supported(
     is_causal: bool,
     s_stage: int,
     desc_kv: bool = True,
+    softmax_disc: bool = False,
 ) -> bool:
     """Return whether a non-default KV tile width is legal for this shape.
 
@@ -1678,7 +1690,13 @@ def _flash_kv_tile_n_supported(
     if not _flash_kv_tile_n_fits_tmem(kv_tile_n, head_dim, s_stage):
         return False
     sequence_extent = num_kv * 128
-    return sequence_extent % kv_tile_n == 0 or desc_kv
+    if sequence_extent % kv_tile_n == 0:
+        return True
+    # The trailing partial tile has to be masked, and only the whole-row softmax
+    # body does that; the chunked ("disc") body would consume the out-of-range
+    # columns as real zero scores. It also needs the descending KV order that
+    # visits the partial tile first.
+    return desc_kv and not softmax_disc
 
 
 def _flash_bool_env(name: str, default: bool) -> bool:
@@ -3138,10 +3156,31 @@ def resolve_flash_config(
         e2e_offset = 0
         e2e_offset0 = 0
         causal_lpt_swizzle = 0
+    kv_tile_n = int(_flash_env_get("HELION_CUTE_FLASH_KV_TILE_N", "128") or "128")
+    kv_tile_n_cfg = _cfg(FLASH_KV_TILE_N_KEY)
+    if kv_tile_n_cfg is not None:
+        kv_tile_n = int(cast("int", kv_tile_n_cfg))
+    if not _flash_kv_tile_n_supported(
+        kv_tile_n,
+        head_dim=head_dim,
+        num_kv=num_kv,
+        topology=topology,
+        is_causal=is_causal,
+        s_stage=s_stage,
+        desc_kv=kv_order == "descending",
+        softmax_disc=softmax_disc,
+    ):
+        kv_tile_n = 128
+
     if topology == "fa4" and not separate_kv_rings and head_dim in (64, 128):
+        # The staging depth has to be capped for the *configured* tile width:
+        # each K/V slot is ``kv_tile_n * head_dim`` elements, so a wider tile
+        # fits fewer stages, and exceeding the budget makes the launch fail
+        # with cudaErrorInvalidValue rather than falling back.
         aliased_kv_stage_cap = _flash_aliased_kv_stage_cap(
             head_dim,
             stage_output=epi_tma or epi_stg,
+            kv_tile_n=kv_tile_n,
         )
         kv_stage = min(max(kv_stage, 2), aliased_kv_stage_cap)
     pipeline_family = _flash_pipeline_family_from_flags(
@@ -3237,21 +3276,6 @@ def resolve_flash_config(
     )
     if epi_tma_setup not in ("shared", "role_local") or not epi_tma_setup_eligible:
         epi_tma_setup = "shared"
-
-    kv_tile_n = int(_flash_env_get("HELION_CUTE_FLASH_KV_TILE_N", "128") or "128")
-    kv_tile_n_cfg = _cfg(FLASH_KV_TILE_N_KEY)
-    if kv_tile_n_cfg is not None:
-        kv_tile_n = int(cast("int", kv_tile_n_cfg))
-    if not _flash_kv_tile_n_supported(
-        kv_tile_n,
-        head_dim=head_dim,
-        num_kv=num_kv,
-        topology=topology,
-        is_causal=is_causal,
-        s_stage=s_stage,
-        desc_kv=kv_order == "descending",
-    ):
-        kv_tile_n = 128
 
     if exp2_packet in _FLASH_CAUSAL_HD128_RESIDENT_EXP2_PACKETS and (
         pipeline_family != "fa4" or not causal_loop_split
@@ -3950,17 +3974,34 @@ def _flash_resident_softmax_config(
     )
 
 
-def _flash_causal_resident_native_seed_matches(
+def _flash_causal_resident_schedule_supported(
     cfg: FlashAttentionConfig,
     policy: FlashCausalTuningPolicy | None,
 ) -> bool:
-    """Return whether ``cfg`` is the validated causal resident seed shape."""
-    return policy is not None and _flash_config_matches_tuning_values(
-        cfg,
-        {
-            **_flash_causal_tuning_overrides(policy),
-            FLASH_Q_TILE_COUNT_KEY: 2,
-        },
+    """Return whether ``cfg``'s schedule can host the causal resident lowering.
+
+    Same reasoning as the dense gate: list the structural requirements the
+    lowering actually has, not a byte-exact comparison against the promoted
+    seed. The exact match cost ~20% for every neighbour of the causal seed on
+    GB300 (1367 -> ~1090 TFLOP/s on 2x32x262144x64 fp16, the same number for
+    every single-field perturbation), which is a cliff the autotuner cannot
+    climb out of.
+    """
+    if policy is None:
+        return False
+    return (
+        cfg.pipeline_family == "fa4"
+        and not cfg.persistent
+        and cfg.q_tile_count == 2
+        # The degree-2 causal body is written against this exp2 packet and its
+        # paired masked/unmasked cadence.
+        and cfg.exp2_packet == _FLASH_DEG2_EXP2_PACKET
+        and cfg.e2e_schedule == "16/6"
+        and cfg.masked_e2e_schedule == "16/6"
+        and cfg.split_p_arrive
+        and cfg.rescale_threshold > 0.0
+        and cfg.p_store_repetition == 16
+        and cfg.s_load_repetition == 32
     )
 
 
@@ -7307,10 +7348,10 @@ def emit_flash_fa4_device_body(
     causal_tuning = (
         tuning_policy.causal_policy(num_kv) if tuning_policy is not None else None
     )
-    causal_seed_matches = _flash_causal_resident_native_seed_matches(cfg, causal_tuning)
+    causal_schedule_ok = _flash_causal_resident_schedule_supported(cfg, causal_tuning)
     use_causal_resident_native = (
         causal_tuning is not None
-        and causal_seed_matches
+        and causal_schedule_ok
         and use_tmem_row_reduce
         and is_causal
         and not has_lse

--- a/helion/_compiler/cute/flash_policy.py
+++ b/helion/_compiler/cute/flash_policy.py
@@ -230,7 +230,7 @@ _FLASH_TARGET_POLICIES = {
                 ),
                 FlashCausalTuningPolicy(
                     num_kv=1024,
-                    kv_stage=3,
+                    kv_stage=6,
                     e2e_offset=1,
                     e2e_offset0=14,
                     role_map="fa4",
@@ -240,7 +240,7 @@ _FLASH_TARGET_POLICIES = {
                 ),
                 FlashCausalTuningPolicy(
                     num_kv=2048,
-                    kv_stage=3,
+                    kv_stage=8,
                     e2e_offset=14,
                     e2e_offset0=12,
                     role_map="fa4",

--- a/helion/_compiler/cute/flash_schedule.py
+++ b/helion/_compiler/cute/flash_schedule.py
@@ -193,7 +193,8 @@ def max_fa4_kv_depth(
     if limits is None:
         limits = FlashScheduleLimits()
     base_bytes = _shared_memory_bytes(dataclasses.replace(spec, kv_depth=0))
-    tile_bytes = 128 * spec.head_dim * spec.dtype_bytes
+    # A staging slot holds one KV tile, which is ``kv_tile_n`` wide.
+    tile_bytes = spec.kv_tile_n * spec.head_dim * spec.dtype_bytes
     bytes_per_stage = (2 if spec.separate_kv else 1) * tile_bytes
     return max(0, (limits.shared_memory_bytes - base_bytes) // bytes_per_stage)
 

--- a/test/test_cute_flash_arch.py
+++ b/test/test_cute_flash_arch.py
@@ -252,7 +252,7 @@ def test_sm103_flash_target_policy() -> None:
             "descending",
         ),
         1024: (
-            3,
+            6,
             FlashCausalSeedTemplate.DEGREE2_V1,
             1,
             14,
@@ -265,7 +265,7 @@ def test_sm103_flash_target_policy() -> None:
             "descending",
         ),
         2048: (
-            3,
+            8,
             FlashCausalSeedTemplate.DEGREE2_V1,
             14,
             12,

--- a/test/test_cute_flash_exp2.py
+++ b/test/test_cute_flash_exp2.py
@@ -1304,7 +1304,8 @@ def test_kv_tile_width_is_legalized_against_tmem_and_the_sequence() -> None:
     """
     fits = cute_flash._flash_kv_tile_n_fits_tmem
     assert fits(160, 64, 2)  # 2*160 + 2*64 = 448
-    assert fits(192, 64, 2)  # 2*192 + 2*64 = 512
+    # 192 fits exactly (512) and produces NaN, so the check demands headroom.
+    assert not fits(192, 64, 2)
     assert not fits(224, 64, 2)  # 2*224 + 2*64 = 576
 
     supported = cute_flash._flash_kv_tile_n_supported
@@ -1315,6 +1316,7 @@ def test_kv_tile_width_is_legalized_against_tmem_and_the_sequence() -> None:
     # needs the descending order that visits it first.
     assert supported(160, num_kv=256, **common)  # 32768 % 160 != 0
     assert not supported(160, num_kv=256, **{**common, "desc_kv": False})
+    assert not supported(192, num_kv=1280, **common)  # no TMEM headroom
     assert not supported(224, num_kv=1280, **common)  # will not fit TMEM
     assert not supported(160, num_kv=1280, **{**common, "is_causal": True})
     assert not supported(160, num_kv=1280, **{**common, "topology": "ws_overlap"})
@@ -1609,7 +1611,7 @@ def test_causal_resident_softmax_lowering_dispatch_is_exhaustive() -> None:
     assert "resident_softmax_value_graph" in value_graph_source
 
 
-@pytest.mark.parametrize(("num_kv", "kv_stage"), ((1024, 3), (2048, 3), (4096, 6)))
+@pytest.mark.parametrize(("num_kv", "kv_stage"), ((1024, 6), (2048, 8), (4096, 6)))
 def test_causal_resident_native_additional_stage_codegen(
     num_kv: int, kv_stage: int
 ) -> None:
@@ -1646,13 +1648,35 @@ def test_causal_resident_native_gate_preserves_fallbacks() -> None:
         _emit_causal_resident_native_source(
             config_overrides={cute_flash.FLASH_EXP2_PACKET_KEY: "4x1"}
         ),
-        _emit_causal_resident_native_source(
-            config_overrides={cute_flash.FLASH_SOFTMAX_REGS_KEY: 176}
-        ),
     )
     for fallback_source in fallback_sources:
         assert "fa4_disc_exp_convert_store" in fallback_source
         assert "resident_softmax_value_graph" not in fallback_source
+
+    # The resident body's live set does not fit in 176 registers, so that also
+    # drops the lowering -- to the whole-row body rather than the chunked one.
+    starved = _emit_causal_resident_native_source(
+        config_overrides={cute_flash.FLASH_SOFTMAX_REGS_KEY: 176}
+    )
+    assert "resident_softmax_value_graph" not in starved
+
+    # Fields the lowering does not depend on must keep it. The exact-seed gate
+    # this replaced dropped every neighbour to the chunked body, which measured
+    # ~20% slower on GB300 causal 2x32x262144x64 (1367 -> ~1090 TFLOP/s, the
+    # same value for every single-field perturbation).
+    # num_kv=512 is seeded with the stateful lowering; 1024 is the resident one.
+    assert "resident_softmax_value_graph" in _emit_causal_resident_native_source(
+        num_kv=1024
+    )
+    for neighbour in (
+        {cute_flash.FLASH_ROLE_MAP_KEY: "helion"},
+        {cute_flash.FLASH_E2E_OFFSET_KEY: 8},
+        {cute_flash.FLASH_E2E_OFFSET0_KEY: 5},
+    ):
+        neighbour_source = _emit_causal_resident_native_source(
+            num_kv=1024, config_overrides=neighbour
+        )
+        assert "resident_softmax_value_graph" in neighbour_source, neighbour
 
 
 @onlyBackends(["cute"])
@@ -1786,7 +1810,7 @@ def test_causal_target_seed_match_ignores_conflicting_environment() -> None:
         )
         policy = get_flash_target_policy((10, 3)).tuning.causal_policy(512)
         assert causal_cfg.wait_hint == 0
-        assert cute_flash._flash_causal_resident_native_seed_matches(causal_cfg, policy)
+        assert cute_flash._flash_causal_resident_schedule_supported(causal_cfg, policy)
 
     effective = cute_flash._flash_resident_softmax_config(causal_cfg)
     assert causal_cfg.exp2_packet == _DEG2_PACKET


### PR DESCRIPTION
Stacked PRs:
 * #3579
 * #3578
 * __->__#3577
 * #3576
 * #3575
 * #3574
 * #3573
 * #3572
 * #3571


--- --- ---

### [cutedsl] Gate the causal resident softmax on its schedule, and close two KV-width holes


The causal resident lowering had the same byte-exact-seed cliff the dense one
had; replace it with the schedule preconditions it actually depends on. With
the cliff gone the causal shapes retune: 128K and 256K want deeper staging,
and 512K deeper still.

Two legality holes that a full autotune found by walking into them:

- The FA4 staging cap was computed for a 128-wide tile, so a wider tile could
  ask for more stages than shared memory holds and the launch failed with
  CUDA_LAUNCH_INVALID_CONFIG. The cap is now width-aware.
- The chunked ("disc") softmax body does not mask, so with an indivisible
  width it consumed the out-of-range columns of the trailing tile as real
  zero scores and returned wrong results. Indivisible widths now require the
  whole-row body and the descending KV order.