### PR TITLE
[metal] Add reduction support

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -416,6 +416,14 @@ class Backend(abc.ABC):
         """Whether reduction strategies should occupy the first (lowest) thread axes."""
         return False
 
+    def supports_lane_loop_reductions(self) -> bool:
+        """Whether reductions may be carried by a tile strategy's lane loop."""
+        return False
+
+    def validate_reduction_input(self, block_index: int, value: torch.Tensor) -> None:
+        """Validate a value before lowering its reduction."""
+        return None
+
     def force_tile_mask(self) -> bool:
         """Whether tile strategies must emit explicit masks for all tiles."""
         return False
@@ -659,6 +667,18 @@ class Backend(abc.ABC):
     ) -> str:
         raise exc.BackendUnsupported(self.name, "full tensor creation")
 
+    def reduction_acc_init_expr(
+        self, shape_dims: list[str], value_expr: str, dtype: torch.dtype
+    ) -> str:
+        """Initial value of a rolled reduction's per-thread accumulator.
+
+        Separate from :meth:`full_expr` because the accumulator must be as wide
+        as the backend's combine expression, which may promote (Metal reduces
+        ``int8``/``bool`` in an ``int``).  Declaring it at storage width would
+        truncate on every loop iteration.
+        """
+        return self.full_expr(shape_dims, value_expr, dtype)
+
     def reshape_expr(self, expr: str, shape: str) -> str:
         raise exc.BackendUnsupported(self.name, "reshape")
 
@@ -739,7 +759,15 @@ class Backend(abc.ABC):
         *,
         block_size_var: str | None = None,
         threads_in_group: int | None = None,
+        dtype: torch.dtype | None = None,
     ) -> str:
+        """Generate the cross-thread reduction expression.
+
+        ``dtype`` is the accumulation dtype
+        (``get_computation_dtype(input.dtype)``) when the caller knows it.
+        Backends that allocate typed scratch storage for the reduction (e.g.
+        Metal's ``threadgroup`` buffers) need it; the rest ignore it.
+        """
         raise exc.BackendUnsupported(self.name, f"reduction {reduction_type!r}")
 
     def thread_linear_index_expr(self, axis_sizes: dict[int, int]) -> str | None:
@@ -773,7 +801,13 @@ class Backend(abc.ABC):
         block_size_var: str | None = None,
         index_dtype: torch.dtype | None = None,
         threads_in_group: int | None = None,
+        dtype: torch.dtype | None = None,
     ) -> str:
+        """Generate the cross-thread argmin/argmax expression.
+
+        ``dtype`` is the accumulation dtype of the *value* operand; see
+        :meth:`reduction_expr`.
+        """
         raise exc.BackendUnsupported(self.name, "argmin/argmax reductions")
 
     def argreduce_loop_update_statements(
@@ -784,7 +818,13 @@ class Backend(abc.ABC):
         acc_index: str,
         value: str,
         index: str,
+        dtype: torch.dtype | None = None,
     ) -> list[str]:
+        """Per-iteration accumulator update for a rolled argmin/argmax.
+
+        ``dtype`` is the accumulation dtype of the value operand; see
+        :meth:`reduction_expr`.
+        """
         raise exc.BackendUnsupported(self.name, "argmin/argmax reductions")
 
     def inductor_op_overrides(self) -> InductorOpOverrides:

--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -1460,6 +1460,9 @@ class CuteBackend(Backend):
     def reduction_axis_first(self) -> bool:
         return True
 
+    def supports_lane_loop_reductions(self) -> bool:
+        return True
+
     def thread_in_tile_mask_expr(
         self, block_size_var: str, *, axis: int = 0
     ) -> str | None:
@@ -1596,6 +1599,7 @@ class CuteBackend(Backend):
         *,
         block_size_var: str | None = None,
         threads_in_group: int | None = None,
+        dtype: torch.dtype | None = None,
     ) -> str:
         threads = (
             threads_in_group
@@ -1647,6 +1651,7 @@ class CuteBackend(Backend):
         block_size_var: str | None = None,
         index_dtype: torch.dtype | None = None,
         threads_in_group: int | None = None,
+        dtype: torch.dtype | None = None,
     ) -> str:
         if index_dtype is None:
             raise exc.BackendUnsupported(self.name, "missing index_dtype for argreduce")
@@ -1678,6 +1683,7 @@ class CuteBackend(Backend):
         acc_index: str,
         value: str,
         index: str,
+        dtype: torch.dtype | None = None,
     ) -> list[str]:
         if reduction_type == "argmin":
             better = (

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -946,6 +946,7 @@ class ReductionLowering(InductorLowering):
 
             strategy = BlockReductionStrategy(state, self.block_index)
 
+        env.backend.validate_reduction_input(strategy.block_index, repr_input)
         result_ast = strategy.codegen_reduction(
             state,
             output_name,

--- a/helion/_compiler/metal/_constants.py
+++ b/helion/_compiler/metal/_constants.py
@@ -1,0 +1,31 @@
+"""Apple hardware limits shared by the Metal backend.
+
+Kept in a leaf module (no package imports) so codegen (``backend.py``,
+``reduction.py``) and the MSL preamble (``msl_reduction.py``) can all use
+these without import cycles.
+"""
+
+from __future__ import annotations
+
+# Metal SIMD-group width on all Apple GPUs.  ``c10/metal/reduction_utils.h``
+# hardcodes the same assumption (see its "simdgroup is 32" comment).
+SIMD_WIDTH = 32
+
+#: Maximum threads in a Metal threadgroup.
+#:
+#: Numerically equal to ``cute.thread_budget.MAX_THREADS_PER_BLOCK``: one
+#: Apple hardware limit under two names.  The MPP budget in ``backend.py``
+#: uses the CuTe name; everything else on this backend uses this one.
+MAX_THREADS_PER_THREADGROUP = 1024
+
+#: Maximum number of SIMD groups in a threadgroup, hence the slot count of
+#: every ``threadgroup`` scratch buffer (one slot per SIMD group; see
+#: ``reduction.alloc_threadgroup_buffer``).
+MAX_SIMD_GROUPS = MAX_THREADS_PER_THREADGROUP // SIMD_WIDTH
+
+#: A Metal threadgroup is three-dimensional:
+#: ``thread_position_in_threadgroup`` is a ``uint3``.  A kernel needing a
+#: fourth thread axis has no way to express it, and indexing ``tid[3]``
+#: reads past the end of that vector -- which the shader compiler accepts
+#: and which silently returns garbage.
+MAX_THREAD_AXES = 3

--- a/helion/_compiler/metal/backend.py
+++ b/helion/_compiler/metal/backend.py
@@ -14,6 +14,8 @@ from ... import exc
 from ..backend import Backend
 from ..backend import _largest_divisor_at_most
 from ..cute.backend import CuteBackend
+from ._constants import MAX_THREAD_AXES
+from ._constants import MAX_THREADS_PER_THREADGROUP
 
 if TYPE_CHECKING:
     from torch._inductor.ops_handler import OpsHandler
@@ -53,6 +55,7 @@ class MetalBackend(Backend):
             "block_sizes",
             "num_threads",
             "num_warps",
+            "reduction_loops",
         }
     )
 
@@ -104,12 +107,32 @@ class MetalBackend(Backend):
         return f"{name} = {value}"
 
     def cast_expr(self, expr_str: str, dtype_str: str) -> str:
-        return f"static_cast<{dtype_str}>({expr_str})"
+        # The outer parens matter: Python parses ``static_cast<T>(x)`` as a
+        # chained comparison, and without them ``a + static_cast<T>(x)`` binds
+        # as ``(a + static_cast) < T > x``, which the MSL walker cannot
+        # recognize as a cast.
+        return f"(static_cast<{dtype_str}>({expr_str}))"
+
+    def _tid(self, axis: int) -> str:
+        """The ``tid`` component for a thread axis, rejecting a fourth one.
+
+        Metal provides three.  A kernel wanting more -- a 3-D tile whose
+        innermost dimension is also fully sliced, so that it claims an axis of
+        its own -- would otherwise index past the end of the ``uint3``, which
+        compiles cleanly and returns garbage.
+        """
+        if axis >= MAX_THREAD_AXES:
+            raise exc.BackendUnsupported(
+                self.name,
+                f"thread axis {axis}: a Metal threadgroup has "
+                f"{MAX_THREAD_AXES} dimensions, this kernel needs {axis + 1}",
+            )
+        return f"tid[{axis}]"
 
     def lane_index_expr(
         self, offset_var: str, elements_per_thread: int, *, axis: int
     ) -> str:
-        return f"{offset_var} + tid[{axis}] * {elements_per_thread}"
+        return f"{offset_var} + {self._tid(axis)} * {elements_per_thread}"
 
     def lane_offset_expr(self, lane_var: str) -> str:
         return lane_var
@@ -122,14 +145,14 @@ class MetalBackend(Backend):
     ) -> str:
         if block_size_var == "1":
             return offset_var
-        return f"{offset_var} + tid[{axis}]"
+        return f"{offset_var} + {self._tid(axis)}"
 
     def loop_index_expr(
         self, offset_var: str, block_size_var: str, dtype: str, *, axis: int
     ) -> str:
         if block_size_var == "1":
             return offset_var
-        return f"{offset_var} + tid[{axis}]"
+        return f"{offset_var} + {self._tid(axis)}"
 
     def arange_expr(
         self,
@@ -140,12 +163,12 @@ class MetalBackend(Backend):
         *,
         axis: int = 0,
     ) -> str:
-        return f"{offsets_var} = ({lid}) * ({block_size_var}) + tid[{axis}]"
+        return f"{offsets_var} = ({lid}) * ({block_size_var}) + {self._tid(axis)}"
 
     def thread_in_tile_mask_expr(
         self, block_size_var: str, *, axis: int = 0
     ) -> str | None:
-        return f"tid[{axis}] < ({block_size_var})"
+        return f"{self._tid(axis)} < ({block_size_var})"
 
     def force_tile_mask(self) -> bool:
         return True
@@ -166,6 +189,14 @@ class MetalBackend(Backend):
         metal_type = self.dtype_str(dtype)
         return f"{metal_type}({value_expr})"
 
+    def reduction_acc_init_expr(
+        self, shape_dims: list[str], value_expr: str, dtype: torch.dtype
+    ) -> str:
+        # Must match the width metal/reduction.py casts the incoming value to,
+        # or a rolled int8/bool reduction truncates (or saturates) each
+        # iteration.  See _metal_acc_dtype.
+        return f"{self.acc_type(dtype)}({value_expr})"
+
     def reshape_expr(self, expr: str, shape: str) -> str:
         return expr
 
@@ -184,6 +215,264 @@ class MetalBackend(Backend):
 
     def supports_config_key(self, key: str) -> bool:
         return key in self._SUPPORTED_CONFIG_KEYS
+
+    # ------------------------------------------------------------------
+    # Reductions.  See ``metal/reduction.py`` for the emitters and
+    # ``metal/msl_reduction.py`` for the device-side helpers.
+    # ------------------------------------------------------------------
+
+    def max_reduction_threads(self) -> int | None:
+        return MAX_THREADS_PER_THREADGROUP
+
+    def reduction_axis_first(self) -> bool:
+        # Metal linearizes ``tid`` with ``tid[0]`` fastest-varying and assigns
+        # SIMD groups in that order, so putting the reduction on the lowest
+        # axis is what makes its threads a contiguous run of SIMD lanes.
+        return True
+
+    def validate_reduction_input(self, block_index: int, value: torch.Tensor) -> None:
+        """Reject a reduced value whose block id spans more than one axis.
+
+        Equal-size reduction dimensions reuse one index. Metal maps that index
+        to one thread axis, so broadcasting separately loaded values can make
+        two logical axes collapse onto the same thread.
+        """
+        from ..compile_environment import CompileEnvironment
+
+        env = CompileEnvironment.current()
+        axes = [
+            dim
+            for dim, size in enumerate(value.size())
+            if env.get_block_id(size) == block_index
+        ]
+        if len(axes) > 1:
+            raise exc.BackendUnsupported(
+                self.name,
+                f"reduction over a value whose dimensions {axes} share one "
+                "index (equal-size reduction dimensions reuse a block id); "
+                "Metal maps one index to one thread axis, so the axes would "
+                "collapse onto the same thread",
+            )
+
+    def adjust_reduction_thread_count(
+        self, requested: int, existing_strategies: list[TileStrategy]
+    ) -> int:
+        """Shrink the reduction span until the whole threadgroup fits in 1024.
+
+        Halving preserves the power-of-two span that the SIMD butterflies and
+        the two-stage threadgroup reduction both require.
+        """
+        from ..reduction_strategy import ReductionStrategy
+
+        if requested <= 1:
+            return requested
+        other_threads = 1
+        for strategy in existing_strategies:
+            if isinstance(strategy, ReductionStrategy):
+                count = strategy._reduction_thread_count()
+                if count > 0:
+                    other_threads *= count
+            else:
+                for size in strategy.thread_block_sizes():
+                    if size > 1:
+                        other_threads *= size
+        while other_threads * requested > MAX_THREADS_PER_THREADGROUP and requested > 1:
+            requested //= 2
+        return requested
+
+    def reduction_index_expr(
+        self, block_size_var: str, dtype: str, block_idx: int, *, axis: int
+    ) -> str:
+        self._reject_extra_reduction_dimension()
+        return self._tid(axis)
+
+    def _reject_extra_reduction_dimension(self) -> None:
+        """Allow at most one reduction dimension to hold a thread axis.
+
+        Each reduction dimension claims a ``tid`` axis, but a second one is not
+        given an axis disjoint from the tile strategy's: it lands back on an
+        axis a tile already owns, so the two indices alias and the kernel reads
+        (or writes) a diagonal.  Reject that rather than emit it.
+
+        This is about distinct reduction *dimensions*, not distinct reductions:
+        softmax's max and sum, or LayerNorm's mean and variance, share one
+        dimension and one axis, and are unaffected.
+        """
+        from ..compile_environment import CompileEnvironment
+
+        env = CompileEnvironment.current()
+        rdims = [bs.block_id for bs in env.block_sizes if bs.reduction]
+        if len(rdims) > 1:
+            raise exc.BackendUnsupported(
+                self.name,
+                f"{len(rdims)} reduction dimensions in one kernel "
+                f"(block ids {rdims}); Metal gives each reduction dimension a "
+                "thread axis and only one such axis is available alongside the "
+                "tile axes",
+            )
+
+    def reduction_index_zero_expr(self, dtype: str) -> str:
+        return "0"
+
+    def next_power_of_2_host_expr(self, expr: str) -> str:
+        return f"helion.next_power_of_2({expr})"
+
+    def reduction_threads_hint(self, block_size_var: str | None = None) -> int | None:
+        from ..device_function import DeviceFunction
+        from .reduction import resolve_group
+
+        group = resolve_group(DeviceFunction.current(), block_size_var)
+        return group.span if group is not None else None
+
+    def reduction_combine_expr(
+        self,
+        reduction_type: str,
+        acc: str,
+        val: str,
+        dtype: torch.dtype,
+    ) -> str:
+        from .reduction import reduction_combine_expr
+
+        return reduction_combine_expr(reduction_type, acc, val, dtype)
+
+    def reduction_expr(
+        self,
+        input_name: str,
+        reduction_type: str,
+        dim: int,
+        *,
+        block_size_var: str | None = None,
+        threads_in_group: int | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> str:
+        from .reduction import reduction_expr
+
+        return reduction_expr(
+            input_name,
+            reduction_type,
+            block_size_var=block_size_var,
+            threads_in_group=threads_in_group,
+            dtype=dtype,
+        )
+
+    def is_indexed_reduction(self, reduction_type: str) -> bool:
+        return reduction_type in {"argmin", "argmax"}
+
+    def argreduce_result_expr(
+        self,
+        input_name: str,
+        index_value: str,
+        reduction_type: str,
+        dim: int,
+        output_dtype: torch.dtype,
+        *,
+        block_size_var: str | None = None,
+        index_dtype: torch.dtype | None = None,
+        threads_in_group: int | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> str:
+        from .reduction import argreduce_result_expr
+
+        return argreduce_result_expr(
+            input_name,
+            index_value,
+            reduction_type,
+            output_dtype,
+            block_size_var=block_size_var,
+            index_dtype=index_dtype,
+            threads_in_group=threads_in_group,
+            dtype=dtype,
+        )
+
+    def argreduce_loop_update_statements(
+        self,
+        *,
+        reduction_type: str,
+        acc: str,
+        acc_index: str,
+        value: str,
+        index: str,
+        dtype: torch.dtype | None = None,
+    ) -> list[str]:
+        from .reduction import argreduce_loop_update_statements
+
+        return argreduce_loop_update_statements(
+            reduction_type=reduction_type,
+            acc=acc,
+            acc_index=acc_index,
+            value=value,
+            index=index,
+            dtype=dtype,
+        )
+
+    def create_reduction_strategy(
+        self, fn: DeviceFunction, block_id: int, reduction_loop: int | None
+    ) -> TileStrategy:
+        """Build the reduction strategy and reject extents we cannot cover.
+
+        Metal reduces one element per thread: unlike CuTe, it has no compiler
+        machinery to carry a reduction across a lane loop, so a reduction is
+        only correct when every element it has to cover in one pass is backed
+        by a live thread.  Short of that it does not fail -- it reduces the
+        first ``span`` elements and returns a plausible wrong answer.
+
+        Both strategies can land there, for different reasons, so both are
+        checked:
+
+        - Persistent covers the whole dimension in one pass.  Dimensions too
+          wide for a threadgroup are normally rolled by the config spec, but
+          one the roller rejected (e.g. fused with a matmul) stays persistent.
+        - Looped covers one rolled chunk per iteration.  The chunk is sized
+          from ``reduction_loops``, then ``adjust_reduction_thread_count``
+          shrinks the span to fit whatever the tile axes left over -- and can
+          shrink it below the chunk.
+
+        The budget passes in ``create_loop_strategy`` should keep the
+        product within one threadgroup, making this unreachable; it is
+        checked rather than assumed.
+        """
+        from ..compile_environment import CompileEnvironment
+        from ..reduction_strategy import LoopedReductionStrategy
+        from ..reduction_strategy import PersistentReductionStrategy
+        from ..reduction_strategy import ReductionStrategy
+
+        strategy = super().create_reduction_strategy(fn, block_id, reduction_loop)
+        # Narrow for the type checker as CuTe does: only reduction strategies
+        # carry a thread count; anything else counts zero and returns below.
+        span = (
+            strategy._reduction_thread_count()
+            if isinstance(strategy, ReductionStrategy)
+            else 0
+        )
+        if span <= 0:
+            return strategy
+
+        env = CompileEnvironment.current()
+        if isinstance(strategy, PersistentReductionStrategy):
+            covered = env.block_sizes[block_id].size_hint()
+            what = f"persistent reduction over {covered} elements"
+            hint = (
+                "the tile axes left too few threads for it; give the reduction "
+                "a smaller chunk with reduction_loops, or the tiles a smaller "
+                "block_size"
+            )
+        elif isinstance(strategy, LoopedReductionStrategy):
+            covered = strategy.block_size
+            what = f"reduction loop over chunks of {covered} elements"
+            hint = (
+                "either the chunk exceeds a threadgroup or the tile axes left "
+                "too few threads for it"
+            )
+        else:
+            return strategy
+
+        needed = self.static_rdim_size(covered)
+        if needed > span:
+            raise exc.BackendUnsupported(
+                self.name,
+                f"{what} needs {needed} threads but only {span} are available; {hint}",
+            )
+        return strategy
 
     def supports_precompile(self) -> bool:
         return False
@@ -256,6 +545,8 @@ class MetalBackend(Backend):
         lower ``num_threads`` or ``block_sizes``.
         """
         config = self._config_with_mpp_thread_budget(fn, block_ids, config)
+        # Cap tile thread counts so the reduction axes still fit alongside them.
+        config = self._config_with_reduction_thread_budget(block_ids, config)
         # pyrefly: ignore[bad-argument-type]
         strategy = CuteBackend.create_loop_strategy(self, fn, block_ids, config)
         self._reject_dynamic_thread_extents(strategy)
@@ -298,6 +589,95 @@ class MetalBackend(Backend):
                 "time; give the tile a block_size the config can resolve, or "
                 "compile the kernel with static_shapes=True",
             )
+
+    def _reserved_reduction_threads(self, config: Config) -> int:
+        """Threads the reduction axes will claim from the threadgroup.
+
+        Every element of a persistent reduction has to be backed by a live
+        thread -- Metal has no CuTe-style lane-loop fallback to cover a wider
+        dimension with a narrower thread group.  Reduction dimensions too wide
+        for one threadgroup are rolled by the config spec
+        (``reduction_loops``), so the span needed here is the rolled chunk.
+        """
+        from torch._inductor.runtime.runtime_utils import next_power_of_2
+
+        from ..compile_environment import CompileEnvironment
+
+        env = CompileEnvironment.current()
+        reserved = 1
+        for block_size_info in env.block_sizes:
+            if not block_size_info.reduction:
+                continue
+            block_id = block_size_info.block_id
+            rolled = env.config_spec.reduction_loops.config_get(
+                config.reduction_loops, block_id, None
+            )
+            extent = rolled if rolled is not None else block_size_info.size_hint()
+            reserved *= next_power_of_2(
+                max(1, min(int(extent), MAX_THREADS_PER_THREADGROUP))
+            )
+        return min(reserved, MAX_THREADS_PER_THREADGROUP)
+
+    def _config_with_reduction_thread_budget(
+        self, block_ids: list[int], config: Config
+    ) -> Config:
+        """Cap auto tile thread counts so the reduction axes still fit.
+
+        Tile strategies are built before reduction strategies
+        (``TileStrategyDispatch.__init__``), so without this the tiles claim
+        the whole 1024-thread budget and ``adjust_reduction_thread_count``
+        would shrink the reduction below the extent it has to cover.
+        """
+        reserved = self._reserved_reduction_threads(config)
+        if reserved <= 1:
+            return config
+
+        from ...runtime.config import Config
+        from ..compile_environment import CompileEnvironment
+
+        env = CompileEnvironment.current()
+        num_threads = list(config.num_threads)
+        if len(num_threads) < len(env.config_spec.num_threads):
+            num_threads.extend(
+                [0] * (len(env.config_spec.num_threads) - len(num_threads))
+            )
+
+        used = reserved
+        changed = False
+        tunable = set(env.config_spec.num_threads.valid_block_ids())
+        for block_id in block_ids:
+            configured = int(
+                env.config_spec.num_threads.config_get(config.num_threads, block_id, 0)
+            )
+            if configured > 0:
+                used *= configured
+                continue
+            axis_size = env.block_sizes[block_id].from_config(config)
+            if not isinstance(axis_size, int):
+                continue
+            if block_id not in tunable:
+                # An explicit ``hl.tile(n, block_size=<int>)`` or an ``hl.grid``
+                # allocates no ``NumThreadsSpec``, so the axis has no
+                # thread-count knob and always runs one thread per element.
+                # Charge it to the budget rather than indexing a map it is not
+                # in; if the total no longer fits, the reduction strategy
+                # rejects the config with a diagnostic.
+                used *= axis_size
+                continue
+            budget = max(1, MAX_THREADS_PER_THREADGROUP // max(1, used))
+            chosen = _largest_divisor_at_most(axis_size, budget)
+            if chosen >= axis_size:
+                used *= chosen
+                continue
+            config_index = env.config_spec.num_threads.block_id_to_index(block_id)
+            if num_threads[config_index] != chosen:
+                num_threads[config_index] = chosen
+                changed = True
+            used *= chosen
+
+        if not changed:
+            return config
+        return Config.from_dict({**config.config, "num_threads": num_threads})
 
     def _config_with_mpp_thread_budget(
         self, fn: DeviceFunction, block_ids: list[int], config: Config

--- a/helion/_compiler/metal/memory_ops.py
+++ b/helion/_compiler/metal/memory_ops.py
@@ -22,6 +22,60 @@ if TYPE_CHECKING:
     from ..inductor_lowering import CodegenState
 
 
+def _reject_aliased_slice_dims(
+    tensor: torch.Tensor, subscript: list[object] | tuple[object, ...]
+) -> None:
+    """Reject an access whose full slices share one reduction index.
+
+    ``CompileEnvironment.allocate_reduction_dimension`` caches by size, so two
+    ``:`` axes of equal length get the same block id and therefore the same
+    ``tid`` component.  A tile-level backend keeps them apart by broadcasting;
+    Metal, where each value is a scalar per thread, would collapse them and
+    walk the diagonal -- ``out[tile, :, :] = a[tile, :, None] * b[None, None, :]``
+    over ``[m, n, n]`` writes only ``out[m, i, i]``.
+
+    ``MetalBackend.validate_reduction_input`` catches the same mistake once a
+    reduction consumes the axes; this covers accesses that never reach a
+    reduction at all.
+
+    Sizes are compared pairwise with ``known_equal`` rather than looked up in a
+    dict keyed by the size itself.  Under dynamic shapes a size is a ``SymInt``,
+    which is unhashable and whose ``__eq__`` compares symbols; the sizes that
+    actually alias are the ones ``allocate_reduction_dimension`` unifies, and
+    ``known_equal`` is the predicate it unifies them with.
+    """
+    from ..compile_environment import CompileEnvironment
+
+    env = CompileEnvironment.current()
+    full_slices: list[tuple[int, int | torch.SymInt]] = []
+    dim = -1
+    for index in subscript:
+        if index is None:
+            continue  # inserts a new axis; consumes no tensor dimension
+        dim += 1
+        if not (isinstance(index, slice) and index == slice(None)):
+            continue
+        size = tensor.size(dim)
+        # A length-1 slice never reaches allocate_reduction_dimension (see
+        # ``indexing_strategy``, which indexes it with a constant 0), so it
+        # claims no thread axis and cannot collapse onto another dimension.
+        if isinstance(size, int) and size == 1:
+            continue
+        full_slices.append((dim, size))
+
+    for position, (first, first_size) in enumerate(full_slices):
+        for other, other_size in full_slices[position + 1 :]:
+            if env.known_equal(first_size, other_size):
+                raise exc.BackendUnsupported(
+                    "metal",
+                    f"dimensions {first} and {other} are both indexed by a "
+                    f"full slice of length {first_size}; equal-length slices "
+                    "share one reduction index, and Metal maps one index to "
+                    "one thread axis, so the two axes would collapse onto the "
+                    "same thread",
+                )
+
+
 @_decorators.codegen(store, "metal")
 def _(state: CodegenState) -> ast.AST:
     # Metal delegates to the same PointerIndexingStrategy as Triton.
@@ -35,6 +89,7 @@ def _(state: CodegenState) -> ast.AST:
     assert isinstance(extra_mask, (type(None), ast.AST))
 
     if isinstance(tensor, torch.Tensor):
+        _reject_aliased_slice_dims(tensor, subscript)
         device_fn = state.device_function
         device_fn.device_store_index += 1
         indexing_idx = device_fn.device_memory_op_index
@@ -62,6 +117,7 @@ def _(state: CodegenState) -> ast.AST:
     assert isinstance(eviction_policy, (type(None), ast.AST))
 
     if isinstance(tensor, torch.Tensor):
+        _reject_aliased_slice_dims(tensor, subscript)
         device_fn = state.device_function
         device_fn.device_load_index += 1
         indexing_idx = device_fn.device_memory_op_index

--- a/helion/_compiler/metal/metal_jit.py
+++ b/helion/_compiler/metal/metal_jit.py
@@ -33,6 +33,11 @@ import torch
 from ... import exc
 from .msl_ast_walker import EmitState
 from .msl_ast_walker import _emit_stmts
+from .msl_reduction import REDUCTION_INCLUDES
+from .msl_reduction import REDUCTION_NAMESPACE
+from .msl_reduction import REDUCTION_PREAMBLE
+from .reduction import SIMD_GROUP_VAR
+from .reduction import TG_BUFFER_GLOBAL_PREFIX
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -57,6 +62,7 @@ class _MetalKernel:
 
         Args are the kernel arguments (tensors and scalars) — used to
         infer dtypes for the MSL kernel signature.
+
         """
         # Parse the function source to get the AST
         source = inspect.getsource(self._fn)
@@ -103,6 +109,11 @@ def _generate_msl(
         "#include <c10/metal/special_math.h>",
         "using namespace metal;",
     ]
+    threadgroup_buffers = _threadgroup_buffers(fn_globals, body_stmts)
+    uses_reductions = _uses_reductions(body_stmts)
+    if uses_reductions:
+        msl_parts.extend(REDUCTION_INCLUDES)
+        msl_parts.extend(("", REDUCTION_PREAMBLE))
     if _uses_mpp_markers(body_stmts):
         _raise_if_mpp_unsupported_device()
         msl_parts.extend(
@@ -128,8 +139,14 @@ def _generate_msl(
 
     params: list[str] = []
     scalar_preamble: list[str] = []
-    for buf_idx, (name, arg) in enumerate(zip(param_names, args, strict=True)):
-        assert isinstance(arg, torch.Tensor), f"Expected tensor, got {type(arg)}"
+    buf_idx = 0
+    for name, arg in zip(param_names, args, strict=True):
+        if not isinstance(arg, torch.Tensor):
+            # A host-side constexpr the launcher passes positionally (e.g. a
+            # rolled reduction's ``_REDUCTION_BLOCK_*``).  ``default_metal_launcher``
+            # only binds tensors as buffers, so bake the value into the shader.
+            scalar_preamble.append(f"    {_constexpr_decl(name, arg)}")
+            continue
         if arg.dtype not in DTYPE_TO_METAL:
             raise ValueError(f"Unsupported Metal dtype: {arg.dtype}")
         metal_dtype = DTYPE_TO_METAL[arg.dtype]
@@ -142,6 +159,7 @@ def _generate_msl(
             scalar_preamble.append(f"    {metal_dtype} {name} = {buf_param}[0];")
         else:
             params.append(f"device {metal_dtype}* {name} [[buffer({buf_idx})]]")
+        buf_idx += 1
 
     params.extend(
         (
@@ -149,6 +167,10 @@ def _generate_msl(
             "uint3 tid [[thread_position_in_threadgroup]]",
         )
     )
+    if threadgroup_buffers:
+        # Cross-SIMD-group reductions index their slice of the shared scratch
+        # buffer by SIMD group; see metal/reduction.py::_group_base_expr.
+        params.append(f"uint {SIMD_GROUP_VAR} [[simdgroup_index_in_threadgroup]]")
 
     sig = ",\n    ".join(params)
     required_threads_attr = ""
@@ -171,12 +193,31 @@ def _generate_msl(
     for name in sorted(block_sizes):
         msl_parts.append(f"    constexpr int {name} = {block_sizes[name]};")
 
-    state = EmitState(declared=set(block_sizes))
+    # ``threadgroup`` variables are only legal at kernel scope, but a reduction
+    # can be emitted from inside a loop body, so their declarations are hoisted
+    # here from the generated ``_METAL_TG_BUF_*`` module globals.
+    for buf_name, buf_dtype, buf_slots in threadgroup_buffers:
+        msl_parts.append(f"    threadgroup {buf_dtype} {buf_name}[{buf_slots}];")
+
+    state = EmitState(
+        declared={*block_sizes, *(name for name, _, _ in threadgroup_buffers)}
+    )
 
     _emit_stmts(body_stmts, msl_parts, indent=4, state=state)
 
     msl_parts.append("}")
     return "\n".join(msl_parts)
+
+
+def _constexpr_decl(name: str, value: object) -> str:
+    """MSL declaration for a non-tensor kernel argument."""
+    if isinstance(value, bool):
+        return f"constexpr bool {name} = {'true' if value else 'false'};"
+    if isinstance(value, int):
+        return f"constexpr int {name} = {value};"
+    if isinstance(value, float):
+        return f"constexpr float {name} = {value!r};"
+    raise exc.BackendUnsupported("metal", f"kernel argument type: {type(value)}")
 
 
 def _uses_mpp_markers(body_stmts: list[ast.stmt]) -> bool:
@@ -187,6 +228,46 @@ def _uses_mpp_markers(body_stmts: list[ast.stmt]) -> bool:
         if isinstance(func, ast.Name) and func.id.startswith("_metal_mpp_"):
             return True
     return False
+
+
+def _uses_reductions(body_stmts: list[ast.stmt]) -> bool:
+    """Return True if the body calls into the ``helion_red`` MSL namespace.
+
+    Every reduction the Metal backend emits is routed through that namespace
+    (see ``metal/msl_reduction.py``), so this one check decides whether the
+    kernel needs the reduction preamble and the SIMD-group index parameter.
+    """
+    for node in ast.walk(ast.Module(body=body_stmts, type_ignores=[])):
+        if isinstance(node, ast.Name) and node.id == REDUCTION_NAMESPACE:
+            return True
+    return False
+
+
+def _threadgroup_buffers(
+    fn_globals: dict[str, object],
+    body_stmts: list[ast.stmt],
+) -> list[tuple[str, str, int]]:
+    """Collect ``(name, metal_dtype, slots)`` scratch declarations to hoist.
+
+    Written by ``metal/reduction.py::alloc_threadgroup_buffer`` as generated
+    module-level globals, the same transport ``_BLOCK_SIZE_*`` uses.  Only
+    buffers this kernel body actually references are declared, so a global left
+    behind by discarded codegen cannot consume threadgroup memory here.
+    """
+    referenced = {
+        node.id
+        for node in ast.walk(ast.Module(body=body_stmts, type_ignores=[]))
+        if isinstance(node, ast.Name)
+    }
+    buffers = []
+    for name in sorted(fn_globals):
+        if not name.startswith(TG_BUFFER_GLOBAL_PREFIX):
+            continue
+        buf_name, buf_dtype, buf_slots = fn_globals[name]  # type: ignore[misc]
+        if buf_name not in referenced:
+            continue
+        buffers.append((str(buf_name), str(buf_dtype), int(buf_slots)))  # type: ignore[arg-type]
+    return buffers
 
 
 def _raise_if_mpp_unsupported_device() -> None:

--- a/helion/_compiler/metal/msl_ast_walker.py
+++ b/helion/_compiler/metal/msl_ast_walker.py
@@ -21,10 +21,13 @@ Handles:
 from __future__ import annotations
 
 import ast
+import contextlib
 import dataclasses
+from typing import Iterator
 
 from ... import exc
 from .mpp_graph_codegen import MPPSetupParams
+from .msl_reduction import REDUCTION_NAMESPACE
 
 
 @dataclasses.dataclass
@@ -34,12 +37,34 @@ class EmitState:
     Tracks declared variable names (to avoid duplicate ``auto`` declarations)
     and MPP matmul setup parameters (keyed by setup variable name).
 
+    Declarations are tracked per C++ block scope.  A rolled reduction emits
+    several sibling ``for`` loops that assign the same Helion variable (e.g.
+    ``rindex_1``); each needs its own ``auto`` because the previous loop's
+    declaration went out of scope at its closing brace.
+
     MPPGraph lowering emits explicit ``_coop_iter`` loops. The walker derives
     the MMA-result substitution from the setup marker's ``fx_name``.
     """
 
     declared: set[str] = dataclasses.field(default_factory=set)
     mpp_setups: dict[str, MPPSetupParams] = dataclasses.field(default_factory=dict)
+    _enclosing: list[set[str]] = dataclasses.field(default_factory=list)
+
+    def is_declared(self, name: str) -> bool:
+        return name in self.declared or any(name in s for s in self._enclosing)
+
+    def declare(self, name: str) -> None:
+        self.declared.add(name)
+
+    @contextlib.contextmanager
+    def block_scope(self) -> Iterator[None]:
+        """Enter a nested C++ block; declarations made inside do not escape."""
+        self._enclosing.append(self.declared)
+        self.declared = set()
+        try:
+            yield
+        finally:
+            self.declared = self._enclosing.pop()
 
 
 # ---------------------------------------------------------------------------
@@ -125,14 +150,14 @@ def _emit_stmts(
                 params = _extract_mpp_setup_params(value)
                 state.mpp_setups[target.id] = params
                 _emit_mpp_setup(target.id, params, parts, indent=indent)
-                state.declared.add(target.id)
+                state.declare(target.id)
                 continue
             val_msl = _ast_expr_to_msl(value, subs=subs)
-            if target.id in state.declared:
+            if state.is_declared(target.id):
                 parts.append(f"{pad}{target.id} = {val_msl};")
             else:
                 parts.append(f"{pad}auto {target.id} = {val_msl};")
-                state.declared.add(target.id)
+                state.declare(target.id)
         elif isinstance(stmt, ast.Expr):
             call = stmt.value
             # tl.store(ptr + offset, val, mask) → if (mask) { *(ptr+offset) = val; }
@@ -171,12 +196,14 @@ def _emit_stmts(
         elif isinstance(stmt, ast.If):
             test_msl = _ast_expr_to_msl(stmt.test, subs=subs)
             parts.append(f"{pad}if ({test_msl}) {{")
-            _emit_stmts(stmt.body, parts, indent=indent + 4, state=state, subs=subs)
+            with state.block_scope():
+                _emit_stmts(stmt.body, parts, indent=indent + 4, state=state, subs=subs)
             if stmt.orelse:
                 parts.append(f"{pad}}} else {{")
-                _emit_stmts(
-                    stmt.orelse, parts, indent=indent + 4, state=state, subs=subs
-                )
+                with state.block_scope():
+                    _emit_stmts(
+                        stmt.orelse, parts, indent=indent + 4, state=state, subs=subs
+                    )
             parts.append(f"{pad}}}")
         elif isinstance(stmt, ast.For):
             _emit_for(stmt, parts, indent=indent, state=state, subs=subs)
@@ -238,7 +265,10 @@ def _emit_for(
                 f"{pad}for (auto _it = {coop}.begin(); _it != {coop}.end(); _it++) {{",
             )
         )
-        _emit_stmts(stmt.body, parts, indent=indent + 4, state=state, subs=coop_subs)
+        with state.block_scope():
+            _emit_stmts(
+                stmt.body, parts, indent=indent + 4, state=state, subs=coop_subs
+            )
         parts.append(f"{pad}}}")
         return
 
@@ -278,8 +308,9 @@ def _emit_for(
     parts.append(
         f"{pad}for (int {loop_var} = {start}; {loop_var} < {end}; {loop_var} += {step}) {{"
     )
-    state.declared.add(loop_var)
-    _emit_stmts(stmt.body, parts, indent=indent + 4, state=state, subs=subs)
+    with state.block_scope():
+        state.declare(loop_var)
+        _emit_stmts(stmt.body, parts, indent=indent + 4, state=state, subs=subs)
     parts.append(f"{pad}}}")
 
 
@@ -714,6 +745,22 @@ def _ast_call_to_msl(node: ast.AST, subs: dict[str, str] | None = None) -> str:
     assert isinstance(node, ast.Call)
     func = node.func
 
+    # Inductor's constant_repr spells non-finite floats as float("inf") /
+    # float("-inf") / float("nan"); MSL has literals for those.  Reduction
+    # identities for max/min are the main source.
+    if (
+        isinstance(func, ast.Name)
+        and func.id == "float"
+        and len(node.args) == 1
+        and isinstance(node.args[0], ast.Constant)
+        and isinstance(node.args[0].value, str)
+    ):
+        text = node.args[0].value.strip().lower()
+        literal = _NON_FINITE_FLOATS.get(text)
+        if literal is None:
+            raise exc.BackendUnsupported("metal", f"float constant: {text!r}")
+        return literal
+
     # tl.load(ptr + offset, mask, other=0) → (mask ? *(ptr+offset) : (other))
     if (
         isinstance(func, ast.Attribute)
@@ -748,7 +795,14 @@ def _ast_call_to_msl(node: ast.AST, subs: dict[str, str] | None = None) -> str:
     return f"{func_msl}({', '.join(args_msl)})"
 
 
-_CPP_NAMESPACE_ROOTS = frozenset({"metal", "c10"})
+#: What Inductor's ``constant_repr`` emits for non-finite float constants.
+_NON_FINITE_FLOATS = {
+    "inf": "INFINITY",
+    "-inf": "(-INFINITY)",
+    "nan": "NAN",
+}
+
+_CPP_NAMESPACE_ROOTS = frozenset({"metal", "c10", REDUCTION_NAMESPACE})
 
 
 def _is_cpp_namespace_root(node: ast.Attribute) -> bool:
@@ -763,12 +817,34 @@ def _is_cpp_namespace_root(node: ast.Attribute) -> bool:
     return isinstance(node.value, ast.Name) and node.value.id in _CPP_NAMESPACE_ROOTS
 
 
+def _is_broadcast_subscript(index: ast.expr) -> bool:
+    """Return True for a pure reshape/broadcast index such as ``[:, None]``."""
+    elts = index.elts if isinstance(index, ast.Tuple) else [index]
+    if not elts:
+        return False
+    return all(
+        (
+            isinstance(elt, ast.Slice)
+            and elt.lower is None
+            and elt.upper is None
+            and elt.step is None
+        )
+        or (isinstance(elt, ast.Constant) and elt.value is None)
+        for elt in elts
+    )
+
+
 def _ast_subscript_to_msl(node: ast.AST, subs: dict[str, str] | None = None) -> str:
     """Convert an AST Subscript node to MSL.
 
-    Only simple index subscripts (e.g. ``tgid[0]``) are supported.
+    Only simple index subscripts (e.g. ``tgid[0]``) are supported, plus
+    tile-shape broadcasts (``x[:, None]``), which Helion emits when a reduced
+    value is broadcast back over the reduction axis.  Metal values are
+    per-thread scalars, so those are a no-op.
     """
     assert isinstance(node, ast.Subscript)
+    if _is_broadcast_subscript(node.slice):
+        return _ast_expr_to_msl(node.value, subs=subs)
     buf_name = _ast_expr_to_msl(node.value, subs=subs)
     idx = _ast_expr_to_msl(node.slice, subs=subs)
     return f"{buf_name}[{idx}]"

--- a/helion/_compiler/metal/msl_reduction.py
+++ b/helion/_compiler/metal/msl_reduction.py
@@ -1,0 +1,200 @@
+"""MSL device-side reduction preamble for the Metal backend.
+
+The heavy lifting is done by Inductor's ``c10/metal/reduction_utils.h``, which
+already ships with PyTorch and is reachable from ``torch.mps.compile_shader``
+(it embeds the ``c10`` headers).  It provides, for every dtype Helion supports:
+
+- ``c10::metal::simd_{sum,prod,max,min}`` -- 32-lane SIMD-group reductions with
+  bfloat upcasting, a ``long`` fallback (Metal has no 64-bit SIMD reduction),
+  and NaN propagation for floating-point min/max.
+- ``c10::metal::simd_arg{min,max}(value, index)`` -- ``simd_ballot``-based
+  index selection returning a ``pair``.
+
+This module wraps those helpers for Helion's needs: leading barriers make
+threadgroup scratch reusable inside device loops, segmented butterflies isolate
+sub-SIMD-group reductions, and argreductions compare carried global indices
+rather than assuming that SIMD lane order is index order.
+
+The one primitive it does *not* reuse is ``c10::metal::threadgroup_*``: that
+helper re-reduces with a partially populated SIMD group, which the ``long``
+emulation mis-handles.  ``HELION_TG_REDUCE`` below builds the same two-stage
+reduction on top of ``c10::metal::simd_*`` with the second stage padded out to
+a full SIMD group.
+"""
+
+from __future__ import annotations
+
+#: ``#include`` lines added to the MSL preamble when a kernel reduces.
+REDUCTION_INCLUDES: tuple[str, ...] = ("#include <c10/metal/reduction_utils.h>",)
+
+#: Reduction kinds that map onto a ``c10::metal::`` primitive.
+SUPPORTED_REDUCTIONS = frozenset({"sum", "prod", "max", "min"})
+SUPPORTED_ARGREDUCTIONS = frozenset({"argmin", "argmax"})
+
+#: MSL namespace holding Helion's reduction entry points.  Every reduction the
+#: Metal backend emits goes through it -- including the ones that are a plain
+#: forward to ``c10::metal`` -- so ``metal_jit`` can decide whether a kernel
+#: needs the reduction preamble by looking for this single name.
+REDUCTION_NAMESPACE = "helion_red"
+
+REDUCTION_PREAMBLE = """
+namespace helion_red {
+
+// Whole-SIMD-group reductions, straight from Inductor.
+#define HELION_SIMD_REDUCE(NAME)                                   \\
+  template <typename T>                                            \\
+  inline T simd_##NAME(T v) {                                      \\
+    return ::c10::metal::simd_##NAME(v);                           \\
+  }
+HELION_SIMD_REDUCE(sum)
+HELION_SIMD_REDUCE(prod)
+HELION_SIMD_REDUCE(max)
+HELION_SIMD_REDUCE(min)
+#undef HELION_SIMD_REDUCE
+
+// Metal has no 64-bit simd_shuffle_xor overload; shuffle the halves instead.
+template <typename T>
+inline T sxor(T v, ushort m) {
+  return ::metal::simd_shuffle_xor(v, m);
+}
+inline long sxor(long v, ushort m) {
+  uint2 p = as_type<uint2>(v);
+  return as_type<long>(uint2(::metal::simd_shuffle_xor(p.x, m),
+                             ::metal::simd_shuffle_xor(p.y, m)));
+}
+inline ulong sxor(ulong v, ushort m) {
+  uint2 p = as_type<uint2>(v);
+  return as_type<ulong>(uint2(::metal::simd_shuffle_xor(p.x, m),
+                              ::metal::simd_shuffle_xor(p.y, m)));
+}
+
+// Butterfly over `span` contiguous lanes (a power of two dividing the SIMD
+// width), leaving the group result in every lane of the group.  Used when a
+// SIMD group holds more than one reduction group, where c10::metal::simd_*
+// would fold unrelated groups together.
+#define HELION_SEG_REDUCE(NAME, EXPR)                              \\
+  template <typename T>                                            \\
+  inline T seg_##NAME(T v, uint span) {                            \\
+    for (uint off = span >> 1; off > 0; off >>= 1) {               \\
+      T o = sxor(v, ushort(off));                                  \\
+      v = (EXPR);                                                  \\
+    }                                                              \\
+    return v;                                                      \\
+  }
+HELION_SEG_REDUCE(sum, v + o)
+HELION_SEG_REDUCE(prod, v * o)
+HELION_SEG_REDUCE(max, ::c10::metal::max(v, o))
+HELION_SEG_REDUCE(min, ::c10::metal::min(v, o))
+#undef HELION_SEG_REDUCE
+
+// "Is this the extremum?" -- NaN counts as one, matching torch and
+// c10::metal::simd_arg*.  The integral case has no NaN.
+template <typename T>
+inline bool is_extremum(T v, T best) {
+  return v == best;
+}
+inline bool is_extremum(float v, float best) {
+  return v == best || ::metal::isnan(v);
+}
+inline bool is_extremum(half v, half best) {
+  return v == best || ::metal::isnan(v);
+}
+inline bool is_extremum(bfloat v, bfloat best) {
+  return v == best || ::metal::isnan(float(v));
+}
+
+// Whole-SIMD-group argmin/argmax.  c10::metal::simd_arg* selects the first
+// winning SIMD lane, which is only the lowest index when each lane carries its
+// own lane index.  A rolled reduction instead carries the winner from several
+// chunks, so reduce the value first and then the global candidate index.
+#define HELION_SIMD_ARGREDUCE(NAME, VALUE_OP)                      \\
+  template <typename T, typename I>                                \\
+  inline I simd_##NAME(T v, I idx) {                               \\
+    T best = ::c10::metal::simd_##VALUE_OP(v);                     \\
+    I cand = is_extremum(v, best)                                  \\
+                 ? idx                                             \\
+                 : ::metal::numeric_limits<I>::max();              \\
+    return ::c10::metal::simd_min(cand);                           \\
+  }
+HELION_SIMD_ARGREDUCE(argmax, max)
+HELION_SIMD_ARGREDUCE(argmin, min)
+#undef HELION_SIMD_ARGREDUCE
+
+// Segmented argmin/argmax.  c10::metal::simd_arg* ballots over all 32 lanes,
+// which would span several reduction groups when span < 32; reduce the value
+// within the segment, then take the lowest index attaining it (torch's
+// tie-break).
+#define HELION_SEG_ARGREDUCE(NAME, VALUE_OP)                       \\
+  template <typename T, typename I>                                \\
+  inline I seg_##NAME(T v, I idx, uint span) {                     \\
+    T best = seg_##VALUE_OP(v, span);                              \\
+    I cand = is_extremum(v, best)                                  \\
+                 ? idx                                             \\
+                 : ::metal::numeric_limits<I>::max();              \\
+    return seg_min(cand, span);                                    \\
+  }
+HELION_SEG_ARGREDUCE(argmax, max)
+HELION_SEG_ARGREDUCE(argmin, min)
+#undef HELION_SEG_ARGREDUCE
+
+// Cross-SIMD-group reduction, in two stages: every SIMD group folds its own
+// lanes and writes one scratch slot, then the reduction group's first SIMD
+// group folds those slots and broadcasts slot 0 back to every thread.
+//
+// Deliberately not a forward to ``c10::metal::threadgroup_*``.  That helper
+// guards its second stage with ``idx < ceil(size / 32)``, so a span of
+// 64..512 re-reduces with only 2..16 of the 32 lanes live.  Metal has no
+// 64-bit SIMD reduction, so c10 emulates the ``long`` case with
+// ``simd_shuffle_and_fill_down``, whose fill is ``int2(0)`` -- the identity
+// for sum and for nothing else.  An int64 ``amax`` over an all-negative span
+// therefore returned 0.  Reading a padded slot instead keeps all 32 lanes
+// live, which is correct for every dtype and costs one select.
+//
+// The leading barrier makes the scratch buffer safe to reuse across
+// device-loop iterations: without it a fast thread's stage-1 write for
+// iteration i+1 can clobber a slow thread's broadcast read for iteration i.
+#define HELION_TG_REDUCE(NAME, IDENTITY)                                     \\
+  template <typename T>                                                      \\
+  inline T tg_##NAME(threadgroup T* buf, T v, uint idx, uint size) {         \\
+    constexpr uint w = ::c10::metal::simdgroup_size;                         \\
+    const uint groups = (size + w - 1) / w;                                  \\
+    ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);       \\
+    T part = ::c10::metal::simd_##NAME(v);                                   \\
+    if (idx % w == 0) {                                                      \\
+      buf[idx / w] = part;                                                   \\
+    }                                                                        \\
+    ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);       \\
+    if (idx < w) {                                                           \\
+      T slot = idx < groups ? buf[idx] : T(IDENTITY);                        \\
+      T total = ::c10::metal::simd_##NAME(slot);                             \\
+      if (idx == 0) {                                                        \\
+        buf[0] = total;                                                      \\
+      }                                                                      \\
+    }                                                                        \\
+    ::metal::threadgroup_barrier(::metal::mem_flags::mem_threadgroup);       \\
+    return buf[0];                                                           \\
+  }
+HELION_TG_REDUCE(sum, 0)
+HELION_TG_REDUCE(prod, 1)
+HELION_TG_REDUCE(max, ::metal::numeric_limits<T>::lowest())
+HELION_TG_REDUCE(min, ::metal::numeric_limits<T>::max())
+#undef HELION_TG_REDUCE
+
+// Each tg_* below carries its own leading barrier, which is what keeps the
+// value pass and the index pass from racing on their separate buffers.
+#define HELION_TG_ARGREDUCE(NAME, VALUE_OP)                                  \\
+  template <typename T, typename I>                                          \\
+  inline I tg_##NAME(threadgroup T* vbuf, threadgroup I* ibuf, T v, I i,      \\
+                     uint idx, uint size) {                                  \\
+    T best = tg_##VALUE_OP(vbuf, v, idx, size);                              \\
+    I cand = is_extremum(v, best)                                            \\
+                 ? i                                                        \\
+                 : ::metal::numeric_limits<I>::max();                       \\
+    return tg_min(ibuf, cand, idx, size);                                    \\
+  }
+HELION_TG_ARGREDUCE(argmax, max)
+HELION_TG_ARGREDUCE(argmin, min)
+#undef HELION_TG_ARGREDUCE
+
+}  // namespace helion_red
+""".strip()

--- a/helion/_compiler/metal/reduction.py
+++ b/helion/_compiler/metal/reduction.py
@@ -1,0 +1,402 @@
+"""Metal reduction expression emitters.
+
+Turns Helion's backend-neutral reduction requests into MSL text built on
+Inductor's ``c10::metal::`` reduction helpers (see :mod:`.msl_reduction` for
+what comes from where).
+
+Reduction group layout
+----------------------
+``MetalBackend.reduction_axis_first()`` is ``True``, so a reduction owns a whole
+thread axis and tiles occupy the axes above it.  ``tid`` is laid out with
+``tid[0]`` fastest-varying, and Metal assigns SIMD groups in that linear order,
+so a reduction on axis 0 covers a contiguous run of lanes.  Three cases follow,
+in increasing cost:
+
+======================  ==========================================  =============
+span (reduction lanes)  emission                                    cost
+======================  ==========================================  =============
+``< 32``                ``helion_red::seg_*`` butterfly             shuffles only
+``== 32``               ``helion_red::simd_*``                      shuffles only
+``% 32 == 0``           ``helion_red::tg_*`` + threadgroup scratch  3 barriers
+======================  ==========================================  =============
+
+Spans are always powers of two (``static_rdim_size`` rounds the reduction
+extent up), so a span above the SIMD width is automatically a whole number of
+SIMD groups.  Spans wider than one threadgroup never reach here: the config
+spec rolls those into a ``for`` loop over the reduction dimension, and only the
+per-thread accumulator is combined across threads.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+
+from ... import exc
+from ..ast_extension import statement_from_string
+from ._constants import MAX_SIMD_GROUPS
+from ._constants import MAX_THREADS_PER_THREADGROUP
+from ._constants import SIMD_WIDTH
+from .msl_reduction import REDUCTION_NAMESPACE as NS
+from .msl_reduction import SUPPORTED_ARGREDUCTIONS
+from .msl_reduction import SUPPORTED_REDUCTIONS
+
+if TYPE_CHECKING:
+    import torch
+
+    from ..device_function import DeviceFunction
+
+#: Prefix of the generated module-level globals that carry threadgroup scratch
+#: declarations from codegen to ``metal_jit._generate_msl``.  Mirrors how
+#: ``_BLOCK_SIZE_*`` globals reach the same place.
+TG_BUFFER_GLOBAL_PREFIX = "_METAL_TG_BUF_"
+
+#: Name of the MSL kernel parameter bound to
+#: ``[[simdgroup_index_in_threadgroup]]``, used to pick a reduction group's
+#: slice of the shared scratch buffer.
+SIMD_GROUP_VAR = "_simd_group"
+
+
+def _metal_acc_dtype(dtype: torch.dtype) -> str:
+    """MSL *accumulator* type for a reduction over values of ``dtype``.
+
+    Not the storage type: ``c10::metal::threadgroup_sum`` takes its scratch as
+    ``threadgroup opmath_t<T>*``, and ``c10/metal/utils.h`` promotes
+    ``char``/``short``/``uchar`` to ``int`` -- so passing a ``threadgroup char*``
+    has no viable overload and the shader fails to compile.  ``simd_shuffle_xor``
+    likewise has no ``bool`` overload.  ``Backend.acc_type`` already encodes the
+    right promotion for every dtype Metal supports.
+    """
+    from ..compile_environment import CompileEnvironment
+
+    return CompileEnvironment.current().backend.acc_type(dtype)
+
+
+def alloc_threadgroup_buffer(metal_dtype: str) -> str:
+    """Reserve a ``threadgroup`` scratch array and return its MSL name.
+
+    Every reduction site gets its own buffer.  Sharing one buffer between two
+    reductions in the same kernel (LayerNorm's mean and variance, say) races on
+    Apple GPUs even with barriers in between, and ``slots`` is only 32 entries,
+    so the isolation is cheap.
+    """
+    from ..device_function import DeviceFunction
+
+    device_fn = DeviceFunction.current()
+    name = device_fn.new_var("_red_scratch")
+    device_fn.codegen.module_statements.append(
+        statement_from_string(
+            f"{TG_BUFFER_GLOBAL_PREFIX}{name} = "
+            f"({name!r}, {metal_dtype!r}, {MAX_SIMD_GROUPS})"
+        )
+    )
+    return name
+
+
+@dataclasses.dataclass(frozen=True)
+class ReductionGroup:
+    """Where a reduction's threads live in the Metal threadgroup.
+
+    ``axis`` is the ``tid`` component the reduction spans, ``span`` how many
+    threads it spans, and ``stride`` the distance between consecutive members
+    on the linear thread index (``tid[0] + tid[1] * dim0 + ...``).  Only
+    ``stride == 1`` groups map onto SIMD lanes, which every Metal reduction
+    primitive requires.
+    """
+
+    axis: int
+    span: int
+    stride: int
+
+    @property
+    def index_expr(self) -> str:
+        return f"tid[{self.axis}]"
+
+
+def resolve_group(
+    device_fn: DeviceFunction, block_size_var: str | None
+) -> ReductionGroup | None:
+    """Locate the reduction strategy owning *block_size_var* and describe it."""
+    from ..reduction_strategy import ReductionStrategy
+    from ..tile_strategy import BlockSizeTileStrategy
+
+    tile_strategy = device_fn.tile_strategy
+    dims = tile_strategy.thread_block_dims()
+
+    def make(axis: int, span: int) -> ReductionGroup:
+        stride = 1
+        for lower in range(min(axis, len(dims))):
+            stride *= max(1, dims[lower])
+        return ReductionGroup(axis, span, stride)
+
+    for strategy in tile_strategy.strategies:
+        if not isinstance(strategy, ReductionStrategy):
+            continue
+        if strategy.block_size_var(strategy.block_index) != block_size_var:
+            continue
+        span = strategy._reduction_thread_count()
+        return make(strategy._get_thread_axis(), span) if span > 0 else None
+
+    # ``BlockReductionStrategy`` reduces over a user tile, so the block size var
+    # belongs to the tile strategy that owns the axis instead.
+    for strategy in tile_strategy.strategies:
+        if not isinstance(strategy, BlockSizeTileStrategy):
+            continue
+        for block_id in strategy.block_ids:
+            if strategy.block_size_var(block_id) != block_size_var:
+                continue
+            axis = _tile_thread_axis(device_fn, block_id)
+            extent = tile_strategy.thread_extent_for_block_id(block_id)
+            if axis is None or extent is None or extent <= 0:
+                return None
+            return make(axis, extent)
+    return None
+
+
+def _tile_thread_axis(device_fn: DeviceFunction, block_id: int) -> int | None:
+    """Thread axis a tile block occupies in the active loop nest, if any."""
+    from ..tile_strategy import DeviceGridState
+    from ..tile_strategy import DeviceLoopState
+
+    codegen = device_fn.codegen
+    current_grid = codegen.current_grid_state
+    if isinstance(current_grid, DeviceGridState):
+        axis = current_grid.block_thread_axes.get(block_id)
+        if axis is not None:
+            return axis
+    for loops in codegen.active_device_loops.values():
+        for loop_state in loops:
+            if not isinstance(loop_state, (DeviceGridState, DeviceLoopState)):
+                continue
+            axis = loop_state.block_thread_axes.get(block_id)
+            if axis is not None:
+                return axis
+    return None
+
+
+def _unsupported_span(reduction_type: str, span: int) -> exc.BackendUnsupported:
+    return exc.BackendUnsupported(
+        "metal",
+        f"{reduction_type} reduction over {span} threads (the reduction must "
+        f"span a power-of-two group of at most {MAX_THREADS_PER_THREADGROUP} "
+        f"threads, and beyond {SIMD_WIDTH} a whole number of SIMD groups)",
+    )
+
+
+def _cast(expr: str, dtype: torch.dtype | None) -> tuple[str, str]:
+    """Cast *expr* to the accumulation dtype and return ``(expr, metal_type)``.
+
+    Casting up front pins the template argument of the ``c10::metal::`` helper,
+    which is what makes the scratch buffer's element type predictable: a masked
+    fp16 load can still carry its storage dtype into an fp32 accumulation.
+    """
+    if dtype is None:
+        raise exc.BackendUnsupported("metal", "reduction without an accumulator dtype")
+    metal_type = _metal_acc_dtype(dtype)
+    return f"(static_cast<{metal_type}>({expr}))", metal_type
+
+
+def _reject_strided_group(reduction_type: str, group: ReductionGroup | None) -> None:
+    """Metal's SIMD reductions fold adjacent lanes, so a group whose members are
+    not lane-contiguous would combine unrelated rows."""
+    if group is not None and group.stride != 1:
+        raise exc.BackendUnsupported(
+            "metal",
+            f"{reduction_type} over a strided thread axis (axis {group.axis}, "
+            f"lane stride {group.stride}); Metal needs the reduced dimension to "
+            "be the fastest-varying thread axis",
+        )
+
+
+def reduction_expr(
+    input_name: str,
+    reduction_type: str,
+    *,
+    block_size_var: str | None,
+    threads_in_group: int | None,
+    dtype: torch.dtype | None,
+) -> str:
+    from ..device_function import DeviceFunction
+
+    if reduction_type not in SUPPORTED_REDUCTIONS:
+        raise exc.BackendUnsupported("metal", f"reduction {reduction_type!r}")
+
+    device_fn = DeviceFunction.current()
+    group = resolve_group(device_fn, block_size_var)
+    span = (
+        threads_in_group
+        if threads_in_group is not None
+        else (group.span if group is not None else None)
+    )
+    value, metal_type = _cast(input_name, dtype)
+
+    if span is None:
+        raise exc.BackendUnsupported(
+            "metal", f"unresolved thread group for reduction {reduction_type!r}"
+        )
+    if span <= 1:
+        return value
+    if span & (span - 1):
+        raise _unsupported_span(reduction_type, span)
+    _reject_strided_group(reduction_type, group)
+
+    if span < SIMD_WIDTH:
+        return f"{NS}.seg_{reduction_type}({value}, {span})"
+    if span == SIMD_WIDTH:
+        return f"{NS}.simd_{reduction_type}({value})"
+    if span % SIMD_WIDTH or span > MAX_THREADS_PER_THREADGROUP:
+        raise _unsupported_span(reduction_type, span)
+
+    if group is None:
+        # ``c10::metal::threadgroup_*`` needs each thread's index *within* the
+        # reduction group to pick its scratch slot; guessing ``tid[0]`` would
+        # make every thread claim slot 0 and race.  The sub-SIMD-group and
+        # single-SIMD-group tiers above need no such index, so only the shared
+        # path has to bail.
+        raise exc.BackendUnsupported(
+            "metal",
+            f"{reduction_type} reduction over {span} threads whose thread axis "
+            "could not be resolved",
+        )
+    buffer = alloc_threadgroup_buffer(metal_type)
+    return (
+        f"{NS}.tg_{reduction_type}("
+        f"{buffer} + {_group_base_expr(span)}, {value}, {group.index_expr}, {span})"
+    )
+
+
+def _group_base_expr(span: int) -> str:
+    """Offset of this reduction group's slice of the shared scratch buffer.
+
+    ``[[simdgroup_index_in_threadgroup]]`` counts SIMD groups over the whole
+    threadgroup, and a span that is a multiple of the SIMD width means each
+    reduction group owns ``span / 32`` consecutive SIMD groups.
+    """
+    simd_groups = span // SIMD_WIDTH
+    return f"({SIMD_GROUP_VAR} / {simd_groups}) * {simd_groups}"
+
+
+def reduction_combine_expr(
+    reduction_type: str, acc: str, val: str, dtype: torch.dtype
+) -> str:
+    """Per-iteration combine for ``LoopedReductionStrategy``'s accumulator."""
+    value, _ = _cast(val, dtype)
+    if reduction_type == "sum":
+        return f"({acc} + {value})"
+    if reduction_type == "prod":
+        return f"({acc} * {value})"
+    # c10::metal::max/min propagate NaN, matching torch semantics; ::metal:: does not.
+    if reduction_type in ("max", "min"):
+        return f"c10.metal.{reduction_type}({acc}, {value})"
+    raise exc.BackendUnsupported("metal", f"reduction combine {reduction_type!r}")
+
+
+def argreduce_result_expr(
+    input_name: str,
+    index_value: str,
+    reduction_type: str,
+    output_dtype: torch.dtype,
+    *,
+    block_size_var: str | None,
+    index_dtype: torch.dtype | None,
+    threads_in_group: int | None,
+    dtype: torch.dtype | None,
+) -> str:
+    from ..compile_environment import CompileEnvironment
+    from ..device_function import DeviceFunction
+
+    if reduction_type not in SUPPORTED_ARGREDUCTIONS:
+        raise exc.BackendUnsupported("metal", f"reduction {reduction_type!r}")
+    if index_dtype is None:
+        raise exc.BackendUnsupported("metal", "missing index_dtype for argreduce")
+
+    backend = CompileEnvironment.current().backend
+    device_fn = DeviceFunction.current()
+    group = resolve_group(device_fn, block_size_var)
+    span = (
+        threads_in_group
+        if threads_in_group is not None
+        else (group.span if group is not None else None)
+    )
+    value, value_type = _cast(input_name, dtype)
+    index_type = backend.index_type_str(index_dtype)
+    index = f"(static_cast<{index_type}>({index_value}))"
+    out_type = backend.dtype_str(output_dtype)
+
+    if span is None:
+        raise exc.BackendUnsupported(
+            "metal", f"unresolved thread group for reduction {reduction_type!r}"
+        )
+    if span <= 1:
+        return f"(static_cast<{out_type}>({index}))"
+    if span & (span - 1) or span > MAX_THREADS_PER_THREADGROUP:
+        raise _unsupported_span(reduction_type, span)
+    _reject_strided_group(reduction_type, group)
+    if span < SIMD_WIDTH:
+        result = f"{NS}.seg_{reduction_type}({value}, {index}, {span})"
+        return f"(static_cast<{out_type}>({result}))"
+
+    if span == SIMD_WIDTH:
+        result = f"{NS}.simd_{reduction_type}({value}, {index})"
+        return f"(static_cast<{out_type}>({result}))"
+
+    if span % SIMD_WIDTH:
+        raise _unsupported_span(reduction_type, span)
+    if group is None:
+        # See reduction_expr: the shared tier needs the in-group thread index.
+        raise exc.BackendUnsupported(
+            "metal",
+            f"{reduction_type} over {span} threads whose thread axis could not "
+            "be resolved",
+        )
+    base = _group_base_expr(span)
+    value_buffer = alloc_threadgroup_buffer(value_type)
+    index_buffer = alloc_threadgroup_buffer(index_type)
+    result = (
+        f"{NS}.tg_{reduction_type}("
+        f"{value_buffer} + {base}, {index_buffer} + {base}, "
+        f"{value}, {index}, {group.index_expr}, {span})"
+    )
+    return f"(static_cast<{out_type}>({result}))"
+
+
+def argreduce_loop_update_statements(
+    *,
+    reduction_type: str,
+    acc: str,
+    acc_index: str,
+    value: str,
+    index: str,
+    dtype: torch.dtype | None,
+) -> list[str]:
+    """Branch-free accumulator update for a rolled argmin/argmax.
+
+    Lowest index wins a tie, matching Inductor's MPS semantics (``mps.py``) and
+    torch.  The tie is explicit rather than implied by a strict comparison: the
+    accumulator index starts at ``reduction_index_init_expr`` (INT_MAX), so a
+    row that never strictly beats the identity -- an all-``-inf`` row under
+    argmax, say -- would otherwise never write ``acc_index`` and return the
+    sentinel as if it were a position.
+
+    NaN counts as a new extremum for floats, but only over a non-NaN
+    accumulator.  Letting it win against a NaN too would keep moving the index
+    forward and report the *last* NaN a thread saw; the equality tie-break
+    cannot cover this, since ``NaN != NaN``.
+    """
+    from ..device_function import DeviceFunction
+
+    if reduction_type not in SUPPORTED_ARGREDUCTIONS:
+        raise exc.BackendUnsupported("metal", f"reduction {reduction_type!r}")
+    op = ">" if reduction_type == "argmax" else "<"
+    better = (
+        f"(({value}) {op} ({acc}))"
+        f" or ((({value}) == ({acc})) and (({index}) < ({acc_index})))"
+    )
+    if dtype is not None and dtype.is_floating_point:
+        better = f"({better} or (metal.isnan({value}) and not metal.isnan({acc})))"
+    flag = DeviceFunction.current().new_var("_argreduce_better")
+    return [
+        f"{flag} = {better}",
+        f"{acc_index} = ({index} if {flag} else {acc_index})",
+        f"{acc} = ({value} if {flag} else {acc})",
+    ]

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -453,6 +453,7 @@ class PallasBackend(Backend):
         *,
         block_size_var: str | None = None,
         threads_in_group: int | None = None,
+        dtype: torch.dtype | None = None,
     ) -> str:
         if reduction_type in {"sum", "max", "min", "prod"}:
             return f"jnp.{reduction_type}({input_name}, axis={dim})"
@@ -472,6 +473,7 @@ class PallasBackend(Backend):
         block_size_var: str | None = None,
         index_dtype: torch.dtype | None = None,
         threads_in_group: int | None = None,
+        dtype: torch.dtype | None = None,
     ) -> str:
         fn = "jnp.argmax" if reduction_type == "argmax" else "jnp.argmin"
         return (
@@ -487,6 +489,7 @@ class PallasBackend(Backend):
         acc_index: str,
         value: str,
         index: str,
+        dtype: torch.dtype | None = None,
     ) -> list[str]:
         if reduction_type == "argmin":
             better = (

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -615,6 +615,7 @@ class ReductionStrategy(TileStrategy):
         fake_output: torch.Tensor,
     ) -> str:
         backend = CompileEnvironment.current().backend
+        acc_dtype = get_computation_dtype(fake_input.dtype)
         if backend.is_indexed_reduction(reduction_type):
             index_var = self.index_var(self.block_index)
             return self.call_indexed_reduction(
@@ -623,12 +624,14 @@ class ReductionStrategy(TileStrategy):
                 reduction_type,
                 dim,
                 fake_output,
+                dtype=acc_dtype,
             )
         return backend.reduction_expr(
             input_name,
             reduction_type,
             dim,
             block_size_var=self.block_size_var(self.block_index),
+            dtype=acc_dtype,
         )
 
     def _index_init_expr(self, block_size_var: str, dtype: str, block_idx: int) -> str:
@@ -650,6 +653,8 @@ class ReductionStrategy(TileStrategy):
         reduction_type: str,
         dim: int,
         fake_output: torch.Tensor,
+        *,
+        dtype: torch.dtype | None = None,
     ) -> str:
         env = CompileEnvironment.current()
         return env.backend.argreduce_result_expr(
@@ -660,6 +665,7 @@ class ReductionStrategy(TileStrategy):
             fake_output.dtype,
             block_size_var=self.block_size_var(self.block_index),
             index_dtype=env.index_dtype,
+            dtype=dtype,
         )
 
     def maybe_reshape(
@@ -1748,7 +1754,9 @@ class LoopedReductionStrategy(ReductionStrategy):
             assert isinstance(default, (float, int, bool))
             assert state.fx_node is not None
             acc = self.fn.new_var(f"{state.fx_node.name}_acc", dce=True)
-            acc_full = backend.full_expr(shape_dims, constant_repr(default), acc_dtype)
+            acc_full = backend.reduction_acc_init_expr(
+                shape_dims, constant_repr(default), acc_dtype
+            )
             device_loop.outer_prefix.append(
                 statement_from_string(f"{acc} = {acc_full}")
             )
@@ -1827,6 +1835,7 @@ class LoopedReductionStrategy(ReductionStrategy):
                     acc_index=acc_index,
                     value=input_name,
                     index=index,
+                    dtype=acc_dtype,
                 ):
                     state.add_statement(stmt)
                 expr = self.call_indexed_reduction(
@@ -1835,6 +1844,7 @@ class LoopedReductionStrategy(ReductionStrategy):
                     reduction_type,
                     dim,
                     fake_output,
+                    dtype=acc_dtype,
                 )
             # Ensure the final reduction result matches torch.* dtype semantics
             expr = self.maybe_reshape(expr, dim, fake_input, fake_output)
@@ -2644,6 +2654,16 @@ class BlockReductionStrategy(ReductionStrategy):
                     shape_dims, constant_repr(default), fake_output.dtype
                 )
             )
+        has_lane_loop = (
+            self._reduction_block_has_lane_loops()
+            or self._reduction_block_in_device_lane_loop()
+        )
+        if has_lane_loop and not env.backend.supports_lane_loop_reductions():
+            raise exc.BackendUnsupported(
+                env.backend.name,
+                f"{reduction_type} reduction over an axis strided by a tile lane "
+                "loop; this backend does not support lane-loop reductions",
+            )
         if (
             strided_expr := self._strided_thread_reduction_expr(
                 state, input_name, reduction_type, dim, fake_input, default
@@ -2655,10 +2675,7 @@ class BlockReductionStrategy(ReductionStrategy):
             # active loop nest (it is iterated either by a serial device loop,
             # by a lane loop, or has no thread axis at all).
             if (
-                (
-                    self._reduction_block_has_lane_loops()
-                    or self._reduction_block_in_device_lane_loop()
-                )
+                has_lane_loop
                 and not self._lane_reduce_marker_unsupported(state)
                 and (threads := self._lane_reduce_threads_in_group()) is not None
             ):

--- a/helion/_compiler/triton/backend.py
+++ b/helion/_compiler/triton/backend.py
@@ -427,6 +427,7 @@ class TritonBackend(Backend):
         *,
         block_size_var: str | None = None,
         threads_in_group: int | None = None,
+        dtype: torch.dtype | None = None,
     ) -> str:
         if reduction_type in {"sum", "max", "min"}:
             return f"tl.{reduction_type}({input_name}, {dim})"
@@ -448,6 +449,7 @@ class TritonBackend(Backend):
         block_size_var: str | None = None,
         index_dtype: torch.dtype | None = None,
         threads_in_group: int | None = None,
+        dtype: torch.dtype | None = None,
     ) -> str:
         helper = "max" if reduction_type == "argmax" else "min"
         return (
@@ -463,6 +465,7 @@ class TritonBackend(Backend):
         acc_index: str,
         value: str,
         index: str,
+        dtype: torch.dtype | None = None,
     ) -> list[str]:
         helper = "maximum" if reduction_type == "argmax" else "minimum"
         return [

--- a/test/test_metal.py
+++ b/test/test_metal.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 import sys
 import unittest
 from unittest.mock import patch
@@ -1294,6 +1295,827 @@ class TestMetalMatmul(unittest.TestCase):
                 torch.testing.assert_close(
                     kernel(x, y, bias), expected, rtol=2e-3, atol=2e-3
                 )
+
+
+# ---------------------------------------------------------------------------
+# Kernel definitions - reductions
+# ---------------------------------------------------------------------------
+
+_REDUCTION_CONFIG = [helion.Config(block_sizes=[16])]
+
+
+@helion.kernel(backend="metal", configs=_REDUCTION_CONFIG)
+def row_sum(x: torch.Tensor) -> torch.Tensor:
+    m, _ = x.shape
+    out = torch.empty([m], dtype=x.dtype, device=x.device)
+    for tile_m in hl.tile(m):
+        out[tile_m] = x[tile_m, :].sum(-1)
+    return out
+
+
+@helion.kernel(backend="metal", configs=_REDUCTION_CONFIG)
+def row_amax(x: torch.Tensor) -> torch.Tensor:
+    m, _ = x.shape
+    out = torch.empty([m], dtype=x.dtype, device=x.device)
+    for tile_m in hl.tile(m):
+        out[tile_m] = torch.amax(x[tile_m, :], dim=-1)
+    return out
+
+
+@helion.kernel(backend="metal", configs=_REDUCTION_CONFIG)
+def row_amin(x: torch.Tensor) -> torch.Tensor:
+    m, _ = x.shape
+    out = torch.empty([m], dtype=x.dtype, device=x.device)
+    for tile_m in hl.tile(m):
+        out[tile_m] = torch.amin(x[tile_m, :], dim=-1)
+    return out
+
+
+@helion.kernel(backend="metal", configs=_REDUCTION_CONFIG)
+def row_prod(x: torch.Tensor) -> torch.Tensor:
+    m, _ = x.shape
+    out = torch.empty([m], dtype=x.dtype, device=x.device)
+    for tile_m in hl.tile(m):
+        out[tile_m] = torch.prod(x[tile_m, :], dim=-1)
+    return out
+
+
+@helion.kernel(backend="metal", configs=_REDUCTION_CONFIG)
+def row_mean(x: torch.Tensor) -> torch.Tensor:
+    m, _ = x.shape
+    out = torch.empty([m], dtype=x.dtype, device=x.device)
+    for tile_m in hl.tile(m):
+        out[tile_m] = torch.mean(x[tile_m, :], dim=-1)
+    return out
+
+
+@helion.kernel(backend="metal", configs=_REDUCTION_CONFIG)
+def row_argmax(x: torch.Tensor) -> torch.Tensor:
+    m, _ = x.shape
+    out = torch.empty([m], dtype=torch.int64, device=x.device)
+    for tile_m in hl.tile(m):
+        out[tile_m] = torch.argmax(x[tile_m, :], dim=-1)
+    return out
+
+
+@helion.kernel(backend="metal", configs=_REDUCTION_CONFIG)
+def row_argmin(x: torch.Tensor) -> torch.Tensor:
+    m, _ = x.shape
+    out = torch.empty([m], dtype=torch.int64, device=x.device)
+    for tile_m in hl.tile(m):
+        out[tile_m] = torch.argmin(x[tile_m, :], dim=-1)
+    return out
+
+
+@helion.kernel(backend="metal", configs=_REDUCTION_CONFIG)
+def softmax_decomposed(x: torch.Tensor) -> torch.Tensor:
+    m, _ = x.shape
+    out = torch.empty_like(x)
+    for tile_m in hl.tile(m):
+        values = x[tile_m, :]
+        amax = torch.amax(values, dim=1, keepdim=True)
+        exp_v = torch.exp(values - amax)
+        out[tile_m, :] = exp_v / torch.sum(exp_v, dim=1, keepdim=True)
+    return out
+
+
+@helion.kernel(backend="metal", configs=_REDUCTION_CONFIG)
+def rms_norm_fwd(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    m, _ = x.shape
+    out = torch.empty_like(x)
+    for tile_m in hl.tile(m):
+        x_tile = x[tile_m, :].to(torch.float32)
+        mean_sq = torch.mean(x_tile * x_tile, dim=-1, keepdim=True)
+        normalized = x_tile * torch.rsqrt(mean_sq + 1e-5)
+        out[tile_m, :] = (normalized * weight[:].to(torch.float32)).to(x.dtype)
+    return out
+
+
+@helion.kernel(backend="metal", configs=_REDUCTION_CONFIG)
+def layer_norm_fwd(
+    x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor
+) -> torch.Tensor:
+    m, n = x.shape
+    out = torch.empty_like(x)
+    for tile_m in hl.tile(m):
+        acc = x[tile_m, :].to(torch.float32)
+        mean = torch.sum(acc, dim=-1, keepdim=True) / n
+        centered = acc - mean
+        var = torch.sum(centered * centered, dim=-1, keepdim=True) / n
+        normalized = centered * torch.rsqrt(var + 1e-5)
+        out[tile_m, :] = (normalized * weight[:] + bias[:]).to(x.dtype)
+    return out
+
+
+@helion.kernel(
+    backend="metal",
+    configs=_REDUCTION_CONFIG,
+    ignore_warnings=[exc.TensorOperationInWrapper],
+)
+def cross_entropy(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+    n, v = logits.shape
+    losses = torch.zeros([n], dtype=torch.float32, device=logits.device)
+    logits_flat = logits.view(-1)
+    for tile_n in hl.tile(n):
+        flat_indices = tile_n.index * v + labels[tile_n]
+        correct = hl.load(logits_flat, [flat_indices]).to(torch.float32)
+        row = logits[tile_n, :].to(torch.float32)
+        row_max = torch.amax(row, dim=-1)
+        shifted = row - row_max[:, None]
+        logsumexp = torch.log(torch.sum(torch.exp(shifted), dim=-1))
+        losses[tile_n] = logsumexp + row_max - correct
+    return losses
+
+
+@helion.kernel(backend="metal", configs=[helion.Config(block_sizes=[4, 2])])
+def sum_in_device_loop(x: torch.Tensor) -> torch.Tensor:
+    """Reduction inside a device loop, so its scratch buffer is reused.
+
+    The inner ``hl.tile(k)`` becomes a serial device loop, and the reduction
+    over the trailing dim runs once per iteration against the same
+    ``threadgroup`` scratch array.
+    """
+    m, k, _ = x.shape
+    out = torch.empty([m, k], dtype=torch.float32, device=x.device)
+    for tile_m in hl.tile(m):
+        for tile_k in hl.tile(k):
+            out[tile_m, tile_k] = x[tile_m, tile_k, :].to(torch.float32).sum(-1)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Reduction tests
+# ---------------------------------------------------------------------------
+
+
+@_requires_darwin
+class TestMetalReductions(unittest.TestCase):
+    """Reductions across all three Metal cross-thread reduction tiers.
+
+    The tier is chosen by the reduction's thread span (see
+    ``helion/_compiler/metal/reduction.py``):
+
+    ==============  ==========================================================
+    span            emission
+    ==============  ==========================================================
+    ``< 32``        ``helion_red::seg_*``, a shuffle butterfly over the segment
+    ``== 32``       ``c10::metal::simd_*``
+    ``> 32``        ``helion_red::tg_*`` + a ``threadgroup`` scratch buffer
+    ==============  ==========================================================
+
+    Spans above one threadgroup (1024) are rolled into a ``for`` loop over the
+    reduction dim by ``reduction_loops``.
+    """
+
+    def _check(
+        self,
+        kernel: helion.Kernel,
+        args: tuple[object, ...],
+        expected: torch.Tensor,
+        *,
+        rtol: float = 1e-4,
+        atol: float = 1e-4,
+    ) -> None:
+        result = kernel(*args)
+        torch.testing.assert_close(result, expected, rtol=rtol, atol=atol)
+
+    # -- span tiers ---------------------------------------------------------
+
+    def test_sum_sub_simdgroup_span(self) -> None:
+        """n=8: several reduction groups share one SIMD group."""
+        x = torch.randn(64, 8, device=DEVICE)
+        self._check(row_sum, (x,), x.sum(-1))
+
+    def test_sum_exact_simdgroup_span(self) -> None:
+        x = torch.randn(64, 32, device=DEVICE)
+        self._check(row_sum, (x,), x.sum(-1))
+
+    def test_sum_multi_simdgroup_span(self) -> None:
+        """n=256: 8 SIMD groups per reduction, via threadgroup scratch."""
+        x = torch.randn(64, 256, device=DEVICE)
+        self._check(row_sum, (x,), x.sum(-1))
+
+    def test_sum_full_threadgroup_span(self) -> None:
+        x = torch.randn(32, 1024, device=DEVICE)
+        self._check(row_sum, (x,), x.sum(-1), rtol=1e-3, atol=1e-3)
+
+    def test_sum_non_power_of_2(self) -> None:
+        """The padded lanes must be masked to the identity."""
+        x = torch.randn(64, 1000, device=DEVICE)
+        self._check(row_sum, (x,), x.sum(-1), rtol=1e-3, atol=1e-3)
+
+    def test_sum_rolled_reduction(self) -> None:
+        """n > 1024 rolls into a loop with a per-thread accumulator."""
+        x = torch.randn(64, 4096, device=DEVICE)
+        self._check(row_sum, (x,), x.sum(-1), rtol=1e-3, atol=1e-3)
+
+    def test_sum_deeply_rolled_reduction(self) -> None:
+        x = torch.randn(4, 65536, device=DEVICE)
+        self._check(row_sum, (x,), x.sum(-1), rtol=1e-2, atol=1e-2)
+
+    def test_sum_single_row(self) -> None:
+        """One row: the whole threadgroup cooperates on a single reduction."""
+        x = torch.randn(1, 8192, device=DEVICE)
+        self._check(row_sum, (x,), x.sum(-1), rtol=1e-3, atol=1e-3)
+
+    # -- reduction kinds ----------------------------------------------------
+
+    def test_amax(self) -> None:
+        x = torch.randn(33, 257, device=DEVICE)
+        self._check(row_amax, (x,), x.amax(-1))
+
+    def test_amax_propagates_nan(self) -> None:
+        x = torch.randn(8, 64, device=DEVICE)
+        x[3, 17] = float("nan")
+        result = row_amax(x)
+        self.assertTrue(torch.isnan(result[3]).item())
+        torch.testing.assert_close(result[:3], x[:3].amax(-1))
+
+    def test_amin(self) -> None:
+        x = torch.randn(33, 100, device=DEVICE)
+        self._check(row_amin, (x,), x.amin(-1))
+
+    def test_prod(self) -> None:
+        x = torch.rand(16, 16, device=DEVICE) + 0.5
+        self._check(row_prod, (x,), x.prod(-1))
+
+    def test_mean(self) -> None:
+        x = torch.randn(32, 512, device=DEVICE)
+        self._check(row_mean, (x,), x.mean(-1))
+
+    def test_argmax_sub_simdgroup_span(self) -> None:
+        x = torch.randn(32, 16, device=DEVICE)
+        self._check(row_argmax, (x,), x.argmax(-1))
+
+    def test_argmax_exact_simdgroup_span(self) -> None:
+        x = torch.randn(32, 32, device=DEVICE)
+        self._check(row_argmax, (x,), x.argmax(-1))
+
+    def test_argmax_multi_simdgroup_span(self) -> None:
+        x = torch.randn(32, 256, device=DEVICE)
+        self._check(row_argmax, (x,), x.argmax(-1))
+
+    def test_argmax_ties_take_lowest_index(self) -> None:
+        x = torch.zeros(4, 64, device=DEVICE)
+        x[:, 5] = 1.0
+        x[:, 40] = 1.0
+        self._check(row_argmax, (x,), x.argmax(-1))
+
+    def test_rolled_argreductions_take_lowest_global_index(self) -> None:
+        """The final cross-lane reduction must compare carried indices.
+
+        With a 4096-element row, lanes locally reduce four chunks.  Indices 1
+        and 1024 are therefore carried by different lanes in reverse index
+        order; selecting the first winning lane incorrectly returns 1024.
+        """
+        expected = torch.ones(4, dtype=torch.int64, device=DEVICE)
+        for kernel, name, extremum in (
+            (row_argmax, "argmax", 1.0),
+            (row_argmin, "argmin", -1.0),
+        ):
+            with self.subTest(kernel=name, case="tie"):
+                x = torch.zeros(4, 4096, device=DEVICE)
+                x[:, 1] = extremum
+                x[:, 1024] = extremum
+                self._check(kernel, (x,), expected)
+
+            with self.subTest(kernel=name, case="nan"):
+                x = torch.zeros(4, 4096, device=DEVICE)
+                x[:, 1] = float("nan")
+                x[:, 1024] = float("nan")
+                self._check(kernel, (x,), expected)
+
+    def test_argmin(self) -> None:
+        x = torch.randn(32, 256, device=DEVICE)
+        self._check(row_argmin, (x,), x.argmin(-1))
+
+    # -- dtypes -------------------------------------------------------------
+
+    def test_sum_float16(self) -> None:
+        # Helion and torch both accumulate in fp32 and round once, so the only
+        # slack needed is a rounding boundary flipped by summation order.
+        x = torch.randn(32, 128, dtype=torch.float16, device=DEVICE)
+        self._check(row_sum, (x,), x.sum(-1), rtol=5e-3, atol=5e-3)
+
+    def test_sum_bfloat16(self) -> None:
+        x = torch.randn(32, 128, dtype=torch.bfloat16, device=DEVICE)
+        self._check(row_sum, (x,), x.sum(-1), rtol=2e-2, atol=2e-2)
+
+    def test_sum_int32(self) -> None:
+        x = torch.randint(-50, 50, (32, 128), dtype=torch.int32, device=DEVICE)
+        self._check(row_sum, (x,), x.sum(-1).to(torch.int32))
+
+    def test_sum_int64(self) -> None:
+        """Metal has no 64-bit SIMD shuffle; c10::metal works around it."""
+        x = torch.randint(-50, 50, (32, 128), dtype=torch.int64, device=DEVICE)
+        self._check(row_sum, (x,), x.sum(-1))
+
+    def test_amax_int64(self) -> None:
+        x = torch.randint(-(10**12), 10**12, (32, 128), device=DEVICE)
+        self._check(row_amax, (x,), x.amax(-1))
+
+    def test_int64_extrema_are_not_polluted_by_a_zero_fill(self) -> None:
+        """An int64 extremum must not be clamped towards zero.
+
+        The cross-SIMD-group tier re-reduces the per-SIMD-group partials, and
+        ``c10::metal::threadgroup_*`` does that with only ``span / 32`` lanes
+        live.  Metal has no 64-bit SIMD reduction, so c10 emulates ``long``
+        with ``simd_shuffle_and_fill_down`` and a fill of 0 -- which is the
+        identity for sum and for nothing else, so every one of these returned
+        0.  Sign-uniform data is what makes the fill visible; a two-sided
+        range hides it, since the true extremum is then almost surely on the
+        same side of zero as the fill.
+        """
+        for n in (64, 100, 128, 256, 512, 1024):
+            with self.subTest(n=n):
+                neg = torch.randint(-(10**12), -1, (8, n), device=DEVICE)
+                self._check(row_amax, (neg,), neg.amax(-1))
+                pos = torch.randint(1, 10**12, (8, n), device=DEVICE)
+                self._check(row_amin, (pos,), pos.amin(-1))
+                ones = torch.ones(8, n, dtype=torch.int64, device=DEVICE)
+                self._check(row_prod, (ones,), ones.prod(-1))
+
+    def test_rolled_int64_amax(self) -> None:
+        """A rolled int64 reduction emits ``iinfo(int64).min`` as its identity."""
+        x = torch.randint(-(10**12), -1, (8, 4096), device=DEVICE)
+        self._check(row_amax, (x,), x.amax(-1))
+
+    # -- composite kernels --------------------------------------------------
+
+    def test_softmax(self) -> None:
+        x = torch.randn(32, 256, device=DEVICE)
+        self._check(softmax_decomposed, (x,), torch.softmax(x, dim=-1))
+
+    def test_softmax_rolled(self) -> None:
+        x = torch.randn(8, 4096, device=DEVICE)
+        self._check(softmax_decomposed, (x,), torch.softmax(x, dim=-1))
+
+    def test_rms_norm(self) -> None:
+        x = torch.randn(32, 256, device=DEVICE)
+        weight = torch.randn(256, device=DEVICE)
+        expected = torch.nn.functional.rms_norm(x, (256,), weight, eps=1e-5)
+        self._check(rms_norm_fwd, (x, weight), expected, rtol=1e-3, atol=1e-3)
+
+    def test_layer_norm_two_reductions(self) -> None:
+        """Mean and variance must not share a threadgroup scratch buffer."""
+        x = torch.randn(32, 256, device=DEVICE)
+        weight = torch.randn(256, device=DEVICE)
+        bias = torch.randn(256, device=DEVICE)
+        expected = torch.nn.functional.layer_norm(x, (256,), weight, bias, 1e-5)
+        for _ in range(20):
+            # The historical scratch-aliasing race was non-deterministic.
+            self._check(
+                layer_norm_fwd, (x, weight, bias), expected, rtol=1e-3, atol=1e-3
+            )
+
+    def test_cross_entropy(self) -> None:
+        logits = torch.randn(64, 512, device=DEVICE)
+        labels = torch.randint(0, 512, (64,), device=DEVICE)
+        expected = torch.nn.functional.cross_entropy(
+            logits.float(), labels, reduction="none"
+        )
+        self._check(cross_entropy, (logits, labels), expected, rtol=1e-3, atol=1e-3)
+
+    def test_reduction_in_device_loop(self) -> None:
+        """Scratch reuse across device-loop iterations needs a leading barrier."""
+        x = torch.randn(16, 6, 128, device=DEVICE)
+        for _ in range(20):
+            self._check(sum_in_device_loop, (x,), x.sum(-1), rtol=1e-3, atol=1e-3)
+
+    # -- numeric edge cases across every tier -------------------------------
+
+    _TIERS = (
+        (8, "segmented"),
+        (32, "simd_group"),
+        (256, "threadgroup"),
+        (4096, "rolled"),
+    )
+
+    def test_nan_and_inf_across_tiers(self) -> None:
+        for n, tier in self._TIERS:
+            with self.subTest(n=n, tier=tier):
+                x = torch.randn(16, n, device=DEVICE)
+                x[0, n // 2] = float("nan")
+                for kernel, ref in (
+                    (row_sum, x.sum(-1)),
+                    (row_amax, x.amax(-1)),
+                    (row_amin, x.amin(-1)),
+                    (row_argmax, x.argmax(-1)),
+                    (row_argmin, x.argmin(-1)),
+                ):
+                    result = kernel(x)
+                    torch.testing.assert_close(
+                        result, ref, rtol=1e-3, atol=1e-3, equal_nan=True
+                    )
+                # +inf and -inf in the same row must sum to NaN, not cancel.
+                z = torch.full((16, n), float("inf"), device=DEVICE)
+                z[:, 1] = -float("inf")
+                torch.testing.assert_close(row_sum(z), z.sum(-1), equal_nan=True)
+
+    def test_argmax_edge_positions_across_tiers(self) -> None:
+        for n, tier in self._TIERS:
+            with self.subTest(n=n, tier=tier):
+                # All-equal: torch returns the lowest index.
+                flat = torch.zeros(16, n, device=DEVICE)
+                torch.testing.assert_close(row_argmax(flat), flat.argmax(-1))
+                # The extremum in the last lane of the last SIMD group.
+                last = torch.zeros(16, n, device=DEVICE)
+                last[:, n - 1] = 1.0
+                torch.testing.assert_close(row_argmax(last), last.argmax(-1))
+
+    def test_non_power_of_two_extents_at_tier_boundaries(self) -> None:
+        for n in (7, 31, 33, 63, 65, 1023, 1025, 1500):
+            with self.subTest(n=n):
+                x = torch.randn(16, n, device=DEVICE)
+                torch.testing.assert_close(row_sum(x), x.sum(-1), rtol=1e-3, atol=1e-3)
+                torch.testing.assert_close(row_amax(x), x.amax(-1))
+
+    def test_int32_sum_wraps_like_torch(self) -> None:
+        for n, tier in self._TIERS:
+            with self.subTest(n=n, tier=tier):
+                x = torch.full((16, n), 2**20, dtype=torch.int32, device=DEVICE)
+                torch.testing.assert_close(row_sum(x), x.sum(-1).to(torch.int32))
+
+    # -- codegen ------------------------------------------------------------
+
+    def test_codegen_uses_c10_metal_helpers(self) -> None:
+        """Cross-SIMD-group reductions go through Inductor's reduction_utils.
+
+        Both stages call ``c10::metal::simd_*``; the cross-SIMD-group combine
+        around them is Helion's, because c10's runs its second stage with a
+        partially populated SIMD group (see ``msl_reduction``).
+        """
+        x = torch.randn(64, 256, device=DEVICE)
+        msl = _get_msl(row_sum, (x,))
+        self.assertIn("#include <c10/metal/reduction_utils.h>", msl)
+        self.assertIn("::c10::metal::simd_##NAME", msl)
+        self.assertNotIn("::c10::metal::threadgroup_", msl)
+        self.assertIn("helion_red::tg_sum(", msl)
+        self.assertIn("threadgroup float _red_scratch", msl)
+        self.assertIn("[[simdgroup_index_in_threadgroup]]", msl)
+
+    def test_codegen_simdgroup_span_needs_no_shared_memory(self) -> None:
+        x = torch.randn(64, 32, device=DEVICE)
+        msl = _get_msl(row_sum, (x,))
+        self.assertIn("helion_red::simd_sum", msl)
+        self.assertNotIn("threadgroup float _red_scratch", msl)
+        self.assertNotIn("simdgroup_index_in_threadgroup", msl)
+
+    def test_codegen_sub_simdgroup_span_uses_segmented_butterfly(self) -> None:
+        x = torch.randn(64, 8, device=DEVICE)
+        msl = _get_msl(row_sum, (x,))
+        self.assertIn("helion_red::seg_sum", msl)
+        self.assertNotIn("threadgroup float _red_scratch", msl)
+        self.assertNotIn("simdgroup_index_in_threadgroup", msl)
+
+    def test_codegen_two_reductions_get_distinct_scratch(self) -> None:
+        x = torch.randn(32, 256, device=DEVICE)
+        weight = torch.randn(256, device=DEVICE)
+        bias = torch.randn(256, device=DEVICE)
+        msl = _get_msl(layer_norm_fwd, (x, weight, bias))
+        self.assertIn("threadgroup float _red_scratch[", msl)
+        self.assertIn("threadgroup float _red_scratch_1[", msl)
+
+    def test_codegen_elementwise_kernel_has_no_reduction_preamble(self) -> None:
+        x = torch.randn(1024, device=DEVICE)
+        msl = _get_msl(copy_kernel, (x,))
+        self.assertNotIn("reduction_utils.h", msl)
+        self.assertNotIn("helion_red", msl)
+        self.assertNotIn("simdgroup_index_in_threadgroup", msl)
+
+    def test_reduction_owns_thread_axis_zero(self) -> None:
+        """The whole shared tier rests on this invariant.
+
+        ``helion_red::tg_*`` passes ``tid[0]`` as the thread's index *within*
+        its reduction group and sizes the scratch slice as ``span / 32`` SIMD
+        groups.  Both are only sound if thread-block dim 0 is exactly the
+        reduction span -- i.e. the reduction owns axis 0 and no tile axis
+        shares it.
+        """
+        import re
+
+        for block, n in itertools.product([1, 2, 8, 16, 64, 256], [64, 256, 1024]):
+            with self.subTest(block=block, n=n):
+                kernel = helion.kernel(
+                    row_sum.fn,
+                    backend="metal",
+                    configs=[helion.Config(block_sizes=[block])],
+                )
+                msl = _get_msl(kernel, (torch.randn(256, n, device=DEVICE),))
+                dims = re.search(
+                    r"required_threads_per_threadgroup\((\d+), (\d+), (\d+)\)", msl
+                )
+                call = re.search(
+                    r"helion_red::tg_\w+\([^,]+, [^,]+, tid\[(\d)\], (\d+)\)", msl
+                )
+                self.assertIsNotNone(dims)
+                self.assertIsNotNone(call, "expected the threadgroup reduction tier")
+                assert dims is not None and call is not None
+                self.assertEqual(call.group(1), "0", "reduction must own thread axis 0")
+                self.assertEqual(
+                    int(dims.group(1)),
+                    int(call.group(2)),
+                    "thread-block dim 0 must equal the reduction span",
+                )
+
+    def test_narrow_integer_and_bool_sums(self) -> None:
+        """Sub-32-bit ints and bool must reduce in a promoted accumulator.
+
+        ``c10::metal::threadgroup_sum`` takes ``threadgroup opmath_t<T>*``, and
+        c10 promotes char/short/uchar to int; passing the storage type made the
+        shader fail to compile above the SIMD width.
+        """
+        for dtype in (torch.int8, torch.int16, torch.uint8, torch.bool):
+            for n in (16, 32, 64, 256, 4096):  # 4096 exercises the rolled path
+                with self.subTest(dtype=dtype, n=n):
+                    if dtype is torch.bool:
+                        x = torch.randint(0, 2, (4, n), device=DEVICE).bool()
+                    elif dtype is torch.uint8:
+                        x = torch.randint(0, 4, (4, n), dtype=dtype, device=DEVICE)
+                    else:
+                        x = torch.randint(-3, 3, (4, n), dtype=dtype, device=DEVICE)
+                    result = row_sum(x)
+                    torch.testing.assert_close(result, x.sum(-1).to(result.dtype))
+
+    def test_narrow_integer_amax(self) -> None:
+        for dtype in (torch.int8, torch.int16, torch.uint8):
+            for n in (32, 256):
+                with self.subTest(dtype=dtype, n=n):
+                    x = torch.randint(0, 100, (4, n), dtype=dtype, device=DEVICE)
+                    torch.testing.assert_close(row_amax(x), x.amax(-1))
+
+    # -- shapes the aliasing and budget guards must not reject ---------------
+
+    def test_reduction_under_dynamic_shapes(self) -> None:
+        """Every reduction kernel has a full slice, so the guard sees a SymInt.
+
+        ``_reject_aliased_slice_dims`` used to key a dict on ``tensor.size(dim)``,
+        which is unhashable under dynamic shapes -- so any Metal kernel with a
+        ``:`` failed to compile at all.
+        """
+
+        @helion.kernel(backend="metal", autotune_effort="none", static_shapes=False)
+        def dyn_row_sum(x: torch.Tensor) -> torch.Tensor:
+            m, _ = x.size()
+            out = torch.empty([m], dtype=x.dtype, device=x.device)
+            for tile_m in hl.tile(m):
+                out[tile_m] = x[tile_m, :].sum(-1)
+            return out
+
+        for shape in ((64, 128), (48, 96)):
+            with self.subTest(shape=shape):
+                x = torch.randn(*shape, device=DEVICE)
+                torch.testing.assert_close(
+                    dyn_row_sum(x), x.sum(-1), rtol=3e-3, atol=3e-3
+                )
+
+    def test_repeated_size_one_slices_are_allowed(self) -> None:
+        """Length-1 full slices are indexed by a constant, so they cannot alias.
+
+        They never reach ``allocate_reduction_dimension`` and claim no thread
+        axis, but the equal-length check counted them anyway and rejected a
+        kernel that compiles correctly.
+        """
+
+        @helion.kernel(backend="metal", configs=[helion.Config(block_sizes=[16])])
+        def scale(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(x.size(0)):
+                out[tile_m, :, :] = x[tile_m, :, :] * 2.0
+            return out
+
+        x = torch.randn(64, 1, 1, device=DEVICE)
+        torch.testing.assert_close(scale(x), x * 2.0)
+
+    def test_explicit_block_size_with_a_reduction_reports_a_backend_error(self) -> None:
+        """A tile axis with no ``num_threads`` knob must not crash the budget pass.
+
+        ``hl.tile(n, block_size=<int>)`` allocates no ``NumThreadsSpec``, so the
+        reduction thread budget has nowhere to write a cap.  It used to index
+        the spec map anyway and raise a bare ``KeyError`` out of compilation;
+        16 rows x a 128-wide reduction genuinely exceeds a threadgroup, so the
+        right outcome is a Helion diagnostic naming the way out.
+        """
+
+        @helion.kernel(backend="metal", autotune_effort="none")
+        def fixed_tile_row_sum(x: torch.Tensor) -> torch.Tensor:
+            m, _ = x.size()
+            out = torch.empty([m], dtype=x.dtype, device=x.device)
+            for tile_m in hl.tile(x.size(0), block_size=16):
+                out[tile_m] = x[tile_m, :].sum(-1)
+            return out
+
+        x = torch.randn(64, 128, device=DEVICE)
+        with self.assertRaisesRegex(exc.BackendUnsupported, "reduction_loops"):
+            fixed_tile_row_sum(x)
+
+    # -- unsupported --------------------------------------------------------
+
+    def test_two_equal_size_reduction_dims_are_rejected(self) -> None:
+        """Equal-size reduction dims share a block id, hence a thread index.
+
+        ``allocate_reduction_dimension`` caches by size, so both trailing axes
+        of an ``[m, n, n]`` tensor get one index variable.  A tile-level backend
+        keeps them apart by broadcasting; Metal would collapse them onto one
+        thread and reduce the diagonal, so the kernel must be rejected.
+        """
+
+        @helion.kernel(backend="metal", configs=[helion.Config(block_sizes=[1])])
+        def two_reduce_dims(x: torch.Tensor) -> torch.Tensor:
+            m, _, _ = x.shape
+            out = torch.empty([m], dtype=x.dtype, device=x.device)
+            for tile_m in hl.tile(m):
+                out[tile_m] = x[tile_m, :, :].sum(-1).sum(-1)
+            return out
+
+        with self.assertRaisesRegex(exc.BackendUnsupported, "full slice of length 8"):
+            two_reduce_dims(torch.randn(3, 8, 8, device=DEVICE))
+
+    def test_equal_size_slices_without_a_reduction_are_rejected(self) -> None:
+        """Equal-length full slices alias even with no reduction op present.
+
+        ``out[tile, :, :] = a[tile, :, None] * b[None, None, :]`` has two
+        reduction *dimensions* but no reduction, so the check has to live at
+        the access rather than at the reduction lowering.
+        """
+
+        @helion.kernel(backend="metal", configs=[helion.Config(block_sizes=[1])])
+        def outer_product(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            m, n = a.shape
+            (n2,) = b.shape
+            out = torch.empty([m, n, n2], dtype=a.dtype, device=a.device)
+            for tile_m in hl.tile(m):
+                out[tile_m, :, :] = a[tile_m, :, None] * b[None, None, :]
+            return out
+
+        a = torch.randn(3, 8, device=DEVICE)
+        with self.assertRaisesRegex(exc.BackendUnsupported, "full slice of length 8"):
+            outer_product(a, torch.randn(8, device=DEVICE))
+        with self.assertRaisesRegex(exc.BackendUnsupported, "2 reduction dimensions"):
+            outer_product(a, torch.randn(16, device=DEVICE))
+
+    def test_broadcast_aliased_reduction_is_rejected(self) -> None:
+        """Aliasing built by broadcasting two separately-loaded values.
+
+        No single access carries two equal full slices, and both axes are the
+        *same* rdim so the dimension count stays at 1 -- neither access-level
+        guard can see this.  Only the reduction-level check, which inspects the
+        shape of the value being reduced, catches it.  Left unguarded these
+        computed ``dot(a[m], b)`` and broadcast it across the whole output row.
+        """
+
+        @helion.kernel(backend="metal", configs=[helion.Config(block_sizes=[1])])
+        def bcast_two_loads(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            m, n = a.shape
+            out = torch.empty([m, n], dtype=a.dtype, device=a.device)
+            for tile_m in hl.tile(m):
+                out[tile_m, :] = (a[tile_m, :, None] * b[None, None, :]).sum(-1)
+            return out
+
+        @helion.kernel(backend="metal", configs=[helion.Config(block_sizes=[1])])
+        def self_outer(x: torch.Tensor) -> torch.Tensor:
+            m, _ = x.shape
+            out = torch.empty([m], dtype=x.dtype, device=x.device)
+            for tile_m in hl.tile(m):
+                row = x[tile_m, :]
+                out[tile_m] = (row[:, :, None] * row[:, None, :]).sum(-1).sum(-1)
+            return out
+
+        with self.assertRaisesRegex(exc.BackendUnsupported, "share one"):
+            bcast_two_loads(
+                torch.randn(3, 8, device=DEVICE), torch.randn(8, device=DEVICE)
+            )
+        with self.assertRaisesRegex(exc.BackendUnsupported, "share one"):
+            self_outer(torch.randn(5, 8, device=DEVICE))
+
+    def test_two_unequal_reduction_dims_are_rejected(self) -> None:
+        """Distinct sizes give distinct block ids, i.e. two reduction axes."""
+
+        @helion.kernel(backend="metal", configs=[helion.Config(block_sizes=[1])])
+        def two_reduce_dims(x: torch.Tensor) -> torch.Tensor:
+            m, _, _ = x.shape
+            out = torch.empty([m], dtype=x.dtype, device=x.device)
+            for tile_m in hl.tile(m):
+                out[tile_m] = x[tile_m, :, :].sum(-1).sum(-1)
+            return out
+
+        with self.assertRaisesRegex(exc.BackendUnsupported, "2 reduction dimensions"):
+            two_reduce_dims(torch.randn(3, 8, 16, device=DEVICE))
+
+    def test_strided_reduce_group_is_rejected(self) -> None:
+        """Reducing a thread axis above a sibling axis would mix rows."""
+
+        @helion.kernel(backend="metal", autotune_effort="none", static_shapes=True)
+        def inner_dim_sum(w: torch.Tensor) -> torch.Tensor:
+            o, d = w.shape
+            d = hl.specialize(d)
+            out = torch.empty([o], dtype=torch.float32, device=w.device)
+            d_block = hl.register_block_size(
+                helion.next_power_of_2(d), helion.next_power_of_2(d)
+            )
+            for tile_o, tile_d in hl.tile([o, d], block_size=[None, d_block]):
+                out[tile_o] = torch.sum(w[tile_o, tile_d].to(torch.float32), dim=-1)
+            return out
+
+        w = torch.randn(512, 128, device=DEVICE)
+        with self.assertRaisesRegex(exc.BackendUnsupported, "strided by"):
+            inner_dim_sum(w)
+
+    def test_device_loop_lane_reduction_is_rejected(self) -> None:
+        """A reduction carried by a device-loop lane must not under-reduce."""
+
+        @helion.kernel(
+            backend="metal",
+            configs=[helion.Config(block_sizes=[1, 2048], num_threads=[1, 1024])],
+        )
+        def inner_tile_sum(x: torch.Tensor) -> torch.Tensor:
+            m, k = x.shape
+            out = torch.empty([m], dtype=torch.float32, device=x.device)
+            for tile_m in hl.tile(m):
+                for tile_k in hl.tile(k):
+                    out[tile_m] = x[tile_m, tile_k].to(torch.float32).sum(dim=1)
+            return out
+
+        x = torch.randn(1, 2048, device=DEVICE)
+        with self.assertRaisesRegex(exc.BackendUnsupported, "lane-loop reductions"):
+            inner_tile_sum(x)
+
+    def test_a_starved_reduction_loop_raises_instead_of_truncating(self) -> None:
+        """The thread-budget passes keep the span wide enough; assert it anyway.
+
+        A reduction loop whose span is narrower than its chunk reduces only
+        part of each chunk and returns a plausible wrong answer.  The budget
+        passes make that unreachable, so this forces the condition directly --
+        the point is that the invariant is checked rather than trusted, since
+        it silently broke once already.
+        """
+        from helion._compiler.metal.backend import MetalBackend
+
+        @helion.kernel(
+            backend="metal",
+            configs=[helion.Config(block_sizes=[8], reduction_loops=[64])],
+        )
+        def row_sum(x: torch.Tensor) -> torch.Tensor:
+            m, _ = x.size()
+            out = torch.empty([m], dtype=x.dtype, device=x.device)
+            for tm in hl.tile(m):
+                out[tm] = x[tm, :].sum(-1)
+            return out
+
+        x = torch.randn(64, 256, device=DEVICE)
+        torch.testing.assert_close(row_sum(x), x.sum(-1), rtol=3e-3, atol=3e-3)
+
+        # Starve the reduction: hand it half the threads its chunk needs.
+        with (
+            patch.object(
+                MetalBackend,
+                "adjust_reduction_thread_count",
+                lambda self, requested, existing: min(requested, 32),
+            ),
+            self.assertRaisesRegex(exc.BackendUnsupported, "reduction loop"),
+        ):
+            helion.kernel(
+                row_sum.fn,
+                backend="metal",
+                configs=[helion.Config(block_sizes=[8], reduction_loops=[64])],
+            )(x)
+
+    def test_block_reduction_over_a_user_tile(self) -> None:
+        """Reducing a user tile exercises resolve_group's second loop.
+
+        With a single tile axis on ``tid[0]``, each block is contiguous, so
+        the per-tile sum reduces through the ``seg_`` tier and broadcasts
+        back over the tile.
+        """
+        for block in (8, 32):
+            with self.subTest(block=block):
+
+                @helion.kernel(
+                    backend="metal",
+                    configs=[helion.Config(block_sizes=[block])],
+                )
+                def block_broadcast_sum(x: torch.Tensor) -> torch.Tensor:
+                    n = x.shape[0]
+                    out = torch.empty([n], dtype=x.dtype, device=x.device)
+                    for tile_n in hl.tile(n):
+                        out[tile_n] = x[tile_n].sum()
+                    return out
+
+                x = torch.randn(64, device=DEVICE)
+                self._check(
+                    block_broadcast_sum,
+                    (x,),
+                    x.unflatten(-1, (-1, block)).sum(-1).repeat_interleave(block),
+                    rtol=1e-3,
+                    atol=1e-3,
+                )
+
+    def test_prod_across_tiers(self) -> None:
+        """Well-conditioned values: a wide prod would overflow in fp32."""
+        for n in (32, 256, 4096):
+            with self.subTest(n=n):
+                x = 1 + 0.01 * torch.randn(16, n, device=DEVICE)
+                self._check(row_prod, (x,), x.prod(-1), rtol=1e-2, atol=1e-2)
 
 
 if __name__ == "__main__":

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -14,6 +14,7 @@ from helion._testing import _get_backend
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
 from helion._testing import skipIfCute
+from helion._testing import skipIfMetal
 from helion._testing import skipIfNotCUDA
 from helion._testing import skipIfNotTriton
 from helion._testing import skipIfPallas
@@ -69,7 +70,7 @@ def reduce_kernel(
     return out
 
 
-@onlyBackends(["triton", "cute", "pallas"])
+@onlyBackends(["triton", "cute", "pallas", "metal"])
 class TestReductions(RefEagerTestBase, TestCase):
     @skipIfPallas("non-power-of-2 reduction dims not supported on Pallas")
     def test_strided_threaded_reduction_non_sum_ops(self):
@@ -171,6 +172,9 @@ class TestReductions(RefEagerTestBase, TestCase):
                 if _get_backend() == "cute":
                     self.assertIn("_cute_grouped_reduce_shared_two_stage", code)
 
+    @skipIfMetal(
+        "Metal SIMD reductions need the reduced dim to be the fastest-varying thread axis"
+    )
     def test_2d_tile_inner_dim_reduction_to_scalar(self):
         """Reduce the inner dim of a single 2D ``hl.tile([o, d])`` into a per-row scalar.
 
@@ -246,6 +250,7 @@ class TestReductions(RefEagerTestBase, TestCase):
 
     @skipIfPallas("complex layernorm with fp16, not relevant to Pallas")
     @skipIfRefEager("Does not call assert_close")
+    @skipIfMetal("hl.arange needs a Metal prims.iota lowering")
     def test_broken_layernorm(self):
         @helion.kernel(autotune_effort="none")
         def layer_norm_fwd(
@@ -493,6 +498,7 @@ class TestReductions(RefEagerTestBase, TestCase):
             layer_norm_reduction, args, block_size=32, reduction_loop=4
         )
 
+    @skipIfMetal("hl.arange needs a Metal prims.iota lowering")
     def test_reduction_over_arange_dim_stays_persistent(self):
         """Issue #2643: a reduction over an ``hl.arange()`` axis must not be
         registered as a rollable (looped) reduction.
@@ -530,6 +536,7 @@ class TestReductions(RefEagerTestBase, TestCase):
         expected = qkv.to(torch.float32).pow(2).sum(dim=-1)
         torch.testing.assert_close(output, expected, rtol=1e-2, atol=1e-2)
 
+    @skipIfMetal("hl.arange needs a Metal prims.iota lowering")
     def test_reduction_over_arange_dim_size_coincides_with_slice(self):
         """Issue #2643 variant: an ``hl.arange()`` reduction whose size
         coincides with a slice reduction of the same size in the same loop.
@@ -564,6 +571,7 @@ class TestReductions(RefEagerTestBase, TestCase):
         expected = x.to(torch.float32).sum(-1) + x.to(torch.float32).pow(2).sum(-1)
         torch.testing.assert_close(output, expected, rtol=1e-2, atol=1e-2)
 
+    @skipIfMetal("hl.arange needs a Metal prims.iota lowering")
     def test_arange_reduction_with_synthetic_lanes(self):
         """A persistent ``hl.arange()`` reduction whose extent exceeds the live
         thread count must accumulate across synthetic lanes.
@@ -832,6 +840,9 @@ class TestReductions(RefEagerTestBase, TestCase):
         code, out = code_and_output(unsqueeze_sum, (x,))
         torch.testing.assert_close(out, x.float(), rtol=1e-4, atol=1e-4)
 
+    @skipIfMetal(
+        "Metal passes symbolic sizes as float scalars; integer floor_divide fails"
+    )
     def test_size1_reduction_keepdim_sum(self):
         """Second sum over a keepdim=True result should reduce rank (issue #1423).
 
@@ -860,6 +871,7 @@ class TestReductions(RefEagerTestBase, TestCase):
         ref = x.float().sum(0)
         torch.testing.assert_close(out, ref, rtol=1e-4, atol=1e-4)
 
+    @skipIfMetal("argreduce after matmul needs a Metal scalar aten.addmm lowering")
     def test_argmax_on_tile_after_matmul(self):
         """Test that argmax on a matmul tile returns the correct row indices."""
 
@@ -894,6 +906,7 @@ class TestReductions(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, ref)
 
     @skipIfPallas("Pallas TPU argreduce cannot write int64 keepdim outputs")
+    @skipIfMetal("argreduce after matmul needs a Metal scalar aten.addmm lowering")
     def test_argmax_on_tile_after_matmul_keepdim(self):
         @helion.kernel(autotune_effort="none")
         def matmul_argmax_keepdim(
@@ -927,6 +940,7 @@ class TestReductions(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, ref)
 
     @skipIfPallas("nested torch.matmul argreduce lowering is unsupported on Pallas")
+    @skipIfMetal("argreduce after matmul needs a Metal scalar aten.addmm lowering")
     def test_argmax_on_tile_after_torch_matmul(self):
         @helion.kernel(autotune_effort="none")
         def torch_matmul_argmax(
@@ -954,6 +968,7 @@ class TestReductions(RefEagerTestBase, TestCase):
 
     @skipIfPallas("barrier and persistent_blocked not supported on Pallas")
     @skipIfTileIR("TileIR does not support barrier operations")
+    @skipIfMetal("hl.barrier() requires a persistent pid_type, unsupported on Metal")
     def test_reduction_loop_with_multiple_rdims(self):
         """Test that reduction_loops works when there are multiple reduction dimensions."""
 


### PR DESCRIPTION

Metal kernels containing reductions previously failed because the backend did not implement the reduction hooks.

Add segmented, SIMD-group, threadgroup, and rolled reduction lowering (`metal/reduction.py` orchestrates, `msl_reduction.py` emits MSL, wired through the AST walker, typed scratch storage, and the JIT), including stable argmin/argmax tie handling by carried global index. Reject layouts Metal cannot represent instead of silently miscompiling them.

Build the cross-SIMD-group combine on `c10::metal::simd_*` rather than forwarding to `c10::metal::threadgroup_*`, whose second stage re-reduces with a partially populated SIMD group. Metal has no 64-bit SIMD reduction, so that path filled inactive lanes with zero and returned zero for an int64 max, min, or prod.

Keep the shared compiler surface narrow: reduction emitters receive the accumulation dtype, rolled accumulators have a backend initialization hook, lane-loop support is an explicit fail-closed capability, backends may validate reduction inputs, and tile axes with no `num_threads` knob charge to the reduction thread budget. CuTe only declares its existing lane-loop capability and accepts the optional dtype parameters; Triton and Pallas only accept those parameters.

Known gaps, marked skipped in the shared suite: `hl.arange` reductions (no `prims.iota` lowering), `hl.barrier`, argreduce after matmul (no scalar `aten.addmm`), inner-dim 2D-tile-to-scalar reductions, and symbolic sizes passed as float scalars.

Validation: 56 dedicated Metal reduction tests passed; the shared suite reports 13 passed and 17 skipped on Metal. Ruff and codespell pass.
