### PR TITLE
CI: do not pass --reruns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -319,17 +319,17 @@ jobs:
             # worker gets killed mid-compile. Give it headroom.
             TIMEOUT=180
           fi
-          pytest $PARALLEL -rf --timeout=$TIMEOUT --reruns=2 --timeout-method=thread $EXTRA_FLAGS $TEST_PATH | tee >(eval $SKIP_CHECK)
+          pytest $PARALLEL -rf --timeout=$TIMEOUT --timeout-method=thread $EXTRA_FLAGS $TEST_PATH | tee >(eval $SKIP_CHECK)
           # JAX and TorchTPU initialize the TPU runtime differently. Run the
           # physical remote-copy suites in fresh, sequential pytest processes.
           if [[ "${{ matrix.alias }}" == "tpu" ]]; then
-            pytest -rf --timeout=$TIMEOUT --reruns=2 --timeout-method=thread test/test_remote_copy.py::TestRemoteCopyJaxRuntime
-            HELION_TEST_TORCH_TPU_MULTIPROCESS=1 pytest -rf --timeout=$TIMEOUT --reruns=2 --timeout-method=thread test/test_remote_copy.py::TestRemoteCopyTorchTpuRuntime
+            pytest -rf --timeout=$TIMEOUT --timeout-method=thread test/test_remote_copy.py::TestRemoteCopyJaxRuntime
+            HELION_TEST_TORCH_TPU_MULTIPROCESS=1 pytest -rf --timeout=$TIMEOUT --timeout-method=thread test/test_remote_copy.py::TestRemoteCopyTorchTpuRuntime
           fi
           # Each remote-copy test launches one process per GPU, so run this class
           # serially rather than assigning its tests to concurrent xdist workers.
           if [[ "${{ contains(matrix.alias, 'distributed') }}" == "true" ]]; then
-            pytest -rf --timeout=$TIMEOUT --reruns=2 --timeout-method=thread $EXTRA_FLAGS test/test_remote_copy.py::TestRemoteCopyGPU | tee >(eval $SKIP_CHECK)
+            pytest -rf --timeout=$TIMEOUT --timeout-method=thread $EXTRA_FLAGS test/test_remote_copy.py::TestRemoteCopyGPU | tee >(eval $SKIP_CHECK)
           fi
 
   test-notebooks:


### PR DESCRIPTION
It can hide flaky tests. I see it was introduced by XPU CI and then we copied it over:

```
$ git log -G'--reruns=' --oneline --reverse
ce61a2ee [CI] Enable build and test for XPU (#1327)
e76022a3 [Pallas] Add Pallas interpret CI job (revival of #1938) (#2491)
3463eb67 [Pallas] Make sure all TPU tests in test_remote_copy are exeuted in CI. (#3366)
32dd58c4 [Triton] Lower async remote copies through NVSHMEM (#3333)
0abd14d6 (HEAD -> retry_tracebacks) CI: do not pass --reruns
```

If this really is necessary, we should only pass it on the backends that need it, and also pass --rerun-show-tracebacks to show tracebacks for retried failures -- see
https://github.com/pytest-dev/pytest-rerunfailures#show-tracebacks-for-retried-failures.

Context: https://github.com/pytorch/helion/pull/3584