### PR TITLE
CI: do not pip install pytest-rerunfailures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -268,7 +268,6 @@ jobs:
           set -e -o pipefail
           source .venv/bin/activate
           uv pip install pytest-xdist
-          uv pip install pytest-rerunfailures
           # Conditionally enable ref-eager and golden-accept/dtype-assert test modes
           if [[ "${{ matrix.dtype-asserts }}" == "true" ]]; then export HELION_DEBUG_DTYPE_ASSERTS=1; fi
           if [[ "${{ matrix.expecttest-accept }}" == "true" ]]; then export EXPECTTEST_ACCEPT=1; fi


### PR DESCRIPTION
Not needed after https://github.com/pytorch/helion/pull/3585.