### PR TITLE
Remove redundant barriers for inter-loop RAW hazards

### DIFF
--- a/helion/_compiler/ast_read_writes.py
+++ b/helion/_compiler/ast_read_writes.py
@@ -104,18 +104,6 @@ class ReadWrites(typing.NamedTuple):
             visitor.visit(node)
         return visitor.rw
 
-    def read_and_write_name_frozensets(self) -> tuple[frozenset[str], frozenset[str]]:
-        """Pair of (read names, write names) for inter-loop / barrier metadata.
-
-        ``_ReadWriteVisitor.visit_Subscript`` and ``visit_Call`` already
-        increment ``writes`` for both Store-context subscripts and atomic
-        first-args, so ``inplace_writes`` is a strict subset of ``writes``
-        today and adding it explicitly would be redundant.
-        """
-        reads = frozenset(self.reads.keys())
-        writes = frozenset(self.writes.keys())
-        return reads, writes
-
     @staticmethod
     def from_ast(node: ast.AST) -> ReadWrites:
         """

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -337,11 +337,6 @@ class NodeArgsGraphInfo(GraphInfo):
 @dataclasses.dataclass
 class ForLoopGraphInfo(NodeArgsGraphInfo):
     block_ids: list[int]
-    # Host AST read/write names for this device loop body (siblings only; see
-    # ``_ReadWriteVisitor.visit_For`` in ast_read_writes.py).  Used to insert
-    # ``tl.debug_barrier()`` between loops when there is a global RAW dep.
-    host_loop_reads: frozenset[str] = dataclasses.field(default_factory=frozenset)
-    host_loop_writes: frozenset[str] = dataclasses.field(default_factory=frozenset)
     # Precomputed by GenerateAST._compute_inter_loop_barriers: True iff a
     # tl.debug_barrier() must be emitted immediately before this for-loop's
     # outer prefix to make global writes from the previous sibling for-loop
@@ -356,10 +351,6 @@ class ForLoopGraphInfo(NodeArgsGraphInfo):
         return {
             **super().kwargs(),
             "block_ids": [*self.block_ids],
-            "host_loop_reads": self.host_loop_reads,
-            "host_loop_writes": self.host_loop_writes,
-            # ``needs_barrier_before`` is excluded -- recomputed by GenerateAST
-            # per codegen run.
         }
 
     def codegen(self, state: CodegenState) -> list[object]:
@@ -700,113 +691,6 @@ class KernelPhase:
     root_nodes: list[ast.For]
 
 
-def _tensor_to_inter_loop_rw_name(host: HostFunction, t: torch.Tensor) -> str | None:
-    o = host.tensor_to_origin.get(t)
-    if o is None:
-        return None
-    return o.root_rw_name()
-
-
-def _fx_trace_tensor_arg_rw_names(
-    host: HostFunction, arg: object, seen: set[int] | None = None
-) -> list[str]:
-    """Map a load/store tensor FX arg to the list of host variable names it
-    aliases.  Returns an empty list when the arg cannot be resolved to any
-    host name (e.g. a purely device-internal temporary)."""
-    from ..language import _tracing_ops
-
-    if seen is None:
-        seen = set()
-    if isinstance(arg, tuple):
-        out: list[str] = []
-        for a in arg:
-            out.extend(_fx_trace_tensor_arg_rw_names(host, a, seen))
-        return out
-    if not isinstance(arg, torch.fx.Node):
-        return []
-    nid = id(arg)
-    if nid in seen:
-        return []
-    seen.add(nid)
-    val = arg.meta.get("val")
-    if isinstance(val, torch.Tensor):
-        n = _tensor_to_inter_loop_rw_name(host, val)
-        if n is not None:
-            return [n]
-    if arg.op == "call_function" and arg.target is _tracing_ops._host_tensor:
-        val = arg.meta.get("val")
-        if isinstance(val, torch.Tensor):
-            n = _tensor_to_inter_loop_rw_name(host, val)
-            if n is not None:
-                return [n]
-        return []
-    out2: list[str] = []
-    for a in arg.args:
-        out2.extend(_fx_trace_tensor_arg_rw_names(host, a, seen))
-    return out2
-
-
-def _atomic_funcs() -> frozenset[Callable[..., object]]:
-    from ..language import atomic_add
-    from ..language import atomic_and
-    from ..language import atomic_cas
-    from ..language import atomic_max
-    from ..language import atomic_min
-    from ..language import atomic_or
-    from ..language import atomic_xchg
-    from ..language import atomic_xor
-
-    return frozenset(
-        {
-            atomic_add,
-            atomic_and,
-            atomic_cas,
-            atomic_max,
-            atomic_min,
-            atomic_or,
-            atomic_xchg,
-            atomic_xor,
-        }
-    )
-
-
-def _reduction_fx_inter_loop_rw_names(
-    graph: torch.fx.Graph,
-    host: HostFunction,
-) -> tuple[frozenset[str], frozenset[str]]:
-    """Infer host buffer names read/written in a rolled reduction FX subgraph.
-
-    Resolves every hl.load / hl.store / atomic_* tensor arg back to host-named buffers.
-    Args not resolving to a host name are device-internal temporaries (no cross-wavefront
-    coherence) and are excluded.
-    """
-    from ..language import memory_ops
-
-    atomic_funcs = _atomic_funcs()
-    reads: set[str] = set()
-    writes: set[str] = set()
-
-    for node in graph.find_nodes(
-        op="call_function", target=memory_ops.load, sort=False
-    ):
-        reads.update(_fx_trace_tensor_arg_rw_names(host, node.args[0]))
-
-    for node in graph.find_nodes(
-        op="call_function", target=memory_ops.store, sort=False
-    ):
-        writes.update(_fx_trace_tensor_arg_rw_names(host, node.args[0]))
-
-    for atomic_target in atomic_funcs:
-        for node in graph.find_nodes(
-            op="call_function", target=atomic_target, sort=False
-        ):
-            nms = _fx_trace_tensor_arg_rw_names(host, node.args[0])
-            reads.update(nms)
-            writes.update(nms)
-
-    return frozenset(reads), frozenset(writes)
-
-
 class DeviceIR:
     def __init__(self) -> None:
         super().__init__()
@@ -832,9 +716,10 @@ class DeviceIR:
         would repeat a read-modify-write ``cluster_n`` times.
         """
         if self._has_atomic_ops is None:
-            atomic_funcs = _atomic_funcs()
+            from helion.language.atomic_ops import ATOMIC_OPS
+
             self._has_atomic_ops = any(
-                node.op == "call_function" and node.target in atomic_funcs
+                node.op == "call_function" and node.target in ATOMIC_OPS
                 for info in self.graphs
                 for node in info.graph.nodes
             )
@@ -873,14 +758,11 @@ class DeviceIR:
         block_index: int,
         node_args: list[torch.fx.Node],
     ) -> int:
-        reads, writes = _reduction_fx_inter_loop_rw_names(graph, HostFunction.current())
         return self.add_graph(
             graph,
             graph_info_cls=ReductionLoopGraphInfo,
             block_ids=[block_index],
             node_args=node_args,
-            host_loop_reads=reads,
-            host_loop_writes=writes,
         )
 
     def add_root_graph(self, graph: torch.fx.Graph) -> None:
@@ -1967,14 +1849,11 @@ class WalkDeviceAST(NodeVisitor):
                 ):
                     self.device_ir.noncanonical_task_origin_block_ids.add(block_id)
 
-            host_reads, host_writes = rw.read_and_write_name_frozensets()
             graph_idx, outputs = self._trace_graph(
                 inputs,
                 build_subgraph,
                 graph_info_cls=ForLoopGraphInfo,
                 block_ids=block_ids,
-                host_loop_reads=host_reads,
-                host_loop_writes=host_writes,
             )
             step_list = step if isinstance(step, list) else None
             if step_list is None or all(s is None for s in step_list):

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -251,8 +251,8 @@ class GenerateAST(NodeVisitor, CodegenInterface):
     def _compute_inter_loop_barriers(self) -> None:
         """Walk every codegen graph; for each pair of consecutive sibling
         ``_for_loop`` / ``_for_loop_step`` nodes, set ``needs_barrier_before``
-        on the second loop's ``ForLoopGraphInfo`` when there is a global RAW
-        dependency.
+        on the second loop's ``ForLoopGraphInfo`` when their underlying tensor
+        storages have a RAW dependency.
 
         TileIR shares Triton surface syntax but ``tl.debug_barrier()`` lowers
         to ``ttg.barrier`` which the TileIR pass pipeline does not legalize,
@@ -261,9 +261,7 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         from ..language._tracing_ops import _for_loop
         from ..language._tracing_ops import _for_loop_step
         from .device_ir import ForLoopGraphInfo
-        from .loop_dependency_checker import (
-            needs_inter_loop_debug_barrier_for_global_raw,
-        )
+        from .loop_dependency_checker import graph_memory_access_storage_ids
 
         env = CompileEnvironment.current()
         if env.codegen_name != "triton" or env.backend.name == "tileir":
@@ -275,7 +273,7 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             # before a loop, it flushes all earlier writes, so the pending set
             # is reset and only writes from loops AFTER the barrier need to be
             # tracked for subsequent siblings.
-            pending_global_writes: set[str] = set()
+            pending_writes: set[int] = set()
             for node in graph_info.graph.nodes:
                 if node.op != "call_function":
                     continue
@@ -286,19 +284,16 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                 cur_info = self.codegen_graphs[cur_id]
                 if not isinstance(cur_info, ForLoopGraphInfo):
                     continue
-                need_barrier = needs_inter_loop_debug_barrier_for_global_raw(
-                    pending_global_writes,
-                    cur_info.host_loop_reads,
-                    global_barrier_tensor_names=self._triton_global_barrier_tensor_names,
+                reads, writes = graph_memory_access_storage_ids(
+                    self.codegen_graphs, cur_id
                 )
+                need_barrier = bool(pending_writes & reads)
                 cur_info.needs_barrier_before = need_barrier
                 if need_barrier:
                     # Barrier flushes everything written before it.
-                    pending_global_writes = set()
+                    pending_writes.clear()
                 # Accumulate the current loop's writes for future siblings.
-                pending_global_writes |= self._triton_global_barrier_tensor_names(
-                    cur_info.host_loop_writes
-                )
+                pending_writes.update(writes)
 
     def _compute_intra_loop_barriers(self) -> None:
         """Mark loads that read a tensor an earlier store in the same body wrote,
@@ -325,41 +320,6 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             # barrier is always placeable there.
             mark_in_divergent_control_flow=env.backend.name != "cute",
         )
-
-    def _triton_global_barrier_tensor_names(self, names: frozenset[str]) -> set[str]:
-        """Names that may participate in cross-wavefront global (HBM) coherence.
-
-        Triton-specific: the Pallas SMEM filter is intentionally omitted here
-        because the only caller (``_compute_inter_loop_barriers``) gates on
-        Triton codegen.  The ``triton_`` prefix and the assertion below encode
-        that precondition so a future non-Triton caller fails loudly rather
-        than silently mis-classifying SMEM-only tensors as needing a global
-        barrier.
-        """
-        from .type_info import StackTensorType
-        from .type_info import TensorType
-
-        env = CompileEnvironment.current()
-        assert env.codegen_name == "triton" and env.backend.name != "tileir", (
-            "_triton_global_barrier_tensor_names called outside Triton codegen"
-        )
-
-        out: set[str] = set()
-        scratch_names = {s.name for s in self.device_function._scratch_args}
-        local_types = self.host_function.local_types
-        for name in names:
-            if name in scratch_names:
-                continue
-            if local_types is None:
-                out.add(name)
-                continue
-            ti = local_types.get(name)
-            if ti is None:
-                out.add(name)
-                continue
-            if isinstance(ti, (TensorType, StackTensorType)):
-                out.add(name)
-        return out
 
     def _clear_attention_flash_state(self) -> None:
         cute_state = self.device_function.cute_state

--- a/helion/_compiler/loop_dependency_checker.py
+++ b/helion/_compiler/loop_dependency_checker.py
@@ -4,8 +4,6 @@ import ast
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from .device_ir import GraphInfo
 
 
@@ -149,6 +147,103 @@ def _update_host_aliases(stmt: ast.stmt, aliases: dict[str, str]) -> None:
         _update_alias_target(target, value, aliases)
 
 
+def _storage_ids(graphs: list[GraphInfo], graph_id: int, obj: object) -> set[int]:
+    import torch
+
+    from .device_ir import NodeArgsGraphInfo
+
+    if isinstance(obj, (list, tuple)):
+        result: set[int] = set()
+        for item in obj:
+            result.update(_storage_ids(graphs, graph_id, item))
+        return result
+    if not isinstance(obj, torch.fx.Node):
+        return set()
+    graph_info = graphs[graph_id]
+    value = obj.meta.get("val")
+    result = {id(value.untyped_storage())} if isinstance(value, torch.Tensor) else set()
+    if (
+        obj.op == "placeholder"
+        and obj.graph is graph_info.graph
+        and isinstance(graph_info, NodeArgsGraphInfo)
+    ):
+        result.update(
+            _storage_ids(graphs, graph_id, graph_info.placeholder_to_outer_arg(obj))
+        )
+    if result:
+        return result
+    for arg in obj.args:
+        result.update(_storage_ids(graphs, graph_id, arg))
+    return result
+
+
+def graph_memory_access_storage_ids(
+    graphs: list[GraphInfo], graph_id: int
+) -> tuple[set[int], set[int]]:
+    """Return storage identities read and written by a graph and its subgraphs."""
+    from ..language import memory_ops
+    from ..language._tracing_ops import _for_loop
+    from ..language._tracing_ops import _for_loop_step
+    from ..language._tracing_ops import _if
+    from ..language._tracing_ops import _while_loop
+    from ..language.atomic_ops import ATOMIC_OPS
+    from .device_ir import IfGraphInfo
+    from .device_ir import WhileLoopGraphInfo
+
+    reads: set[int] = set()
+    writes: set[int] = set()
+
+    def update_from_subgraph(subgraph_id: int) -> None:
+        subgraph_reads, subgraph_writes = graph_memory_access_storage_ids(
+            graphs, subgraph_id
+        )
+        reads.update(subgraph_reads)
+        writes.update(subgraph_writes)
+
+    for node in graphs[graph_id].graph.nodes:
+        if node.op != "call_function":
+            continue
+        if node.target is memory_ops.load:
+            reads.update(_storage_ids(graphs, graph_id, node.args[0]))
+            continue
+        if node.target is memory_ops.store:
+            writes.update(_storage_ids(graphs, graph_id, node.args[0]))
+            continue
+        if node.target in ATOMIC_OPS:
+            storage_ids = _storage_ids(graphs, graph_id, node.args[0])
+            reads.update(storage_ids)
+            writes.update(storage_ids)
+            continue
+        # Handle subgraphs for control flow constructs
+        if node.target in (_for_loop, _for_loop_step):
+            subgraph_id = node.args[0]
+            assert isinstance(subgraph_id, int)
+            update_from_subgraph(subgraph_id)
+            continue
+        if node.target is _if:
+            subgraph_id = node.args[1]
+            assert isinstance(subgraph_id, int)
+            update_from_subgraph(subgraph_id)
+            if_info = graphs[subgraph_id]
+            assert isinstance(if_info, IfGraphInfo)
+            if if_info.else_branch is not None:
+                else_graph_id = (
+                    if_info.else_branch
+                    if isinstance(if_info.else_branch, int)
+                    else if_info.else_branch.graph_id
+                )
+                update_from_subgraph(else_graph_id)
+            continue
+        if node.target is _while_loop:
+            subgraph_id = node.args[1]
+            assert isinstance(subgraph_id, int)
+            body_info = graphs[subgraph_id]
+            assert isinstance(body_info, WhileLoopGraphInfo)
+            update_from_subgraph(body_info.cond_graph_id)
+            update_from_subgraph(subgraph_id)
+    return reads, writes
+
+
 def mark_intra_loop_raw_barriers(
     graphs: list[GraphInfo],
     root_graph_ids: list[int],
@@ -163,8 +258,7 @@ def mark_intra_loop_raw_barriers(
     an element written by one thread is read back by another with no
     synchronization in between -- a data race (observed corrupting ~0.8% of
     outputs on B200). Helion already inserts ``tl.debug_barrier()`` for the
-    analogous hazard *between* sequential top-level loops
-    (``needs_inter_loop_debug_barrier_for_global_raw``); this extends the same
+    analogous hazard *between* sequential top-level loops; this extends the same
     guarantee to a store->load *within* one loop body.
 
     We mark the load's FX node; the Triton ``load`` codegen emits a
@@ -197,37 +291,6 @@ class _IntraLoopRawBarrierMarker:
         self.graphs = graphs
         self.mark_in_divergent_control_flow = mark_in_divergent_control_flow
 
-    def _storage_ids(self, graph_id: int, obj: object) -> set[int]:
-        import torch
-
-        from .device_ir import NodeArgsGraphInfo
-
-        if isinstance(obj, (list, tuple)):
-            result: set[int] = set()
-            for item in obj:
-                result.update(self._storage_ids(graph_id, item))
-            return result
-        if not isinstance(obj, torch.fx.Node):
-            return set()
-        graph_info = self.graphs[graph_id]
-        value = obj.meta.get("val")
-        result = (
-            {id(value.untyped_storage())} if isinstance(value, torch.Tensor) else set()
-        )
-        if (
-            obj.op == "placeholder"
-            and obj.graph is graph_info.graph
-            and isinstance(graph_info, NodeArgsGraphInfo)
-        ):
-            result.update(
-                self._storage_ids(graph_id, graph_info.placeholder_to_outer_arg(obj))
-            )
-        if result:
-            return result
-        for arg in obj.args:
-            result.update(self._storage_ids(graph_id, arg))
-        return result
-
     def run_graph(
         self, graph_id: int, written: set[int], *, divergent: bool = False
     ) -> set[int]:
@@ -245,12 +308,12 @@ class _IntraLoopRawBarrierMarker:
             if node.op != "call_function":
                 continue
             if node.target is memory_ops.store:
-                pending.update(self._storage_ids(graph_id, node.args[0]))
+                pending.update(_storage_ids(self.graphs, graph_id, node.args[0]))
                 continue
             if node.target is memory_ops.load:
                 if node.meta.get(INTRA_LOOP_RAW_BARRIER_META):
                     pending.clear()
-                elif pending & self._storage_ids(graph_id, node.args[0]):
+                elif pending & _storage_ids(self.graphs, graph_id, node.args[0]):
                     if divergent and not self.mark_in_divergent_control_flow:
                         # Cannot place a convergent barrier here; leave the
                         # hazard pending so a later uniform load re-arms it.
@@ -307,19 +370,3 @@ class _IntraLoopRawBarrierMarker:
                 # The condition executes at least once; the body may not execute.
                 pending = condition_pending | body_pending
         return pending
-
-
-def needs_inter_loop_debug_barrier_for_global_raw(
-    prev_global_writes: set[str],
-    host_loop_reads: frozenset[str],
-    *,
-    global_barrier_tensor_names: Callable[[frozenset[str]], set[str]],
-) -> bool:
-    """Whether to emit ``tl.debug_barrier()`` before the next sequential device loop.
-
-    Returns True when the union of host-named global writes accumulated from
-    all prior siblings (since the last emitted barrier) intersects the current
-    loop's host-named read set.
-    """
-    cur_global_reads = global_barrier_tensor_names(host_loop_reads)
-    return bool(prev_global_writes & cur_global_reads)

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -1821,6 +1821,31 @@ class TestLoops(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, x + 1)
         self.assertNotIn("tl.debug_barrier()", code)
 
+    @skipIfNotTriton("automatic RAW barriers are Triton codegen-specific")
+    def test_sequential_loops_device_local_carry_has_no_barrier(self):
+        @helion.kernel(autotune_effort="none")
+        def two_pass_sum(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.shape
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(m):
+                total = hl.zeros([tile_m], dtype=torch.float32)
+                for tile_n in hl.tile(n):
+                    total += x[tile_m, tile_n].sum(dim=1)
+                for tile_n in hl.tile(n):
+                    out[tile_m, tile_n] = x[tile_m, tile_n] + total[:, None]
+            return out
+
+        x = torch.randn(32, 64, dtype=torch.float32, device=DEVICE)
+        code, result = code_and_output(
+            two_pass_sum,
+            (x,),
+            block_sizes=[8, 16, 16],
+            num_warps=4,
+            num_stages=1,
+        )
+        torch.testing.assert_close(result, x + x.sum(dim=1, keepdim=True))
+        self.assertNotIn("tl.debug_barrier()", code)
+
     @skipIfNotTriton(
         "tl.debug_barrier() is only emitted in Triton device codegen (not Pallas/JAX)"
     )


### PR DESCRIPTION
## Problem
The previous inter-loop analysis #1845  used host-level read/write name sets attached to each `ForLoopGraphInfo`. Those sets do not distinguish global-memory accesses from device-local values carried between loops.

For example, the [two-pass softmax kernel](https://github.com/pytorch/helion/blob/fa2f62eb686ef846c76f8b9e18beec30fbc5bee1/examples/softmax.py#L67) keeps its running maximum and denominator in device-local tensors:

```python
#from 
for tile_m in hl.tile(m, block_size=block_size_m):
    mi = hl.full([tile_m], float("-inf"), dtype=torch.float32)
    di = hl.zeros([tile_m], dtype=torch.float32)

    for tile_n in hl.tile(n, block_size=block_size_n):
        values = x[tile_m, tile_n]
        local_amax = torch.amax(values, dim=1)
        mi_next = torch.maximum(mi, local_amax)
        di = di * torch.exp(mi - mi_next) + torch.exp(
            values - mi_next[:, None]
        ).sum(dim=1)
        mi = mi_next

    for tile_n in hl.tile(n, block_size=block_size_n):
        values = x[tile_m, tile_n]
        out[tile_m, tile_n] = torch.exp(values - mi[:, None]) / di[:, None]
```

The host-level analysis observed that the first inner loop writes `mi` and `di`, while the second inner loop reads them, and conservatively inserted a `tl.debug_barrier()` between the loops. However, these values are carried in op-chip memory; there is no global-memory store followed by a global-memory load that requires synchronization.

The resulting generated code contained an unnecessary barrier before the normalization pass, causing redundant synchronization and potential performance degradation:

```python
for ...:  # reduction pass
    ...

tl.debug_barrier()  # unnecessary

for ...:  # normalization pass
    ...
```

## Implementation

The old inter-loop analysis is replaced by the storage-based analysis already used for intra-loop RAW barriers. It summarizes the actual FX memory operations in each loop and its control-flow subgraphs, then inserts a barrier only when a previous sibling loop wrote storage that the current loop reads.

The obsolete inter-loop metadata and tracing helpers are removed, while the existing barrier emission path and backend gating remain unchanged.