### PR TITLE
node_masking: fix masked value analysis override type (fixes CI lint)

### DIFF
--- a/helion/_compiler/node_masking.py
+++ b/helion/_compiler/node_masking.py
@@ -4,7 +4,6 @@ import functools
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
-from typing_extensions import Never
 
 import sympy
 from torch._inductor.bounds import ValueRangeAnalysis
@@ -449,7 +448,7 @@ class MaskedValueAnalysisInductor(ValueRangeAnalysis):
         return self.input_name_lookup[name]
 
     @classmethod
-    def index_expr(cls, index: Never, dtype: torch.dtype) -> ValueRangesAny:
+    def index_expr(cls, index: object, dtype: torch.dtype) -> ValueRangesAny:
         return ValueRanges.unknown()
 
 


### PR DESCRIPTION
PyTorch changed ValueRangeAnalysis.index_expr's index parameter from Any to object in https://github.com/pytorch/pytorch/pull/196021 (e2ad2281e6a). The Never parameter in Helion's override narrows the accepted type, which has been triggering this linter error since:

    ERROR Class member `MaskedValueAnalysisInductor.index_expr` overrides
    parent class `ValueRangeAnalysis` in an inconsistent manner
    [bad-override]

Use object to match the parent signature.