### PR TITLE
[pallas] test_remote_copy: add missing remote_barrier

### DIFF
--- a/test/test_remote_copy.py
+++ b/test/test_remote_copy.py
@@ -376,6 +376,7 @@ def _parent_store_nested_remote_copy(
     """Initialize a resident exchange buffer before copying from a child loop."""
     num_steps = hl.specialize(src.size(1))
     for _program in hl.grid(1):
+        hl.remote_barrier(peers[0, 0])
         for step in hl.tile(num_steps, block_size=1):
             exchange[0, 0, step.begin, :] = src[0, step.begin, :]
             for peer_step in hl.tile(1, block_size=1):


### PR DESCRIPTION
test_parent_store_nested_remote_copy is currently flaky on TPUv7. ~This hasn't been caught in CI because the TPU in CI doesn't have more than one device. TPUv7, however, has two.~

The cause of the flake is a race due to a missing barrier. Fix it by adding the barrier to match other kernels in the same file.