### PR TITLE
benchmarks: add reproducible KDA comparisons

### DIFF
--- a/benchmarks/cute/compare_kda_decode_backends.py
+++ b/benchmarks/cute/compare_kda_decode_backends.py
@@ -1,0 +1,895 @@
+"""Reproduce the reportable B1/B256 Helion-versus-CAKE decode comparisons.
+
+The harness has one protocol: each provider gets a private one-invocation CUDA
+graph, state/output restoration and an L2 flush happen outside the timed
+region, and samples alternate in balanced ABBA/BAAB order. The tensor contract
+matches FlashInfer's public packed KDA decode API.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from dataclasses import dataclass
+import importlib
+import importlib.util
+import json
+import math
+import os
+from pathlib import Path
+import sys
+from types import ModuleType
+from typing import Any
+from typing import Callable
+from typing import cast
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from benchmarks.cute.kda_benchmark_utils import DEFAULT_COOLDOWN_C  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import PairedGraphArm  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import assert_stable  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import canonical_config_json  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import capture_paired_cuda_graphs  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import file_sha256  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import gpu_info  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import measure_paired_cuda_graphs  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import parse_json_object  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import source_provenance  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import text_sha256  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import validate_pinned_source  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import (  # noqa: E402
+    verify_helion_generated_wrapper,
+)
+import torch  # noqa: E402
+
+import helion  # noqa: E402
+
+DEFAULT_BATCH_SIZES = (1, 256)
+IMPLEMENTATIONS = ("flashinfer-cake", "helion-cute")
+PINNED_FLASHINFER_SHA = "f67bc2ed555c1ad6a764ad68f7aa9622178e9eae"
+PINNED_SGLANG_SHA = "55509b3f421a25c631f89de8a139772f625038d8"
+EXPECTED_CAKE_VARIANTS = {
+    1: "register_tile16",
+    256: "cpasync_tile128_register_pipeline",
+}
+HEADS = 12
+HEAD_DIM = 128
+LOWER_BOUND = -5.0
+L2_EPSILON = 1e-6
+STATE_SLOT_PADDING = 256
+MIXED_QKV_ROW_STRIDE = 4 * HEADS * HEAD_DIM
+
+
+@dataclass(frozen=True)
+class HelionConfigSpec:
+    json_text: str
+    source: str
+    source_sha256: str
+    config_sha256: str
+
+
+@dataclass
+class KDAInputs:
+    mixed_qkv: torch.Tensor
+    raw_gate: torch.Tensor
+    raw_beta: torch.Tensor
+    a_log: torch.Tensor
+    dt_bias: torch.Tensor
+    state: torch.Tensor
+    state_indices: torch.Tensor
+    output: torch.Tensor
+
+    def clone_mutable(self) -> KDAInputs:
+        cloned_state = torch.empty_strided(
+            self.state.shape,
+            self.state.stride(),
+            dtype=self.state.dtype,
+            device=self.state.device,
+        )
+        cloned_state.copy_(self.state)
+        return KDAInputs(
+            mixed_qkv=self.mixed_qkv,
+            raw_gate=self.raw_gate,
+            raw_beta=self.raw_beta,
+            a_log=self.a_log,
+            dt_bias=self.dt_bias,
+            state=cloned_state,
+            state_indices=self.state_indices,
+            output=torch.empty_like(self.output),
+        )
+
+    def helion_args(self) -> tuple[object, ...]:
+        return (
+            self.mixed_qkv,
+            self.raw_gate,
+            self.raw_beta,
+            self.a_log,
+            self.dt_bias,
+            HEAD_DIM**-0.5,
+            LOWER_BOUND,
+            self.state,
+            self.output,
+            self.state_indices,
+            True,
+            True,
+            True,
+        )
+
+
+def _load_helion_config(args: argparse.Namespace) -> HelionConfigSpec:
+    if args.helion_config is not None:
+        canonical = canonical_config_json(args.helion_config, "--helion-config")
+        return HelionConfigSpec(
+            json_text=canonical,
+            source="inline-cli",
+            source_sha256=text_sha256(args.helion_config),
+            config_sha256=text_sha256(canonical),
+        )
+    if args.helion_config_file is None:
+        raise ValueError("a pinned Helion config is required")
+    path = args.helion_config_file.resolve()
+    contents = path.read_bytes()
+    try:
+        text = contents.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ValueError(f"--helion-config-file must be UTF-8: {path}") from error
+    canonical = canonical_config_json(text, "--helion-config-file")
+    return HelionConfigSpec(
+        json_text=canonical,
+        source=str(path),
+        source_sha256=file_sha256(path),
+        config_sha256=text_sha256(canonical),
+    )
+
+
+def _source_fingerprint(args: argparse.Namespace) -> dict[str, Any]:
+    harness_path = Path(__file__).resolve()
+    helper_path = Path(measure_paired_cuda_graphs.__code__.co_filename).resolve()
+    if helion.__file__ is None:
+        raise RuntimeError("loaded Helion package has no source path")
+
+    flashinfer_root = args.flashinfer_root.resolve()
+    flashinfer_package = flashinfer_root / "flashinfer"
+    sglang_root = args.sglang_root.resolve()
+    sglang_helion = (
+        sglang_root / "python" / "sglang" / "kernels" / "ops" / "attention" / "helion"
+    )
+    return {
+        "benchmark": {"path": str(harness_path), "sha256": file_sha256(harness_path)},
+        "paired_graph_helper": {
+            "path": str(helper_path),
+            "sha256": file_sha256(helper_path),
+        },
+        "helion": source_provenance(
+            REPO_ROOT,
+            {"package_init": Path(helion.__file__).resolve()},
+            pathspecs=("helion",),
+        ),
+        "flashinfer": source_provenance(
+            flashinfer_root,
+            {
+                "cake_packed_decode": (
+                    flashinfer_package / "kda_kernels" / "cake_packed_kda_decode.py"
+                ),
+                "cake_packed_t1_jit": (
+                    flashinfer_package / "jit" / "cake_kda_packed_t1.py"
+                ),
+                "cake_b1_body": (
+                    flashinfer_root
+                    / "csrc"
+                    / "kda"
+                    / "cake_kda_packed_t1_register_tile16.cu"
+                ),
+                "cake_b256_body": (
+                    flashinfer_root
+                    / "csrc"
+                    / "kda"
+                    / "cake_kda_packed_t1_cpasync_tile128_register_pipeline.cu"
+                ),
+            },
+            expected_commit=args.flashinfer_sha,
+        ),
+        "sglang": source_provenance(
+            sglang_root,
+            {
+                "helion_package": sglang_helion / "__init__.py",
+                "kda_decode": sglang_helion / "kda_decode.py",
+            },
+            expected_commit=args.sglang_sha,
+        ),
+    }
+
+
+def _install_namespace(name: str, path: Path) -> ModuleType:
+    module = ModuleType(name)
+    module.__path__ = [str(path)]  # type: ignore[attr-defined]
+    module.__package__ = name
+    sys.modules[name] = module
+    return module
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"unable to load {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    if module.__file__ is None or Path(module.__file__).resolve() != path.resolve():
+        raise RuntimeError(
+            f"expected module {path.resolve()}, loaded {module.__file__}"
+        )
+    return module
+
+
+def _read_source_int_constant(path: Path, name: str) -> int:
+    """Read one literal integer assignment without executing package code."""
+
+    tree = ast.parse(path.read_text(), filename=str(path))
+    values = [
+        node.value.value
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == name
+            for target in node.targets
+        )
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, int)
+        and not isinstance(node.value.value, bool)
+    ]
+    if len(values) != 1:
+        raise ValueError(f"expected one literal integer {name} assignment in {path}")
+    return values[0]
+
+
+def _load_flashinfer_cake(root: Path) -> ModuleType:
+    package_root = (root / "flashinfer").resolve()
+    source = package_root / "kda_kernels" / "cake_packed_kda_decode.py"
+    if not source.is_file():
+        raise FileNotFoundError(f"not a FlashInfer source checkout: {root}")
+    if importlib.util.find_spec("pynvml") is None:
+        sys.modules["pynvml"] = ModuleType("pynvml")
+    for name, relative in (
+        ("flashinfer", ""),
+        ("flashinfer.jit", "jit"),
+        ("flashinfer.kda_kernels", "kda_kernels"),
+    ):
+        _install_namespace(name, package_root / relative)
+    return _load_module("flashinfer.kda_kernels.cake_packed_kda_decode", source)
+
+
+def _load_sglang_decode(root: Path) -> ModuleType:
+    package_root = (root / "python" / "sglang").resolve()
+    helion_root = package_root / "kernels" / "ops" / "attention" / "helion"
+    source = helion_root / "kda_decode.py"
+    if not source.is_file():
+        raise FileNotFoundError(f"not an SGLang source checkout: {root}")
+    small_value_head_threshold = _read_source_int_constant(
+        helion_root / "__init__.py", "KDA_SMALL_VALUE_HEAD_THRESHOLD"
+    )
+    for name, path in {
+        "sglang": package_root,
+        "sglang.kernels": package_root / "kernels",
+        "sglang.kernels.ops": package_root / "kernels" / "ops",
+        "sglang.kernels.ops.attention": package_root / "kernels" / "ops" / "attention",
+        "sglang.kernels.ops.attention.helion": helion_root,
+    }.items():
+        module = _install_namespace(name, path)
+        if name.endswith(".helion"):
+            module.KDA_SMALL_VALUE_HEAD_THRESHOLD = small_value_head_threshold  # type: ignore[attr-defined]
+    return _load_module("sglang.kernels.ops.attention.helion.kda_decode", source)
+
+
+def _make_inputs(batch: int, seed: int) -> KDAInputs:
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    mixed_qkv = torch.empty_strided(
+        (batch, 3 * HEADS * HEAD_DIM),
+        (MIXED_QKV_ROW_STRIDE, 1),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    mixed_qkv.normal_(mean=0.0, std=0.25, generator=generator)
+    raw_gate = torch.randn(
+        batch,
+        HEADS * HEAD_DIM,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    ).mul_(0.25)
+    raw_beta = torch.randn(
+        batch,
+        HEADS,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    a_log = torch.empty(HEADS, device="cuda", dtype=torch.float32)
+    a_log.uniform_(-2.0, -0.1, generator=generator)
+    dt_bias = torch.randn(
+        HEADS * HEAD_DIM,
+        device="cuda",
+        dtype=torch.float32,
+        generator=generator,
+    ).mul_(0.1)
+    compact_slot = HEADS * HEAD_DIM * HEAD_DIM
+    state = torch.empty_strided(
+        (batch + 8, HEADS, HEAD_DIM, HEAD_DIM),
+        (compact_slot + STATE_SLOT_PADDING, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    state.normal_(mean=0.0, std=0.02, generator=generator)
+    state_indices = torch.arange(batch, 0, -1, device="cuda", dtype=torch.int32)
+    output = torch.empty(batch, 1, HEADS, HEAD_DIM, device="cuda", dtype=torch.bfloat16)
+    return KDAInputs(
+        mixed_qkv=mixed_qkv,
+        raw_gate=raw_gate,
+        raw_beta=raw_beta,
+        a_log=a_log,
+        dt_bias=dt_bias,
+        state=state,
+        state_indices=state_indices,
+        output=output,
+    )
+
+
+def _semantic_metadata(batch_size: int, seed: int) -> dict[str, Any]:
+    return {
+        "variant": f"packed_decode_t1_b{batch_size}_h{HEADS}_d{HEAD_DIM}",
+        "seed": seed,
+        "shape": {
+            "batch_size": batch_size,
+            "num_tokens": 1,
+            "num_heads": HEADS,
+            "head_dim": HEAD_DIM,
+        },
+        "dtype": "bfloat16",
+        "state_dtype": "bfloat16",
+        "mixed_qkv_row_stride": MIXED_QKV_ROW_STRIDE,
+        "state_layout": "[pool,head,value,key]",
+        "state_pool_size": batch_size + 8,
+        "state_slot_padding_elements": STATE_SLOT_PADDING,
+        "state_index_pattern": "descending-from-batch",
+        "qk_l2norm": True,
+        "l2_epsilon": L2_EPSILON,
+        "scale": HEAD_DIM**-0.5,
+        "gate_mode": "raw-lower-bound-sigmoid",
+        "lower_bound": LOWER_BOUND,
+        "beta_is_logit": True,
+        "input_distribution": {
+            "mixed_qkv": "normal-std-0.25-bfloat16",
+            "raw_gate": "normal-std-0.25-bfloat16",
+            "raw_beta": "normal-std-1.0-bfloat16",
+            "a_log": "uniform-minus-2-to-minus-0.1-float32",
+            "dt_bias": "normal-std-0.1-float32",
+            "state": "normal-std-0.02-bfloat16",
+        },
+        "timed_state_semantics": "pristine-reset-before-each-cuda-graph-replay",
+        "correctness_state_semantics": "pristine-clone-single-launch",
+    }
+
+
+def _torch_reference(inputs: KDAInputs) -> tuple[torch.Tensor, torch.Tensor]:
+    batch = inputs.mixed_qkv.shape[0]
+    q_end = HEADS * HEAD_DIM
+    k_end = 2 * q_end
+    q = inputs.mixed_qkv[:, :q_end].reshape(batch, HEADS, HEAD_DIM).float()
+    k = inputs.mixed_qkv[:, q_end:k_end].reshape(batch, HEADS, HEAD_DIM).float()
+    v = inputs.mixed_qkv[:, k_end:].reshape(batch, HEADS, HEAD_DIM).float()
+    q = q * torch.rsqrt((q * q).sum(-1, keepdim=True) + L2_EPSILON)
+    k = k * torch.rsqrt((k * k).sum(-1, keepdim=True) + L2_EPSILON)
+    q = q * HEAD_DIM**-0.5
+
+    gate_input = inputs.raw_gate.reshape(batch, HEADS, HEAD_DIM).float()
+    gate_input = gate_input + inputs.dt_bias.reshape(1, HEADS, HEAD_DIM)
+    decay_parameter = torch.exp(inputs.a_log).reshape(1, HEADS, 1)
+    log_decay = LOWER_BOUND * torch.sigmoid(decay_parameter * gate_input)
+    beta = torch.sigmoid(inputs.raw_beta.float())
+    state_indices = inputs.state_indices.long()
+    state = inputs.state.index_select(0, state_indices).float()
+    state = state * torch.exp(log_decay)[:, :, None, :]
+    residual = v - (state * k[:, :, None, :]).sum(-1)
+    state = state + (residual * beta[:, :, None])[:, :, :, None] * k[:, :, None, :]
+    output = (state * q[:, :, None, :]).sum(-1)
+    inputs.output[:, 0] = output.to(inputs.output.dtype)
+    inputs.state[state_indices] = state.to(inputs.state.dtype)
+    return inputs.output, inputs.state
+
+
+def _effective_bytes(batch: int) -> int:
+    element_bytes = 2
+    state_elements = batch * HEADS * HEAD_DIM * HEAD_DIM
+    activation_elements = batch * (
+        3 * HEADS * HEAD_DIM + HEADS * HEAD_DIM + HEADS + HEADS * HEAD_DIM
+    )
+    parameter_bytes = (HEADS + HEADS * HEAD_DIM) * 4
+    index_bytes = batch * 4
+    return (
+        2 * state_elements * element_bytes
+        + activation_elements * element_bytes
+        + parameter_bytes
+        + index_bytes
+    )
+
+
+def _check_result(
+    actual: tuple[torch.Tensor, torch.Tensor],
+    expected: tuple[torch.Tensor, torch.Tensor],
+) -> dict[str, float]:
+    output, state = actual
+    expected_output, expected_state = expected
+    output_max_abs = float((output.float() - expected_output.float()).abs().max())
+    state_max_abs = float((state.float() - expected_state.float()).abs().max())
+    torch.testing.assert_close(output, expected_output, atol=2e-2, rtol=1e-2)
+    torch.testing.assert_close(state, expected_state, atol=2e-2, rtol=1e-2)
+    return {"output_max_abs": output_max_abs, "state_max_abs": state_max_abs}
+
+
+def _make_helion_kernel(module: ModuleType, args: argparse.Namespace) -> helion.Kernel:
+    return helion.kernel(
+        module._helion_fused_recurrent_kda_packed_decode_body,
+        static_shapes=False,
+        autotune_effort="full",
+        autotune_random_seed=args.autotune_seed,
+        ignore_warnings=[helion.exc.ProcessGroupNameNotFound],
+    )
+
+
+def _helion_codegen_expectation(
+    batch_size: int, config: dict[str, Any]
+) -> tuple[str, tuple[str, ...], tuple[str, ...]]:
+    if batch_size == 1:
+        return "single-token-rank1", ("rank1_helper_abi_version = 4",), ()
+    uses_canonical_async_bf16x2_plan = (
+        config.get("block_sizes") == [128]
+        and config.get("num_threads") == [8, 16]
+        and config.get("cute_bf16x2_recurrence") is True
+        and config.get("cute_async_load_stages") == 5
+        and config.get("cute_async_load_group_rows") == 2
+        and config.get("cute_async_store_policy") == "l2_evict_last"
+        and config.get("cute_vector_widths") == [8, 1, 1, 1]
+    )
+    if uses_canonical_async_bf16x2_plan:
+        return (
+            "generic-async-state-ring-bf16x2",
+            (
+                (
+                    "from helion._compiler.cute.l2_policy import "
+                    "store_u32x4_l2_evict_last as "
+                    "_cute_store_u32x4_l2_evict_last"
+                ),
+                "cute.arch.cp_async_wait_group(0)",
+            ),
+            (
+                (
+                    r"_async_state_[0-9]+_smem = "
+                    r"cutlass\.Array\(cutlass\.Uint16, 10240, "
+                    r"space=cutlass\.AddressSpace\.smem, alignment=128\)"
+                ),
+                (
+                    r"_async_state_[0-9]+_scalar_pairs = "
+                    r"cute\.make_rmem_tensor\(8, cutlass\.Uint32\)"
+                ),
+                r"_bf16x2_[0-9]+_abi_version = 1",
+                r"_cute_store_u32x4_l2_evict_last\(.*\)",
+            ),
+        )
+    return "generic-decode", ("@cute.kernel",), ()
+
+
+def _paired_input_ownership(
+    pristine: KDAInputs, arms: dict[str, KDAInputs]
+) -> dict[str, Any]:
+    immutable_fields = (
+        "mixed_qkv",
+        "raw_gate",
+        "raw_beta",
+        "a_log",
+        "dt_bias",
+        "state_indices",
+    )
+    shared = {
+        field: all(
+            getattr(inputs, field) is getattr(pristine, field)
+            for inputs in arms.values()
+        )
+        for field in immutable_fields
+    }
+    if not all(shared.values()):
+        raise RuntimeError(f"paired immutable inputs are not shared: {shared}")
+    state_pointers = {
+        "pristine": pristine.state.data_ptr(),
+        **{name: inputs.state.data_ptr() for name, inputs in arms.items()},
+    }
+    output_pointers = {
+        "pristine": pristine.output.data_ptr(),
+        **{name: inputs.output.data_ptr() for name, inputs in arms.items()},
+    }
+    if len(set(state_pointers.values())) != len(state_pointers):
+        raise RuntimeError(f"paired state buffers alias: {state_pointers}")
+    if len(set(output_pointers.values())) != len(output_pointers):
+        raise RuntimeError(f"paired output buffers alias: {output_pointers}")
+    return {
+        "shared_immutable_fields": shared,
+        "private_state_buffers": True,
+        "private_output_buffers": True,
+        "state_pointers": state_pointers,
+        "output_pointers": output_pointers,
+    }
+
+
+def _cross_provider_comparison(
+    baseline: KDAInputs, candidate: KDAInputs
+) -> dict[str, float | bool]:
+    return {
+        "output_max_abs": float(
+            (baseline.output.float() - candidate.output.float()).abs().max()
+        ),
+        "state_max_abs": float(
+            (baseline.state.float() - candidate.state.float()).abs().max()
+        ),
+        "output_exact": bool(torch.equal(baseline.output, candidate.output)),
+        "state_exact": bool(torch.equal(baseline.state, candidate.state)),
+    }
+
+
+def _make_cake_launch(module: ModuleType, inputs: KDAInputs) -> Callable[[], object]:
+    def launch() -> object:
+        return module.run_packed_kda_decode(  # pyrefly: ignore[missing-attribute]
+            inputs.mixed_qkv,
+            inputs.raw_gate,
+            inputs.raw_beta,
+            inputs.a_log,
+            inputs.dt_bias,
+            inputs.state,
+            inputs.state_indices,
+            inputs.output,
+        )
+
+    return launch
+
+
+def _tracked_cake_call(
+    module: ModuleType,
+    batch_size: int,
+    inputs: KDAInputs,
+    launch: Callable[[], object],
+) -> tuple[tuple[torch.Tensor, torch.Tensor], dict[str, Any]]:
+    loaded: list[tuple[str, str, str]] = []
+    original_cake = module.get_cake_kda_packed_t1_module  # pyrefly: ignore[missing-attribute]
+    original_legacy = module.get_flash_kda_packed_t1_module  # pyrefly: ignore[missing-attribute]
+
+    def track_cake(variant: str, target: str) -> object:
+        loaded.append(("cake-kda-packed-t1", variant, target))
+        return original_cake(variant, target)
+
+    def track_legacy(variant: str, target: str) -> object:
+        loaded.append(("legacy-flash-kda-packed-t1", variant, target))
+        return original_legacy(variant, target)
+
+    module.get_cake_kda_packed_t1_module = track_cake  # pyrefly: ignore[missing-attribute]
+    module.get_flash_kda_packed_t1_module = track_legacy  # pyrefly: ignore[missing-attribute]
+    try:
+        launch()
+    finally:
+        module.get_cake_kda_packed_t1_module = original_cake  # pyrefly: ignore[missing-attribute]
+        module.get_flash_kda_packed_t1_module = original_legacy  # pyrefly: ignore[missing-attribute]
+
+    expected = EXPECTED_CAKE_VARIANTS[batch_size]
+    if (
+        len(loaded) != 1
+        or loaded[0][0] != "cake-kda-packed-t1"
+        or loaded[0][1] != expected
+    ):
+        raise AssertionError(
+            f"B{batch_size} expected one CAKE {expected} module, got {loaded}"
+        )
+    family, variant, target = loaded[0]
+    jit_module = importlib.import_module("flashinfer.jit.cake_kda_packed_t1")
+    jit_uri = jit_module.get_cake_kda_packed_t1_uri(variant, target)  # pyrefly: ignore[missing-attribute]
+    return (inputs.output, inputs.state), {
+        "variant": variant,
+        "expected_variant": expected,
+        "module_family": family,
+        "jit_target": target,
+        "jit_uri": jit_uri,
+    }
+
+
+def _run_paired_decode_graph(
+    args: argparse.Namespace, config_spec: HelionConfigSpec
+) -> dict[str, Any]:
+    if os.environ.get("HELION_BACKEND") != "cute":
+        raise RuntimeError("set HELION_BACKEND=cute for Helion graph timing")
+
+    source_before = _source_fingerprint(args)
+    validate_pinned_source("FlashInfer", source_before["flashinfer"])
+    validate_pinned_source("SGLang", source_before["sglang"])
+    if _load_helion_config(args) != config_spec:
+        raise RuntimeError("Helion config input changed before paired graph timing")
+
+    batch_size = args.batch_size
+    pristine = _make_inputs(batch_size, args.seed)
+    expected = _torch_reference(pristine.clone_mutable())
+    arm_inputs = {name: pristine.clone_mutable() for name in IMPLEMENTATIONS}
+    ownership = _paired_input_ownership(pristine, arm_inputs)
+
+    cake_module = _load_flashinfer_cake(args.flashinfer_root.resolve())
+    cake_inputs = arm_inputs["flashinfer-cake"]
+    cake_launch = _make_cake_launch(cake_module, cake_inputs)
+    state_aligned, aux_vec4_aligned = cake_module._optimized_alignment_flags(  # pyrefly: ignore[missing-attribute]
+        cake_inputs.mixed_qkv,
+        cake_inputs.raw_gate,
+        cake_inputs.dt_bias,
+        cake_inputs.state,
+    )
+    selected_cake_variant = cake_module.select_cake_kda_packed_t1_variant(  # pyrefly: ignore[missing-attribute]
+        batch_size,
+        state_aligned=state_aligned,
+        aux_vec4_aligned=aux_vec4_aligned,
+    )
+    expected_cake_variant = EXPECTED_CAKE_VARIANTS[batch_size]
+    if selected_cake_variant != expected_cake_variant:
+        raise RuntimeError(
+            f"B{batch_size} expected CAKE variant {expected_cake_variant}, "
+            f"got {selected_cake_variant}"
+        )
+
+    sglang_module = _load_sglang_decode(args.sglang_root.resolve())
+    helion_inputs = arm_inputs["helion-cute"]
+    kernel_args = helion_inputs.helion_args()
+    helion_bound = _make_helion_kernel(sglang_module, args).bind(kernel_args)
+    requested_config = helion.Config(
+        **parse_json_object(config_spec.json_text, "pinned Helion config")
+    )
+    config = helion_bound.config_spec.normalized_config(requested_config)
+    helion_bound.set_config(config)
+    resolved_config = canonical_config_json(config.to_json(), "resolved Helion config")
+
+    def launch_helion(
+        bound_kernel: Callable[..., object] = cast(
+            "Callable[..., object]", helion_bound
+        ),
+        bound_args: tuple[object, ...] = kernel_args,
+    ) -> object:
+        return bound_kernel(*bound_args)
+
+    def reset_cake() -> None:
+        cake_inputs.state.copy_(pristine.state)
+        cake_inputs.output.zero_()
+
+    def reset_helion() -> None:
+        helion_inputs.state.copy_(pristine.state)
+        helion_inputs.output.zero_()
+
+    arms = (
+        PairedGraphArm("flashinfer-cake", cake_launch, reset_cake),
+        PairedGraphArm("helion-cute", launch_helion, reset_helion),
+    )
+
+    eager_correctness: dict[str, Any] = {}
+    reset_cake()
+    cake_actual, cake_route = _tracked_cake_call(
+        cake_module, batch_size, cake_inputs, cake_launch
+    )
+    torch.cuda.synchronize()
+    eager_correctness["flashinfer-cake"] = _check_result(cake_actual, expected)
+    reset_helion()
+    launch_helion()
+    torch.cuda.synchronize()
+    eager_correctness["helion-cute"] = _check_result(
+        (helion_inputs.output, helion_inputs.state), expected
+    )
+
+    config_values = parse_json_object(resolved_config, "resolved Helion config")
+    plan_kind, source_markers, source_patterns = _helion_codegen_expectation(
+        batch_size, config_values
+    )
+    generated_wrapper = verify_helion_generated_wrapper(
+        helion_bound,
+        config,
+        expected_plan_kind=plan_kind,
+        expected_source_markers=source_markers,
+        expected_source_patterns=source_patterns,
+    )
+    provider_metadata = {
+        "flashinfer-cake": {
+            "backend": "cake",
+            "route": cake_route,
+            "state_aligned": state_aligned,
+            "aux_vec4_aligned": aux_vec4_aligned,
+            "provenance": source_before["flashinfer"],
+        },
+        "helion-cute": {
+            "backend": "helion-cute",
+            "requested_config": json.loads(config_spec.json_text),
+            "config": json.loads(resolved_config),
+            "config_metadata": {
+                "mode": "pinned",
+                "source": config_spec.source,
+                "source_sha256": config_spec.source_sha256,
+                "input_config_sha256": config_spec.config_sha256,
+                "resolved_config_sha256": text_sha256(resolved_config),
+            },
+            "generated_wrapper": generated_wrapper,
+            "sglang_provenance": source_before["sglang"],
+        },
+    }
+
+    stream = torch.cuda.Stream()
+    captured = capture_paired_cuda_graphs(arms, stream)
+    graph_correctness: dict[str, Any] = {}
+    for arm in arms:
+        with torch.cuda.stream(stream):
+            arm.reset()
+            captured[arm.name].graph.replay()
+        stream.synchronize()
+        inputs = arm_inputs[arm.name]
+        graph_correctness[arm.name] = _check_result(
+            (inputs.output, inputs.state), expected
+        )
+    cross_provider_correctness = _cross_provider_comparison(cake_inputs, helion_inputs)
+
+    timing = measure_paired_cuda_graphs(
+        captured,
+        baseline="flashinfer-cake",
+        candidate="helion-cute",
+        measurement_cycles=args.graph_measurement_cycles,
+        primer_cycles=args.graph_primer_cycles,
+        cooldown_temp_c=args.cooldown_temp_c,
+        cooldown_timeout_s=args.cooldown_timeout_s,
+        stream=stream,
+    )
+    effective_bytes = _effective_bytes(batch_size)
+    for values in timing["implementations"].values():
+        values["effective_gbps"] = effective_bytes / (values["median_ms"] * 1e6)
+
+    source_after = _source_fingerprint(args)
+    assert_stable(
+        "source fingerprint during paired graph run", source_before, source_after
+    )
+    if _load_helion_config(args) != config_spec:
+        raise RuntimeError("Helion config input changed during paired graph timing")
+    final_config = getattr(helion_bound, "_config", None)
+    if (
+        final_config is None
+        or canonical_config_json(final_config.to_json(), "final Helion config")
+        != resolved_config
+    ):
+        raise RuntimeError("Helion config changed during paired graph timing")
+    final_wrapper = verify_helion_generated_wrapper(
+        helion_bound,
+        final_config,
+        expected_plan_kind=plan_kind,
+        expected_source_markers=source_markers,
+        expected_source_patterns=source_patterns,
+    )
+    assert_stable(
+        "Helion generated wrapper during paired graph run",
+        generated_wrapper,
+        final_wrapper,
+    )
+
+    return {
+        "valid": True,
+        "variant": f"packed_decode_t1_b{batch_size}_h{HEADS}_d{HEAD_DIM}",
+        "batch_size": batch_size,
+        "implementations_order": list(IMPLEMENTATIONS),
+        "semantic_metadata": _semantic_metadata(batch_size, args.seed),
+        "effective_bytes": effective_bytes,
+        "timed_state_semantics": "pristine-reset-before-each-cuda-graph-replay",
+        "correctness_state_semantics": "identical-pristine-clone-one-replay",
+        "correctness": {
+            "eager_vs_oracle": eager_correctness,
+            "graph_replay_vs_oracle": graph_correctness,
+            "cross_provider_after_one_graph": cross_provider_correctness,
+        },
+        "fairness_audit": {
+            "same_process": True,
+            "same_cuda_stream": True,
+            "same_cuda_event_timer": True,
+            "one_provider_invocation_per_graph": True,
+            "one_graph_replay_per_timed_interval": True,
+            "reset_outside_timing": True,
+            "cold_l2_before_every_replay": True,
+            "private_mutable_state_per_arm": True,
+            "private_output_per_arm": True,
+            "shared_immutable_inputs": True,
+            "balanced_position_schedule": True,
+            "outlier_policy": "none discarded",
+        },
+        "input_ownership": ownership,
+        "graph_capture": {
+            "graphs": len(captured),
+            "provider_invocations_per_graph": 1,
+            "graph_objects_kept_alive": all(
+                isinstance(item.graph, torch.cuda.CUDAGraph)
+                for item in captured.values()
+            ),
+        },
+        "providers": provider_metadata,
+        "source_fingerprint_before": source_before,
+        "source_fingerprint_after": source_after,
+        "environment": {
+            "helion_backend": os.environ.get("HELION_BACKEND"),
+            "helion_fast_math": os.environ.get("HELION_FAST_MATH"),
+            "helion_skip_cache": os.environ.get("HELION_SKIP_CACHE"),
+            "cute_dsl_arch": os.environ.get("CUTE_DSL_ARCH"),
+            "pythonhashseed": os.environ.get("PYTHONHASHSEED"),
+        },
+        "seed": args.seed,
+        "argv": sys.argv,
+        "gpu": gpu_info(),
+        **timing,
+    }
+
+
+def _create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--paired-cuda-graph", action="store_true")
+    parser.add_argument("--impls", default=",".join(IMPLEMENTATIONS))
+    parser.add_argument(
+        "--batch-size", type=int, choices=DEFAULT_BATCH_SIZES, required=True
+    )
+    parser.add_argument("--flashinfer-root", type=Path, required=True)
+    parser.add_argument("--flashinfer-sha", default=PINNED_FLASHINFER_SHA)
+    parser.add_argument("--sglang-root", type=Path, required=True)
+    parser.add_argument("--sglang-sha", default=PINNED_SGLANG_SHA)
+    parser.add_argument("--autotune-seed", type=int, default=1337)
+    config_group = parser.add_mutually_exclusive_group(required=True)
+    config_group.add_argument("--helion-config", help="Helion config JSON object")
+    config_group.add_argument("--helion-config-file", type=Path)
+    parser.add_argument("--graph-primer-cycles", type=int, default=2)
+    parser.add_argument("--graph-measurement-cycles", type=int, default=12)
+    parser.add_argument("--cooldown-temp-c", type=float, default=DEFAULT_COOLDOWN_C)
+    parser.add_argument("--cooldown-timeout-s", type=float, default=600.0)
+    parser.add_argument("--seed", type=int, default=20260805)
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def _validate_cli_args(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> HelionConfigSpec:
+    implementations = tuple(value.strip() for value in args.impls.split(","))
+    if implementations != IMPLEMENTATIONS:
+        parser.error(f"--impls must be exactly {','.join(IMPLEMENTATIONS)}")
+    if not args.paired_cuda_graph:
+        parser.error("--paired-cuda-graph is required; legacy timing was removed")
+    if args.graph_primer_cycles <= 0:
+        parser.error("--graph-primer-cycles must be positive")
+    if args.graph_measurement_cycles < 2 or args.graph_measurement_cycles % 2:
+        parser.error("--graph-measurement-cycles must be an even integer >= 2")
+    if args.cooldown_timeout_s <= 0:
+        parser.error("--cooldown-timeout-s must be positive")
+    if not math.isfinite(args.cooldown_temp_c):
+        parser.error("--cooldown-temp-c must be finite")
+    if (
+        args.output is not None
+        and args.helion_config_file is not None
+        and args.output.resolve() == args.helion_config_file.resolve()
+    ):
+        parser.error("--output and --helion-config-file must be different files")
+    try:
+        return _load_helion_config(args)
+    except (OSError, UnicodeError, ValueError) as error:
+        parser.error(str(error))
+
+
+def main() -> None:
+    parser = _create_parser()
+    args = parser.parse_args()
+    config_spec = _validate_cli_args(parser, args)
+    result = _run_paired_decode_graph(args, config_spec)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with args.output.open("x", encoding="utf-8") as output_file:
+            output_file.write(json.dumps(result) + "\n")
+    print("RESULT_JSON: " + json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/cute/compare_kda_prefill_backends.py
+++ b/benchmarks/cute/compare_kda_prefill_backends.py
@@ -1,0 +1,1269 @@
+"""Reproduce the two reportable KDA prefill comparisons.
+
+Each case uses its frozen exhaustive-search winner. Helion is compared with
+the public FlashInfer CAKE and CuTe-DSL routes using private one-invocation
+CUDA graphs and balanced ABBA/BAAB timing.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import functools
+import importlib
+import importlib.util
+import json
+import math
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+from types import ModuleType
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import Literal
+from typing import cast
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from benchmarks.cute import kda_benchmark_utils as benchmark_utils  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import (  # noqa: E402
+    assert_stable as _assert_stable,
+)
+from benchmarks.cute.kda_benchmark_utils import (  # noqa: E402, F401
+    file_sha256 as _sha256,
+)
+from benchmarks.cute.kda_benchmark_utils import gpu_info as _gpu_info  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import (  # noqa: E402
+    source_provenance as _source_provenance,
+)
+from benchmarks.cute.kda_prefill_kernels import KDA_PREPARE_CONFIG  # noqa: E402
+from benchmarks.cute.kda_prefill_kernels import KDA_RECURRENCE_CONFIG  # noqa: E402
+from benchmarks.cute.kda_prefill_kernels import kda_chunk_prepare  # noqa: E402
+from benchmarks.cute.kda_prefill_kernels import kda_chunk_recurrence  # noqa: E402
+from benchmarks.cute.kda_prefill_staged import create_staged_kda_resources  # noqa: E402
+from benchmarks.cute.kda_prefill_staged import launch_staged_kda_prefill  # noqa: E402
+import torch  # noqa: E402
+
+import helion  # noqa: E402
+from helion.runtime.config import Config  # noqa: E402
+
+if TYPE_CHECKING:
+    from helion.runtime.kernel import BoundKernel
+
+DEFAULT_FLASHINFER_SHA = "f67bc2ed555c1ad6a764ad68f7aa9622178e9eae"
+HEAD_DIM = 128
+SAFE_LOWER_BOUND = -5.0
+LOG2_E = math.log2(math.e)
+
+_CUTE_CHUNK_PREPARE_SCHEDULE_KEY = "cute_chunk_prepare_schedule"
+_CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY = "cute_chunk_recurrence_dv_partitions"
+_CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY = "cute_chunk_recurrence_register_cap"
+
+_BT16_PREPARE_VARIANTS = frozenset(("bt16_prepare", "bt16_prepare_beta_tma"))
+_BT16_CHAIN_VARIANTS = frozenset(
+    ("bt16_chain_m64_s7", "bt16_chain_m64_s8", "bt16_chain_m64_s9")
+)
+_BT16_COMBINED_VARIANTS = frozenset(("bt16_prepare_chain_m64_s8",))
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    num_heads: int
+    seq_lens: tuple[int, ...]
+    packed: bool
+    seed: int
+    lower_bound: float = SAFE_LOWER_BOUND
+    expected_cake_variant: str = "bt16_prepare_chain_m64"
+
+    @property
+    def total_tokens(self) -> int:
+        return sum(self.seq_lens)
+
+    @property
+    def batch_size(self) -> int:
+        return 1 if self.packed else len(self.seq_lens)
+
+    @property
+    def num_sequences(self) -> int:
+        return len(self.seq_lens)
+
+
+CASES = {
+    case.name: case
+    for case in (
+        Case("h12_fixed_512", 12, (512,), False, 12002),
+        Case("h12_packed_mixed", 12, (1300, 547, 2048, 963, 271, 3063), True, 12004),
+    )
+}
+OFFICIAL_CASES = tuple(CASES)
+IMPLEMENTATIONS = ("helion-cute", "flashinfer-cake", "flashinfer-cute")
+
+
+@dataclass(frozen=True)
+class HelionConfig:
+    topology: Literal["origin_aux", "serial"]
+    critical_prepare_schedule: str
+    auxiliary_prepare_schedule: str | None
+    recurrence_dv_partitions: int
+    recurrence_register_cap: int | None
+
+    def as_dict(self) -> dict[str, object]:
+        result: dict[str, object] = {
+            "staged_topology": self.topology,
+            "critical_prepare_schedule": self.critical_prepare_schedule,
+            "recurrence_dv_partitions": self.recurrence_dv_partitions,
+            "recurrence_register_cap": self.recurrence_register_cap,
+        }
+        if self.auxiliary_prepare_schedule is not None:
+            result["auxiliary_prepare_schedule"] = self.auxiliary_prepare_schedule
+        return result
+
+
+# Winners from the complete 25/250-candidate cold search, kept immutable here.
+PINNED_HELION_CONFIGS = {
+    "h12_fixed_512": HelionConfig("serial", "split_alias_cpc1", None, 4, None),
+    "h12_packed_mixed": HelionConfig(
+        "origin_aux", "split_alias_cpc2", "split_alias_cpc2", 2, None
+    ),
+}
+
+
+def _semantic_metadata(case: Case) -> dict[str, Any]:
+    return {
+        "case": case.name,
+        "seed": case.seed,
+        "shape": {
+            "batch_size": case.batch_size,
+            "num_sequences": case.num_sequences,
+            "total_tokens": case.total_tokens,
+            "num_heads": case.num_heads,
+            "head_dim": HEAD_DIM,
+            "seq_lens": list(case.seq_lens),
+        },
+        "layout": "packed" if case.packed else "fixed",
+        "activation_dtype": "bfloat16",
+        "canonical_state_dtype": "bfloat16",
+        "canonical_state_layout": "[sequence,head,value,key]",
+        "qk_l2norm": True,
+        "qk_l2norm_epsilon": 1.0e-24,
+        "scale": HEAD_DIM**-0.5,
+        "gate_input": "raw",
+        "gate_mode": "lower-bound-sigmoid",
+        "lower_bound": case.lower_bound,
+        "beta_input": "logit",
+        "indexed_state": False,
+        "checkpoint_every_n_tokens": 0,
+        "input_distribution": {
+            "q_k_v_raw_gate": "normal-float32-rounded-to-bfloat16",
+            "raw_beta": "normal-float32-rounded-to-bfloat16",
+            "a_log": "uniform-[0,1)-float32",
+            "dt_bias": "uniform-[0,1)-float32",
+            "initial_state": "normal-std-0.25-float32-rounded-to-bfloat16",
+        },
+        "timing": "one-call-captured-graph-cuda-events-with-cold-l2",
+        "mutation_isolation": "private-state-and-output-per-captured-graph",
+    }
+
+
+@dataclass
+class KDAInputs:
+    q: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    raw_gate: torch.Tensor
+    raw_beta: torch.Tensor
+    a_log: torch.Tensor
+    dt_bias: torch.Tensor
+    initial_state: torch.Tensor
+    cu_seqlens: torch.Tensor | None
+
+    def clone_mutable(self) -> KDAInputs:
+        return KDAInputs(
+            q=self.q,
+            k=self.k,
+            v=self.v,
+            raw_gate=self.raw_gate,
+            raw_beta=self.raw_beta,
+            a_log=self.a_log,
+            dt_bias=self.dt_bias,
+            initial_state=self.initial_state.clone(),
+            cu_seqlens=self.cu_seqlens,
+        )
+
+
+Invoke = Callable[[KDAInputs, torch.Tensor], tuple[torch.Tensor, torch.Tensor]]
+
+
+def _physical_gpu_index() -> str:
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES", "")
+    first = visible.split(",", 1)[0].strip()
+    return first or "0"
+
+
+def _gpu_field(field: str) -> float | None:
+    try:
+        output = subprocess.run(
+            (
+                "nvidia-smi",
+                "-i",
+                _physical_gpu_index(),
+                f"--query-gpu={field}",
+                "--format=csv,noheader,nounits",
+            ),
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        ).stdout.strip()
+        return float(output.splitlines()[0])
+    except (IndexError, OSError, subprocess.SubprocessError, ValueError):
+        return None
+
+
+def _wait_for_cooldown(target_c: float, timeout_s: float) -> dict[str, Any]:
+    torch.cuda.synchronize()
+    start = _gpu_field("temperature.gpu")
+    current = start
+    started = time.monotonic()
+    while current is not None and current > target_c:
+        if time.monotonic() - started >= timeout_s:
+            break
+        time.sleep(5)
+        current = _gpu_field("temperature.gpu")
+    if start is None or current is None:
+        status = "unavailable"
+    elif current > target_c:
+        status = "timeout"
+    else:
+        status = "cooled"
+    return {
+        "status": status,
+        "valid": status == "cooled",
+        "start_temp_c": start,
+        "end_temp_c": current,
+        "waited_s": round(time.monotonic() - started, 1),
+        "target_c": target_c,
+        "timeout_s": timeout_s,
+    }
+
+
+def _prepare_build_environment() -> None:
+    executable_bin = str(Path(sys.executable).resolve().parent)
+    path_parts = os.environ.get("PATH", "").split(os.pathsep)
+    if executable_bin not in path_parts:
+        os.environ["PATH"] = os.pathsep.join((executable_bin, *path_parts))
+    cuda_root = Path("/usr/local/cuda")
+    if cuda_root.is_dir():
+        os.environ.setdefault("CUDA_HOME", str(cuda_root))
+
+
+def _git_files(root: Path, pathspecs: tuple[str, ...]) -> dict[str, Path]:
+    output = subprocess.run(
+        ("git", "ls-files", "--cached", "-z", "--", *pathspecs),
+        cwd=root,
+        check=True,
+        capture_output=True,
+    ).stdout
+    return {
+        relative: root / relative
+        for relative in sorted(
+            item.decode("utf-8") for item in output.split(b"\0") if item
+        )
+    }
+
+
+def _flashinfer_sources(root: Path) -> dict[str, Path]:
+    relative_paths = (
+        "flashinfer/api_logging.py",
+        "flashinfer/kda.py",
+        "flashinfer/kda_prefill.py",
+        "flashinfer/kda_prefill_cute.py",
+        "flashinfer/utils.py",
+        "flashinfer/trace/template.py",
+        "flashinfer/trace/templates/kda.py",
+        "flashinfer/jit/_kda_jit_common.py",
+        "flashinfer/jit/cake_kda.py",
+        "flashinfer/jit/core.py",
+        "flashinfer/jit/cpp_ext.py",
+        "flashinfer/jit/flash_kda.py",
+    )
+    sources = {relative: root / relative for relative in relative_paths}
+    sources.update(
+        _git_files(
+            root,
+            ("csrc/kda", "flashinfer/cute_dsl", "flashinfer/kda_kernels"),
+        )
+    )
+    return sources
+
+
+def _install_namespace(name: str, path: Path) -> ModuleType:
+    expected_path = path.resolve()
+    existing = sys.modules.get(name)
+    if isinstance(existing, ModuleType):
+        module_path = existing.__dict__.get("__path__")
+        actual_paths = (
+            ()
+            if module_path is None
+            else tuple(Path(item).resolve() for item in module_path)
+        )
+        if actual_paths != (expected_path,):
+            raise ImportError(
+                f"preloaded namespace {name} is outside the requested checkout: "
+                f"expected={(expected_path,)}, actual={actual_paths}"
+            )
+        return existing
+    module = ModuleType(name)
+    module.__path__ = [str(expected_path)]  # type: ignore[attr-defined]
+    module.__package__ = name
+    sys.modules[name] = module
+    return module
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    expected_path = path.resolve()
+    existing = sys.modules.get(name)
+    if isinstance(existing, ModuleType):
+        actual_path = existing.__dict__.get("__file__")
+        if actual_path is None or Path(actual_path).resolve() != expected_path:
+            raise ImportError(
+                f"preloaded module {name} is outside the requested checkout: "
+                f"expected={expected_path}, actual={actual_path}"
+            )
+        return existing
+    spec = importlib.util.spec_from_file_location(name, expected_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"unable to load {name} from {expected_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _unavailable_decode(*args: object, **kwargs: object) -> object:
+    raise RuntimeError("decode-only FlashInfer function is unavailable in this loader")
+
+
+def _load_flashinfer(root: Path) -> ModuleType:
+    """Load only the source modules required by public recurrent-KDA prefill."""
+    root = root.resolve()
+    package_root = root / "flashinfer"
+    source = package_root / "kda.py"
+    if not source.is_file():
+        raise FileNotFoundError(f"not a FlashInfer source checkout: {root}")
+
+    if "pynvml" not in sys.modules and importlib.util.find_spec("pynvml") is None:
+        sys.modules["pynvml"] = ModuleType("pynvml")
+    _install_namespace("flashinfer", package_root)
+    _install_namespace("flashinfer.jit", package_root / "jit")
+    _install_namespace("flashinfer.cute_dsl", package_root / "cute_dsl")
+    _install_namespace("flashinfer.trace", package_root / "trace")
+    _install_namespace(
+        "flashinfer.trace.templates", package_root / "trace" / "templates"
+    )
+
+    # The facade imports decode/training symbols even though this benchmark only
+    # exercises prefill. Keep those optional extensions out of the process.
+    kernels = _install_namespace("flashinfer.kda_kernels", package_root / "kda_kernels")
+    kernels.run_packed_kda_decode = _unavailable_decode  # type: ignore[attr-defined]
+    kernels.run_recurrent_kda = _unavailable_decode  # type: ignore[attr-defined]
+    fused = ModuleType("flashinfer.kda_kernels.fused_kda_decode")
+    fused.run_fused_kda_decode = _unavailable_decode  # type: ignore[attr-defined]
+    sys.modules[fused.__name__] = fused
+    output_only = ModuleType("flashinfer.kda_kernels.kda_decode_wy_output_only")
+    output_only.kda_wy_output_only = _unavailable_decode  # type: ignore[attr-defined]
+    sys.modules[output_only.__name__] = output_only
+
+    backward = ModuleType("flashinfer.kda_backward")
+    backward.RecurrentKDABackwardWorkspace = type(  # type: ignore[attr-defined]
+        "RecurrentKDABackwardWorkspace", (), {}
+    )
+    backward.recurrent_kda_backward = _unavailable_decode  # type: ignore[attr-defined]
+    sys.modules[backward.__name__] = backward
+    training = ModuleType("flashinfer.kda_training")
+    training.RecurrentKDATrainingContext = type(  # type: ignore[attr-defined]
+        "RecurrentKDATrainingContext", (), {}
+    )
+    training.recurrent_kda_training_backward = _unavailable_decode  # type: ignore[attr-defined]
+    training.recurrent_kda_training_forward = _unavailable_decode  # type: ignore[attr-defined]
+    sys.modules[training.__name__] = training
+
+    importlib.import_module("flashinfer.trace.templates.kda")
+    return _load_module("flashinfer.kda", source)
+
+
+def _identity_tensor_cache(
+    fn: Callable[[torch.Tensor, int], torch.Tensor],
+) -> Callable[[torch.Tensor, int], torch.Tensor]:
+    cache: list[tuple[torch.Tensor, int, int, torch.Tensor]] = []
+
+    @functools.wraps(fn)
+    def wrapper(tensor: torch.Tensor, chunk_size: int) -> torch.Tensor:
+        version = tensor._version
+        for cached_tensor, cached_version, cached_chunk, result in cache:
+            if (
+                tensor is cached_tensor
+                and version == cached_version
+                and chunk_size == cached_chunk
+            ):
+                return result
+        result = fn(tensor, chunk_size)
+        cache.append((tensor, version, chunk_size, result))
+        del cache[:-4]
+        return result
+
+    return wrapper
+
+
+@_identity_tensor_cache
+def _prepare_chunk_indices(cu_seqlens: torch.Tensor, chunk_size: int) -> torch.Tensor:
+    lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+    chunk_counts = torch.div(
+        lengths + chunk_size - 1, chunk_size, rounding_mode="floor"
+    )
+    local_chunks = torch.cat(
+        [
+            torch.arange(int(count), device=cu_seqlens.device)
+            for count in chunk_counts.tolist()
+        ]
+    )
+    sequence = torch.repeat_interleave(
+        torch.arange(chunk_counts.numel(), device=cu_seqlens.device), chunk_counts
+    )
+    return torch.stack((sequence, local_chunks), dim=1).to(cu_seqlens)
+
+
+@_identity_tensor_cache
+def _prepare_chunk_offsets(cu_seqlens: torch.Tensor, chunk_size: int) -> torch.Tensor:
+    lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+    chunk_counts = torch.div(
+        lengths + chunk_size - 1, chunk_size, rounding_mode="floor"
+    )
+    return torch.cat((cu_seqlens.new_zeros(1), chunk_counts)).cumsum(0)
+
+
+def _make_inputs(case: Case) -> KDAInputs:
+    generator = torch.Generator(device="cuda").manual_seed(case.seed)
+    shape = (
+        case.batch_size,
+        case.total_tokens // case.batch_size,
+        case.num_heads,
+        HEAD_DIM,
+    )
+
+    def random_bf16(tensor_shape: tuple[int, ...]) -> torch.Tensor:
+        return torch.randn(
+            tensor_shape,
+            generator=generator,
+            dtype=torch.float32,
+            device="cuda",
+        ).to(torch.bfloat16)
+
+    q = random_bf16(shape)
+    k = random_bf16(shape)
+    v = random_bf16(shape)
+    raw_gate = random_bf16(shape)
+    raw_beta = random_bf16(shape[:-1])
+    a_log = torch.rand(
+        case.num_heads,
+        generator=generator,
+        dtype=torch.float32,
+        device="cuda",
+    )
+    dt_bias = torch.rand(
+        case.num_heads,
+        HEAD_DIM,
+        generator=generator,
+        dtype=torch.float32,
+        device="cuda",
+    )
+    initial_state = (
+        torch.randn(
+            case.num_sequences,
+            case.num_heads,
+            HEAD_DIM,
+            HEAD_DIM,
+            generator=generator,
+            dtype=torch.float32,
+            device="cuda",
+        )
+        * 0.25
+    ).to(torch.bfloat16)
+    if case.packed:
+        offsets = [0]
+        for length in case.seq_lens:
+            offsets.append(offsets[-1] + length)
+        cu_seqlens = torch.tensor(offsets, dtype=torch.int64, device="cuda")
+    else:
+        cu_seqlens = None
+    return KDAInputs(
+        q=q,
+        k=k,
+        v=v,
+        raw_gate=raw_gate,
+        raw_beta=raw_beta,
+        a_log=a_log,
+        dt_bias=dt_bias,
+        initial_state=initial_state,
+        cu_seqlens=cu_seqlens,
+    )
+
+
+def _invoke_flashinfer(
+    module: ModuleType,
+    case: Case,
+    backend: str,
+    *,
+    prefill_workspace: object | None = None,
+) -> Invoke:
+    if backend not in ("cake", "cute-dsl"):
+        raise ValueError(f"unsupported FlashInfer backend: {backend}")
+
+    def invoke(
+        inputs: KDAInputs, output: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        kwargs: dict[str, Any] = {
+            "q": inputs.q,
+            "k": inputs.k,
+            "v": inputs.v,
+            "g": inputs.raw_gate,
+            "beta": inputs.raw_beta,
+            "A_log": inputs.a_log,
+            "dt_bias": inputs.dt_bias,
+            "scale": HEAD_DIM**-0.5,
+            "initial_state": inputs.initial_state,
+            "output_final_state": False,
+            "use_qk_l2norm_in_kernel": True,
+            "use_gate_in_kernel": True,
+            "lower_bound": case.lower_bound,
+            "cu_seqlens": inputs.cu_seqlens,
+            "ssm_state_indices": None,
+            "output": output,
+            "beta_is_logit": True,
+            "state_checkpoints": None,
+            "checkpoint_cu_starts": None,
+            "checkpoint_every_n_tokens": 0,
+            "backend": backend,
+        }
+        if prefill_workspace is not None:
+            kwargs["prefill_workspace"] = prefill_workspace
+        result = module.recurrent_kda(**kwargs)
+        if not isinstance(result, tuple) or len(result) != 2:
+            raise AssertionError(
+                f"unexpected recurrent_kda result: {type(result).__name__}"
+            )
+        return result[0], inputs.initial_state
+
+    return invoke
+
+
+def _resolve_safe_gate_modules(
+    modules: list[dict[str, str]],
+) -> tuple[str, str, list[str]]:
+    """Validate one physical safe-gate CAKE dispatch observation."""
+    routes = [(item["variant"], item["target"]) for item in modules]
+    if len(routes) == 1:
+        variant, target = routes[0]
+        if variant in _BT16_COMBINED_VARIANTS:
+            return "bt16_prepare_chain_m64", target, [variant]
+    elif len(routes) == 2:
+        (prepare_variant, prepare_target), (chain_variant, chain_target) = routes
+        if (
+            prepare_variant in _BT16_PREPARE_VARIANTS
+            and chain_variant in _BT16_CHAIN_VARIANTS
+            and prepare_target == chain_target
+        ):
+            return (
+                "bt16_prepare_chain_m64",
+                prepare_target,
+                [prepare_variant, chain_variant],
+            )
+    raise AssertionError(
+        "expected one combined safe-gate CAKE module or one ordered BT16 "
+        f"prepare/chain pair, got {routes}"
+    )
+
+
+def _record_flashinfer_route(
+    module: ModuleType,
+    invoke: Invoke,
+    metadata: dict[str, Any],
+    *,
+    case: Case,
+    expected_route: str,
+) -> Invoke:
+    """Record and validate the public CAKE or CuTe route on first invocation."""
+    if expected_route not in ("cake-safe-gate", "cute-dsl"):
+        raise ValueError(f"unsupported prefill route: {expected_route}")
+    recorded = False
+
+    def recording_invoke(
+        inputs: KDAInputs, output: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        nonlocal recorded
+        if recorded:
+            return invoke(inputs, output)
+
+        prefill_module = module._kda_prefill
+        cute_module = module._kda_prefill_cute
+        original_get_flash_module = prefill_module._get_flash_kda_prefill_module
+        original_cute_run = cute_module._run_cute_dsl_kda_prefill
+        cake_modules: list[dict[str, str]] = []
+        cute_dispatches = 0
+
+        def recording_get_flash_module(variant: str, target: str) -> object:
+            cake_modules.append({"variant": variant, "target": target})
+            return original_get_flash_module(variant, target)
+
+        def recording_cute_run(**kwargs: object) -> object:
+            nonlocal cute_dispatches
+            cute_dispatches += 1
+            return original_cute_run(**kwargs)
+
+        prefill_module._get_flash_kda_prefill_module = recording_get_flash_module
+        cute_module._run_cute_dsl_kda_prefill = recording_cute_run
+        try:
+            result = invoke(inputs, output)
+        finally:
+            prefill_module._get_flash_kda_prefill_module = original_get_flash_module
+            cute_module._run_cute_dsl_kda_prefill = original_cute_run
+
+        if cute_dispatches:
+            if cute_dispatches != 1 or cake_modules:
+                raise AssertionError(
+                    "CuTe route must dispatch exactly once without loading CAKE"
+                )
+            sm_count = torch.cuda.get_device_properties(
+                inputs.q.device
+            ).multi_processor_count
+            variant = (
+                "decomp"
+                if case.num_sequences * case.num_heads * 2 <= sm_count
+                else "engine"
+            )
+            resolved_route = f"cute-dsl-{variant}"
+            metadata["cute_variant"] = variant
+        elif cake_modules:
+            logical_variant, target, physical_variants = _resolve_safe_gate_modules(
+                cake_modules
+            )
+            if logical_variant != case.expected_cake_variant:
+                raise AssertionError(
+                    f"expected CAKE variant {case.expected_cake_variant}, "
+                    f"got {logical_variant}"
+                )
+            expected_target = prefill_module._select_flash_kda_prefill_target(
+                inputs.q.device
+            )
+            if target != expected_target:
+                raise AssertionError(
+                    f"expected CAKE target {expected_target}, got {target}"
+                )
+            resolved_route = "cake-safe-gate"
+            metadata.update(
+                {
+                    "cake_logical_variant": logical_variant,
+                    "cake_target": target,
+                    "cake_physical_variants": physical_variants,
+                }
+            )
+        else:
+            raise AssertionError("no FlashInfer prefill route was observed")
+
+        if not (
+            resolved_route.startswith("cute-dsl-")
+            if expected_route == "cute-dsl"
+            else resolved_route == expected_route
+        ):
+            raise AssertionError(
+                f"expected FlashInfer route {expected_route}, got {resolved_route}"
+            )
+        metadata.update(
+            {
+                "requested_route": expected_route,
+                "resolved_route": resolved_route,
+                "physical_modules": cake_modules,
+                "cute_dispatches": cute_dispatches,
+                "indexed_state": False,
+            }
+        )
+        recorded = True
+        return result
+
+    return recording_invoke
+
+
+def _check_result(
+    actual: tuple[torch.Tensor, torch.Tensor],
+    expected: tuple[torch.Tensor, torch.Tensor],
+) -> dict[str, float]:
+    actual_output, actual_state = actual
+    expected_output, expected_state = expected
+    torch.cuda.synchronize()
+    output_difference = (actual_output.float() - expected_output.float()).abs()
+    state_difference = (actual_state.float() - expected_state.float()).abs()
+    output_max_abs = float(output_difference.max())
+    state_max_abs = float(state_difference.max())
+    output_rms = float(output_difference.square().mean().sqrt())
+    state_rms = float(state_difference.square().mean().sqrt())
+    torch.testing.assert_close(
+        actual_output.float(), expected_output.float(), atol=2e-2, rtol=1e-2
+    )
+    torch.testing.assert_close(
+        actual_state.float(), expected_state.float(), atol=2e-2, rtol=1e-2
+    )
+    return {
+        "output_max_abs": output_max_abs,
+        "state_max_abs": state_max_abs,
+        "output_rms": output_rms,
+        "state_rms": state_rms,
+    }
+
+
+@dataclass(frozen=True)
+class _GeneratedRoute:
+    role: str
+    phase: str
+    bound: BoundKernel[object]
+    config: Config
+    compiled: object
+    plan_kind: str
+    source_marker: str
+    source_pattern: str
+
+    def verify(self) -> dict[str, Any]:
+        return {
+            "role": self.role,
+            "phase": self.phase,
+            "config": dict(self.config.config),
+            **benchmark_utils.verify_helion_generated_wrapper(
+                self.bound,
+                self.config,
+                expected_plan_kind=self.plan_kind,
+                expected_source_markers=(self.source_marker,),
+                expected_source_patterns=(self.source_pattern,),
+                compiled_fn=self.compiled,
+            ),
+        }
+
+
+@dataclass
+class _BenchmarkArm:
+    name: str
+    inputs: KDAInputs
+    output: torch.Tensor
+    pristine_state: torch.Tensor
+    launch: Callable[[], object]
+    owners: tuple[object, ...]
+    route: dict[str, Any]
+    generated_routes: tuple[_GeneratedRoute, ...] = ()
+
+    def reset(self) -> None:
+        self.inputs.initial_state.copy_(self.pristine_state)
+        self.output.zero_()
+
+    def result(self) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.output, self.inputs.initial_state
+
+    def paired(self) -> benchmark_utils.PairedGraphArm:
+        return benchmark_utils.PairedGraphArm(self.name, self.launch, self.reset)
+
+    def verify_generated_routes(self) -> list[dict[str, Any]]:
+        return [route.verify() for route in self.generated_routes]
+
+
+def _case_offsets(case: Case) -> tuple[int, ...]:
+    offsets = [0]
+    for length in case.seq_lens:
+        offsets.append(offsets[-1] + length)
+    return tuple(offsets)
+
+
+def _component_config(base: Config, overrides: dict[str, object]) -> Config:
+    values = dict(base.config)
+    values.update(overrides)
+    return Config.from_dict(values)
+
+
+def _require_matched_choice(
+    choices: tuple[object, ...] | None,
+    selected: object,
+    *,
+    phase: str,
+    role: str,
+) -> None:
+    if choices is None or selected not in choices:
+        raise RuntimeError(
+            f"pinned {phase} choice {selected!r} did not match {role}: {choices}"
+        )
+
+
+def _build_helion_arm(case: Case, inputs: KDAInputs) -> _BenchmarkArm:
+    config = PINNED_HELION_CONFIGS[case.name]
+    if (
+        config.recurrence_dv_partitions == 2
+        and config.recurrence_register_cap is not None
+    ):
+        raise ValueError("the pinned DV2 recurrence must be uncapped")
+    resources = create_staged_kda_resources(
+        _case_offsets(case), heads=case.num_heads, device=inputs.q.device
+    )
+    groups = (resources.critical, *resources.auxiliary)
+    if (config.auxiliary_prepare_schedule is None) != (len(groups) == 1):
+        raise ValueError("pinned auxiliary schedule does not match staged groups")
+
+    call_inputs = inputs.clone_mutable()
+    output = torch.empty_like(inputs.v)
+    prepare_kernels: list[Callable[..., object]] = []
+    recurrence_kernels: list[Callable[..., object]] = []
+    generated_routes: list[_GeneratedRoute] = []
+    for index, group in enumerate(groups):
+        role = "critical" if index == 0 else f"auxiliary-{index - 1}"
+        metadata = group.metadata
+        workspace = group.workspace
+        sequence_begin, sequence_end = metadata.host.sequence_range
+        prepare_bound = cast(
+            "BoundKernel[object]",
+            kda_chunk_prepare.bind(
+                (
+                    call_inputs.q,
+                    call_inputs.k,
+                    call_inputs.raw_gate,
+                    call_inputs.raw_beta,
+                    call_inputs.a_log,
+                    call_inputs.dt_bias,
+                    metadata.cu_seqlens,
+                    metadata.cu_chunks,
+                    metadata.chunk_to_seq,
+                    workspace.kd,
+                    workspace.qd,
+                    workspace.ak,
+                    workspace.aq,
+                    workspace.g_total,
+                    None,
+                    case.lower_bound * LOG2_E,
+                )
+            ),
+        )
+        recurrence_bound = cast(
+            "BoundKernel[object]",
+            kda_chunk_recurrence.bind(
+                (
+                    workspace.kd,
+                    workspace.qd,
+                    workspace.ak,
+                    workspace.aq,
+                    workspace.g_total,
+                    call_inputs.v,
+                    output,
+                    call_inputs.initial_state[sequence_begin:sequence_end],
+                    metadata.cu_seqlens,
+                    metadata.cu_chunks,
+                    HEAD_DIM**-0.5,
+                )
+            ),
+        )
+        schedule = (
+            config.critical_prepare_schedule
+            if index == 0
+            else cast("str", config.auxiliary_prepare_schedule)
+        )
+        prepare_fragment = cast(
+            "Any", prepare_bound.config_spec
+        ).cute_chunk_prepare_schedule
+        recurrence_dv_fragment = cast(
+            "Any", recurrence_bound.config_spec
+        ).cute_chunk_recurrence_dv_partitions
+        recurrence_cap_fragment = cast(
+            "Any", recurrence_bound.config_spec
+        ).cute_chunk_recurrence_register_cap
+        _require_matched_choice(
+            None if prepare_fragment is None else prepare_fragment.choices,
+            schedule,
+            phase="prepare",
+            role=role,
+        )
+        _require_matched_choice(
+            None if recurrence_dv_fragment is None else recurrence_dv_fragment.choices,
+            config.recurrence_dv_partitions,
+            phase="recurrence DV partition",
+            role=role,
+        )
+        _require_matched_choice(
+            None
+            if recurrence_cap_fragment is None
+            else recurrence_cap_fragment.choices,
+            config.recurrence_register_cap,
+            phase="recurrence register cap",
+            role=role,
+        )
+
+        prepare_config = _component_config(
+            KDA_PREPARE_CONFIG, {_CUTE_CHUNK_PREPARE_SCHEDULE_KEY: schedule}
+        )
+        recurrence_config = _component_config(
+            KDA_RECURRENCE_CONFIG,
+            {
+                _CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY: (
+                    config.recurrence_dv_partitions
+                ),
+                _CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY: (
+                    config.recurrence_register_cap
+                ),
+            },
+        )
+        prepare_kernel = cast(
+            "Callable[..., object]",
+            prepare_bound.compile_config(prepare_config, allow_print=False),
+        )
+        recurrence_kernel = cast(
+            "Callable[..., object]",
+            recurrence_bound.compile_config(recurrence_config, allow_print=False),
+        )
+        prepare_kernels.append(prepare_kernel)
+        recurrence_kernels.append(recurrence_kernel)
+        generated_routes.append(
+            _GeneratedRoute(
+                role,
+                "prepare",
+                prepare_bound,
+                prepare_config,
+                prepare_kernel,
+                "chunk_prepare_tma",
+                "from helion._compiler.cute.chunk_prepare_split_alias_device "
+                "import emit_bt16_prepare",
+                rf".*'kind': 'chunk_prepare_tma'.*'schedule': '{schedule}'.*",
+            )
+        )
+        if config.recurrence_dv_partitions == 2:
+            recurrence_kind = "chunk_recurrence_sm100"
+            recurrence_marker = (
+                "from helion._compiler.cute.chunk_recurrence_sm100 import "
+                "host_chain_dv2 as _helion_sm100_chain_host"
+            )
+        else:
+            recurrence_kind = "chunk_recurrence_warp_dv4"
+            recurrence_marker = (
+                "from helion._compiler.cute.chunk_recurrence_dv4_sm100 import "
+                "_recurrence_entry as _helion_sm100_warp_dv4_host"
+            )
+        generated_routes.append(
+            _GeneratedRoute(
+                role,
+                "recurrence",
+                recurrence_bound,
+                recurrence_config,
+                recurrence_kernel,
+                recurrence_kind,
+                recurrence_marker,
+                rf".*'kind': '{recurrence_kind}'.*",
+            )
+        )
+
+    prepare_tuple = tuple(prepare_kernels)
+    recurrence_tuple = tuple(recurrence_kernels)
+
+    def launch() -> tuple[torch.Tensor, torch.Tensor]:
+        return launch_staged_kda_prefill(
+            resources,
+            q=call_inputs.q,
+            k=call_inputs.k,
+            gate=call_inputs.raw_gate,
+            beta_logits=call_inputs.raw_beta,
+            a_log=call_inputs.a_log,
+            dt_bias=call_inputs.dt_bias,
+            values=call_inputs.v,
+            output=output,
+            state=call_inputs.initial_state,
+            scale=HEAD_DIM**-0.5,
+            gate_scale_log2=case.lower_bound * LOG2_E,
+            topology=config.topology,
+            prepare_kernels=prepare_tuple,
+            recurrence_kernels=recurrence_tuple,
+        )
+
+    return _BenchmarkArm(
+        "helion-cute",
+        call_inputs,
+        output,
+        inputs.initial_state,
+        launch,
+        (resources, prepare_tuple, recurrence_tuple),
+        {"backend": "helion-cute", "config": config.as_dict()},
+        tuple(generated_routes),
+    )
+
+
+def _build_flashinfer_arm(
+    module: ModuleType,
+    case: Case,
+    inputs: KDAInputs,
+    backend: Literal["cake", "cute-dsl"],
+) -> _BenchmarkArm:
+    name = "flashinfer-cake" if backend == "cake" else "flashinfer-cute"
+    call_inputs = inputs.clone_mutable()
+    output = torch.empty_like(inputs.v)
+    workspace = module._kda_prefill.RecurrentKDAPrefillWorkspace(inputs.q.device)
+    route: dict[str, Any] = {
+        "backend": backend,
+        "public_entrypoint": "flashinfer.recurrent_kda",
+        "prefill_workspace": "private",
+    }
+    invoke = _record_flashinfer_route(
+        module,
+        _invoke_flashinfer(module, case, backend, prefill_workspace=workspace),
+        route,
+        case=case,
+        expected_route="cake-safe-gate" if backend == "cake" else "cute-dsl",
+    )
+
+    def launch() -> tuple[torch.Tensor, torch.Tensor]:
+        return invoke(call_inputs, output)
+
+    return _BenchmarkArm(
+        name,
+        call_inputs,
+        output,
+        inputs.initial_state,
+        launch,
+        (workspace,),
+        route,
+    )
+
+
+def _run_eager(arm: _BenchmarkArm) -> tuple[torch.Tensor, torch.Tensor]:
+    arm.reset()
+    arm.launch()
+    torch.cuda.synchronize()
+    output, state = arm.result()
+    return output.clone(), state.clone()
+
+
+def _run_pair(
+    module: ModuleType,
+    case: Case,
+    inputs: KDAInputs,
+    reference: tuple[torch.Tensor, torch.Tensor],
+    backend: Literal["cake", "cute-dsl"],
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    helion_arm = _build_helion_arm(case, inputs)
+    baseline_arm = _build_flashinfer_arm(module, case, inputs, backend)
+    generated_before = helion_arm.verify_generated_routes()
+    stream = torch.cuda.Stream()
+    arms = (baseline_arm.paired(), helion_arm.paired())
+    captured = benchmark_utils.capture_paired_cuda_graphs(arms, stream)
+
+    graph_correctness: dict[str, Any] = {}
+    for arm in (baseline_arm, helion_arm):
+        with torch.cuda.stream(stream):
+            arm.reset()
+            captured[arm.name].graph.replay()
+        stream.synchronize()
+        graph_correctness[arm.name] = {
+            "passes": True,
+            **_check_result(arm.result(), reference),
+        }
+
+    timing = benchmark_utils.measure_paired_cuda_graphs(
+        captured,
+        baseline=baseline_arm.name,
+        candidate=helion_arm.name,
+        measurement_cycles=args.graph_measurement_cycles,
+        primer_cycles=args.graph_primer_cycles,
+        cooldown_temp_c=args.cooldown_temp_c,
+        cooldown_timeout_s=args.cooldown_timeout_s,
+        stream=stream,
+    )
+    generated_after = helion_arm.verify_generated_routes()
+    _assert_stable(
+        f"{case.name} Helion generated routes during {baseline_arm.name} timing",
+        generated_before,
+        generated_after,
+    )
+    return {
+        "baseline": baseline_arm.name,
+        "candidate": helion_arm.name,
+        "correctness": graph_correctness,
+        "providers": {
+            baseline_arm.name: baseline_arm.route,
+            helion_arm.name: {
+                **helion_arm.route,
+                "generated_routes": generated_after,
+            },
+        },
+        "fairness_audit": {
+            "same_process": True,
+            "same_cuda_stream": True,
+            "same_cuda_event_timer": True,
+            "one_provider_invocation_per_graph": True,
+            "one_graph_replay_per_timed_interval": True,
+            "reset_outside_timing": True,
+            "cold_l2_before_every_replay": True,
+            "private_mutable_state_per_arm": True,
+            "private_output_per_arm": True,
+            "shared_immutable_inputs": True,
+            "balanced_position_schedule": True,
+            "outlier_policy": "none discarded",
+        },
+        **timing,
+    }
+
+
+def _source_fingerprint(args: argparse.Namespace) -> dict[str, Any]:
+    if helion.__file__ is None:
+        raise RuntimeError("loaded Helion package has no source path")
+    local_sources = {
+        "benchmark": Path(__file__).resolve(),
+        "paired_graph_helper": Path(benchmark_utils.__file__).resolve(),
+        "prefill_kernels": Path(kda_chunk_prepare.fn.__code__.co_filename).resolve(),
+        "staged_pipeline": Path(
+            launch_staged_kda_prefill.__code__.co_filename
+        ).resolve(),
+        "helion_package": Path(helion.__file__).resolve(),
+    }
+    flashinfer_root = args.flashinfer_root.resolve()
+    return {
+        "local": _source_provenance(
+            REPO_ROOT,
+            local_sources,
+            pathspecs=(
+                "helion",
+                "benchmarks/cute/compare_kda_prefill_backends.py",
+                "benchmarks/cute/kda_benchmark_utils.py",
+                "benchmarks/cute/kda_prefill_kernels.py",
+                "benchmarks/cute/kda_prefill_staged.py",
+            ),
+        ),
+        "flashinfer": _source_provenance(
+            flashinfer_root,
+            _flashinfer_sources(flashinfer_root),
+            expected_commit=args.flashinfer_sha,
+        ),
+    }
+
+
+def _run_case(
+    module: ModuleType, case: Case, args: argparse.Namespace
+) -> dict[str, Any]:
+    inputs = _make_inputs(case)
+    cake_oracle = _build_flashinfer_arm(module, case, inputs, "cake")
+    reference = _run_eager(cake_oracle)
+    eager_helion = _build_helion_arm(case, inputs)
+    eager_cute = _build_flashinfer_arm(module, case, inputs, "cute-dsl")
+    eager_correctness = {
+        "helion-cute": {
+            "passes": True,
+            **_check_result(_run_eager(eager_helion), reference),
+        },
+        "flashinfer-cute": {
+            "passes": True,
+            **_check_result(_run_eager(eager_cute), reference),
+        },
+    }
+    eager_routes = {
+        "flashinfer-cake": cake_oracle.route,
+        "flashinfer-cute": eager_cute.route,
+        "helion-cute": {
+            **eager_helion.route,
+            "generated_routes": eager_helion.verify_generated_routes(),
+        },
+    }
+    comparisons = {
+        "flashinfer-cake": _run_pair(module, case, inputs, reference, "cake", args),
+        "flashinfer-cute": _run_pair(module, case, inputs, reference, "cute-dsl", args),
+    }
+    return {
+        "case": case.name,
+        "semantic_metadata": _semantic_metadata(case),
+        "pinned_helion_config": PINNED_HELION_CONFIGS[case.name].as_dict(),
+        "eager_correctness": eager_correctness,
+        "eager_routes": eager_routes,
+        "comparisons": comparisons,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--paired-cuda-graph", action="store_true")
+    parser.add_argument("--impls", default=",".join(IMPLEMENTATIONS))
+    parser.add_argument("--cases", default=",".join(OFFICIAL_CASES))
+    parser.add_argument("--flashinfer-root", type=Path, required=True)
+    parser.add_argument("--flashinfer-sha", default=DEFAULT_FLASHINFER_SHA)
+    parser.add_argument("--graph-primer-cycles", type=int, default=2)
+    parser.add_argument("--graph-measurement-cycles", type=int, default=12)
+    parser.add_argument(
+        "--cooldown-temp-c", type=float, default=benchmark_utils.DEFAULT_COOLDOWN_C
+    )
+    parser.add_argument("--cooldown-timeout-s", type=float, default=600.0)
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def _validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    implementations = tuple(value.strip() for value in args.impls.split(","))
+    if implementations != IMPLEMENTATIONS:
+        parser.error(f"--impls must be exactly {','.join(IMPLEMENTATIONS)}")
+    cases = tuple(value.strip() for value in args.cases.split(","))
+    if cases != OFFICIAL_CASES:
+        parser.error(f"--cases must be exactly {','.join(OFFICIAL_CASES)}")
+    if not args.paired_cuda_graph:
+        parser.error("--paired-cuda-graph is required")
+    if args.graph_primer_cycles < 1:
+        parser.error("--graph-primer-cycles must be positive")
+    if args.graph_measurement_cycles < 2 or args.graph_measurement_cycles % 2:
+        parser.error("--graph-measurement-cycles must be an even integer >= 2")
+    if args.cooldown_timeout_s <= 0:
+        parser.error("--cooldown-timeout-s must be positive")
+    if not math.isfinite(args.cooldown_temp_c):
+        parser.error("--cooldown-temp-c must be finite")
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+    _validate_args(parser, args)
+    if os.environ.get("HELION_BACKEND") != "cute":
+        parser.error("HELION_BACKEND=cute is required")
+    if not torch.cuda.is_available():
+        parser.error("CUDA is required")
+    _prepare_build_environment()
+    source_before = _source_fingerprint(args)
+    benchmark_utils.validate_pinned_source("FlashInfer", source_before["flashinfer"])
+    module = _load_flashinfer(args.flashinfer_root)
+    cases = {name: _run_case(module, CASES[name], args) for name in OFFICIAL_CASES}
+    source_after = _source_fingerprint(args)
+    _assert_stable(
+        "source fingerprint during prefill benchmark", source_before, source_after
+    )
+    result = {
+        "valid": True,
+        "cases": cases,
+        "implementations_order": list(IMPLEMENTATIONS),
+        "source_fingerprint_before": source_before,
+        "source_fingerprint_after": source_after,
+        "environment": {
+            "helion_backend": os.environ.get("HELION_BACKEND"),
+            "helion_fast_math": os.environ.get("HELION_FAST_MATH"),
+            "helion_skip_cache": os.environ.get("HELION_SKIP_CACHE"),
+            "cute_dsl_arch": os.environ.get("CUTE_DSL_ARCH"),
+            "pythonhashseed": os.environ.get("PYTHONHASHSEED"),
+        },
+        "gpu": _gpu_info(),
+        "argv": sys.argv,
+    }
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with args.output.open("x", encoding="utf-8") as output:
+            output.write(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    print("RESULT_JSON: " + json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/cute/compare_kda_recurrent_backends.py
+++ b/benchmarks/cute/compare_kda_recurrent_backends.py
@@ -1,0 +1,1096 @@
+"""Reproduce the reportable recurrent KDA decode comparisons.
+
+The two scoped rows are T1 unbounded-softplus (N=15, H=32) and T3 bounded
+speculative decode (N=8, H=16). FlashInfer CuTe DSL and Helion CuTe each get a
+private one-invocation CUDA graph. State restoration and cold-L2 flushing are
+outside the timed interval, and samples alternate in balanced ABBA/BAAB order.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import functools
+import importlib
+import importlib.util
+import json
+import math
+import os
+from pathlib import Path
+import sys
+from types import ModuleType
+from typing import Any
+from typing import Callable
+from typing import cast
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from benchmarks.cute.kda_benchmark_utils import DEFAULT_COOLDOWN_C  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import PairedGraphArm  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import assert_stable  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import canonical_config_json  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import capture_paired_cuda_graphs  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import file_sha256  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import gpu_info  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import measure_paired_cuda_graphs  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import parse_json_object  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import source_provenance  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import text_sha256  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import validate_pinned_source  # noqa: E402
+from benchmarks.cute.kda_benchmark_utils import (  # noqa: E402
+    verify_helion_generated_wrapper,
+)
+import torch  # noqa: E402
+
+import helion  # noqa: E402
+import helion.language as hl  # noqa: E402
+
+HEAD_DIM = 128
+L2_EPSILON = 1e-6
+LOG2_E = 1.4426950408889634
+LOWER_BOUND = -5.0
+IMPLEMENTATIONS = ("flashinfer-cute", "helion-cute")
+DEFAULT_CASES = (
+    "t1-unbounded-b15-h32",
+    "t3-lower-bound-n8-h16",
+)
+PINNED_FLASHINFER_SHA = "f67bc2ed555c1ad6a764ad68f7aa9622178e9eae"
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    num_sequences: int
+    num_tokens: int
+    num_heads: int
+    lower_bound: float | None
+    beta_is_logit: bool
+
+    @property
+    def total_tokens(self) -> int:
+        return self.num_sequences * self.num_tokens
+
+    @property
+    def gate_mode(self) -> str:
+        return "unbounded-softplus" if self.lower_bound is None else "lower-bound"
+
+
+CASES = {
+    "t1-unbounded-b15-h32": Case(
+        name="t1-unbounded-b15-h32",
+        num_sequences=15,
+        num_tokens=1,
+        num_heads=32,
+        lower_bound=None,
+        beta_is_logit=True,
+    ),
+    "t3-lower-bound-n8-h16": Case(
+        name="t3-lower-bound-n8-h16",
+        num_sequences=8,
+        num_tokens=3,
+        num_heads=16,
+        lower_bound=LOWER_BOUND,
+        beta_is_logit=False,
+    ),
+}
+
+
+@dataclass
+class RecurrentInputs:
+    q: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    gate: torch.Tensor
+    beta: torch.Tensor
+    a_log: torch.Tensor
+    dt_bias: torch.Tensor
+    state: torch.Tensor
+    state_indices: torch.Tensor
+    cu_seqlens: torch.Tensor
+    num_accepted_tokens: torch.Tensor
+    output: torch.Tensor
+
+    def clone_mutable(self) -> RecurrentInputs:
+        return RecurrentInputs(
+            q=self.q,
+            k=self.k,
+            v=self.v,
+            gate=self.gate,
+            beta=self.beta,
+            a_log=self.a_log,
+            dt_bias=self.dt_bias,
+            state=self.state.clone(),
+            state_indices=self.state_indices,
+            cu_seqlens=self.cu_seqlens,
+            num_accepted_tokens=self.num_accepted_tokens,
+            output=torch.empty_like(self.output),
+        )
+
+    def helion_args(self, case: Case) -> tuple[object, ...]:
+        return (
+            self.q,
+            self.k,
+            self.v,
+            self.gate,
+            self.beta,
+            self.a_log,
+            self.dt_bias,
+            self.state,
+            self.state_indices,
+            self.num_accepted_tokens,
+            self.output,
+            HEAD_DIM**-0.5,
+            0.0 if case.lower_bound is None else case.lower_bound,
+            case.num_tokens,
+            True,
+            case.lower_bound is not None,
+            case.beta_is_logit,
+        )
+
+
+def _helion_recurrent_kda_body(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_gate: torch.Tensor,
+    beta: torch.Tensor,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_pool: torch.Tensor,
+    state_indices: torch.Tensor,
+    num_accepted_tokens: torch.Tensor,
+    output: torch.Tensor,
+    scale: float,
+    lower_bound: float,
+    num_tokens: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+    use_gate_in_kernel: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+    use_lower_bound: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+    beta_is_logit: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+) -> torch.Tensor:
+    """One-launch fixed-T KDA recurrence over split input tensors."""
+
+    num_sequences = hl.specialize(state_indices.size(0))
+    num_heads = hl.specialize(q.size(1))
+    num_value_heads = hl.specialize(v.size(1))
+    value_heads_per_query_head = num_value_heads // num_heads
+    head_dim = hl.specialize(q.size(2))
+    value_dim = hl.specialize(v.size(2))
+    hl.specialize(
+        (
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            k.stride(0),
+            k.stride(1),
+            k.stride(2),
+            v.stride(0),
+            v.stride(1),
+            v.stride(2),
+            raw_gate.stride(0),
+            raw_gate.stride(1),
+            raw_gate.stride(2),
+            beta.stride(0),
+            beta.stride(1),
+            state_pool.stride(0),
+            state_pool.stride(1),
+            state_pool.stride(2),
+            state_pool.stride(3),
+            state_indices.stride(0),
+            state_indices.stride(1),
+            num_accepted_tokens.stride(0),
+            output.stride(0),
+            output.stride(1),
+            output.stride(2),
+        )
+    )
+
+    for tile_n, tile_h, tile_v in hl.tile(
+        [num_sequences, num_value_heads, value_dim], block_size=[1, 1, None]
+    ):
+        i_n = tile_n.id
+        i_hv = tile_h.id
+        i_h = i_hv // value_heads_per_query_head
+        k_offsets = hl.arange(head_dim)
+        accepted_index = torch.clamp(
+            num_accepted_tokens[i_n].long() - 1,
+            min=0,
+            max=num_tokens - 1,  # pyrefly: ignore[unsupported-operation]
+        )
+        initial_slot = state_indices[i_n, accepted_index].long()
+        state = state_pool[initial_slot, i_hv, tile_v.index, k_offsets].float()
+
+        for i_t in hl.static_range(num_tokens):  # pyrefly: ignore[bad-argument-type]
+            token = i_n * num_tokens + i_t  # pyrefly: ignore[unsupported-operation]
+            q_vec = q[token, i_h, k_offsets].float()
+            k_vec = k[token, i_h, k_offsets].float()
+            q_vec = q_vec * torch.rsqrt((q_vec * q_vec).sum() + L2_EPSILON)
+            k_vec = k_vec * torch.rsqrt((k_vec * k_vec).sum() + L2_EPSILON)
+
+            gate_input = raw_gate[token, i_hv, k_offsets].float()
+            if use_gate_in_kernel:
+                gate_input = gate_input + dt_bias[i_h * head_dim + k_offsets].float()
+                decay_parameter = torch.exp2(a_log[i_h].float() * LOG2_E)
+                if use_lower_bound:
+                    log_decay = lower_bound * torch.sigmoid(
+                        decay_parameter * gate_input
+                    )
+                else:
+                    gate_exp = torch.exp2(gate_input * LOG2_E)
+                    softplus = torch.where(
+                        gate_input <= 20.0,
+                        torch.log(1.0 + gate_exp),
+                        gate_input,
+                    )
+                    log_decay = -decay_parameter * softplus
+            else:
+                log_decay = gate_input
+            state = state * torch.exp2(log_decay * LOG2_E)[None, :]
+
+            beta_value = beta[token, i_hv].float()
+            if beta_is_logit:
+                beta_value = torch.sigmoid(beta_value)
+            value = v[token, i_hv, tile_v].float()
+            residual = value - (state * k_vec[None, :]).sum(-1)
+            state = state + (beta_value * residual)[:, None] * k_vec[None, :]
+
+            projected = (state * q_vec[None, :]).sum(-1) * scale
+            output[token, i_hv, tile_v] = projected.to(output.dtype)
+            checkpoint_slot = state_indices[i_n, i_t].long()
+            state_pool[checkpoint_slot, i_hv, tile_v.index, k_offsets] = state
+
+    return output
+
+
+def _source_fingerprint(args: argparse.Namespace) -> dict[str, Any]:
+    harness_path = Path(__file__).resolve()
+    helper_path = Path(measure_paired_cuda_graphs.__code__.co_filename).resolve()
+    if helion.__file__ is None:
+        raise RuntimeError("loaded Helion package has no source path")
+    flashinfer_root = args.flashinfer_root.resolve()
+    flashinfer_source = (
+        flashinfer_root / "flashinfer" / "kda_kernels" / "recurrent_kda.py"
+    )
+    return {
+        "benchmark": {"path": str(harness_path), "sha256": file_sha256(harness_path)},
+        "paired_graph_helper": {
+            "path": str(helper_path),
+            "sha256": file_sha256(helper_path),
+        },
+        "helion": source_provenance(
+            REPO_ROOT,
+            {"package_init": Path(helion.__file__).resolve()},
+            pathspecs=("helion",),
+        ),
+        "flashinfer": source_provenance(
+            flashinfer_root,
+            {"recurrent_kda": flashinfer_source},
+            expected_commit=args.flashinfer_sha,
+        ),
+    }
+
+
+def _case_semantics(case: Case, seed: int) -> dict[str, Any]:
+    accepted_tokens = [
+        index % case.num_tokens + 1 for index in range(case.num_sequences)
+    ]
+    return {
+        "case": case.name,
+        "seed": seed,
+        "shape": {
+            "num_sequences": case.num_sequences,
+            "num_tokens": case.num_tokens,
+            "num_query_heads": case.num_heads,
+            "num_value_heads": case.num_heads,
+            "head_dim": HEAD_DIM,
+        },
+        "dtype": "bfloat16",
+        "state_dtype": "bfloat16",
+        "state_layout": "[checkpoint,value_head,value,key]",
+        "state_load": "state_indices[n,clamp(num_accepted_tokens[n]-1,0,T-1)]",
+        "state_store": "all-T-checkpoints-in-place",
+        "state_index_pattern": (
+            "odd-slots" if case.num_tokens == 1 else "contiguous-slots-starting-at-1"
+        ),
+        "num_accepted_tokens": accepted_tokens,
+        "qk_l2norm": True,
+        "l2_epsilon": L2_EPSILON,
+        "scale": HEAD_DIM**-0.5,
+        "gate_mode": case.gate_mode,
+        "lower_bound": case.lower_bound,
+        "beta_is_logit": case.beta_is_logit,
+        "input_distribution": {
+            "q_k_v_raw_gate": "normal-std-0.25-bfloat16",
+            "beta_logits": "normal-std-1.0-bfloat16",
+            "a_log": "uniform[-1.5,0)-float32",
+            "dt_bias": "normal-std-0.1-float32",
+            "state": "normal-std-0.02-bfloat16",
+        },
+    }
+
+
+def _install_namespace(name: str, path: Path) -> None:
+    module = ModuleType(name)
+    module.__path__ = [str(path)]  # type: ignore[attr-defined]
+    module.__package__ = name
+    sys.modules[name] = module
+
+
+def _load_flashinfer_recurrent(root: Path) -> ModuleType:
+    package_root = (root / "flashinfer").resolve()
+    source = package_root / "kda_kernels" / "recurrent_kda.py"
+    if not source.is_file():
+        raise FileNotFoundError(f"not a FlashInfer source checkout: {root}")
+    if importlib.util.find_spec("pynvml") is None:
+        sys.modules["pynvml"] = ModuleType("pynvml")
+    for name, relative in (
+        ("flashinfer", ""),
+        ("flashinfer.jit", "jit"),
+        ("flashinfer.kda_kernels", "kda_kernels"),
+        ("flashinfer.cute_dsl", "cute_dsl"),
+    ):
+        _install_namespace(name, package_root / relative)
+    module = importlib.import_module("flashinfer.kda_kernels.recurrent_kda")
+    if module.__file__ is None or Path(module.__file__).resolve() != source:
+        raise RuntimeError(
+            f"expected FlashInfer module {source}, got {module.__file__}"
+        )
+    return module
+
+
+def _make_inputs(case: Case, seed: int) -> RecurrentInputs:
+    device = torch.device("cuda")
+    generator = torch.Generator(device=device).manual_seed(seed)
+
+    def normal(shape: tuple[int, ...], std: float = 0.25) -> torch.Tensor:
+        return torch.randn(
+            shape,
+            device=device,
+            dtype=torch.bfloat16,
+            generator=generator,
+        ).mul_(std)
+
+    token_shape = (case.total_tokens, case.num_heads, HEAD_DIM)
+    q = normal(token_shape)
+    k = normal(token_shape)
+    v = normal(token_shape)
+    gate = normal(token_shape)
+    beta_logits = normal((case.total_tokens, case.num_heads), std=1.0)
+    beta = beta_logits if case.beta_is_logit else torch.sigmoid(beta_logits)
+    a_log = torch.empty(case.num_heads, device=device, dtype=torch.float32)
+    a_log.uniform_(-1.5, 0.0, generator=generator)
+    dt_bias = torch.randn(
+        case.num_heads * HEAD_DIM,
+        device=device,
+        dtype=torch.float32,
+        generator=generator,
+    ).mul_(0.1)
+
+    if case.num_tokens == 1:
+        state_slots = 2 * case.num_sequences + 1
+        state_indices = (
+            2 * torch.arange(case.num_sequences, device=device, dtype=torch.int32) + 1
+        ).reshape(case.num_sequences, 1)
+    else:
+        state_slots = case.total_tokens + 6
+        state_indices = torch.arange(
+            1,
+            case.total_tokens + 1,
+            device=device,
+            dtype=torch.int32,
+        ).reshape(case.num_sequences, case.num_tokens)
+    state = normal((state_slots, case.num_heads, HEAD_DIM, HEAD_DIM), std=0.02)
+    cu_seqlens = torch.arange(
+        0,
+        case.total_tokens + 1,
+        case.num_tokens,
+        device=device,
+        dtype=torch.int32,
+    )
+    num_accepted_tokens = (
+        torch.arange(case.num_sequences, device=device, dtype=torch.int32)
+        % case.num_tokens
+        + 1
+    )
+    return RecurrentInputs(
+        q=q,
+        k=k,
+        v=v,
+        gate=gate,
+        beta=beta,
+        a_log=a_log,
+        dt_bias=dt_bias,
+        state=state,
+        state_indices=state_indices,
+        cu_seqlens=cu_seqlens,
+        num_accepted_tokens=num_accepted_tokens,
+        output=torch.empty_like(v),
+    )
+
+
+def _torch_reference(
+    case: Case, inputs: RecurrentInputs
+) -> tuple[torch.Tensor, torch.Tensor]:
+    q = inputs.q.float()
+    k = inputs.k.float()
+    q = q * torch.rsqrt((q * q).sum(-1, keepdim=True) + L2_EPSILON)
+    k = k * torch.rsqrt((k * k).sum(-1, keepdim=True) + L2_EPSILON)
+    gate_input = inputs.gate.float() + inputs.dt_bias.reshape(
+        1, case.num_heads, HEAD_DIM
+    )
+    decay_parameter = torch.exp(inputs.a_log).reshape(1, case.num_heads, 1)
+    if case.lower_bound is None:
+        log_decay = -decay_parameter * torch.nn.functional.softplus(gate_input)
+    else:
+        log_decay = case.lower_bound * torch.sigmoid(decay_parameter * gate_input)
+    decay = torch.exp(log_decay)
+    beta = inputs.beta.float()
+    if case.beta_is_logit:
+        beta = torch.sigmoid(beta)
+
+    state_indices = inputs.state_indices.cpu().tolist()
+    accepted_counts = inputs.num_accepted_tokens.cpu().tolist()
+    for sequence, slots in enumerate(state_indices):
+        accepted_index = min(max(accepted_counts[sequence] - 1, 0), len(slots) - 1)
+        state = inputs.state[slots[accepted_index]].float()
+        for local_token, slot in enumerate(slots):
+            token = sequence * case.num_tokens + local_token
+            state = state * decay[token, :, None, :]
+            predicted = (state * k[token, :, None, :]).sum(-1)
+            residual = (inputs.v[token].float() - predicted) * beta[token, :, None]
+            state = state + residual[:, :, None] * k[token, :, None, :]
+            projected = (state * q[token, :, None, :]).sum(-1)
+            inputs.output[token] = (projected * HEAD_DIM**-0.5).to(inputs.output.dtype)
+            inputs.state[slot] = state.to(inputs.state.dtype)
+    return inputs.output, inputs.state
+
+
+def _flashinfer_kwargs(case: Case, inputs: RecurrentInputs) -> dict[str, object]:
+    outer_shape = (1, case.total_tokens)
+    qkv_shape = (*outer_shape, case.num_heads, HEAD_DIM)
+    beta_shape = (*outer_shape, case.num_heads)
+    return {
+        "q": inputs.q.view(qkv_shape),
+        "k": inputs.k.view(qkv_shape),
+        "v": inputs.v.view(qkv_shape),
+        "g": inputs.gate.view(qkv_shape),
+        "beta": inputs.beta.view(beta_shape),
+        "A_log": inputs.a_log,
+        "dt_bias": inputs.dt_bias,
+        "scale": HEAD_DIM**-0.5,
+        "initial_state": inputs.state,
+        "output_final_state": False,
+        "use_qk_l2norm_in_kernel": True,
+        "use_gate_in_kernel": True,
+        "lower_bound": case.lower_bound,
+        "cu_seqlens": inputs.cu_seqlens,
+        "ssm_state_indices": (
+            inputs.state_indices[:, 0] if case.num_tokens == 1 else inputs.state_indices
+        ),
+        "num_spec_tokens": None if case.num_tokens == 1 else case.num_tokens - 1,
+        "num_accepted_tokens": (
+            None if case.num_tokens == 1 else inputs.num_accepted_tokens
+        ),
+        "output": inputs.output.view(qkv_shape),
+        "beta_is_logit": case.beta_is_logit,
+    }
+
+
+def _make_flashinfer_launch(
+    module: ModuleType, case: Case, inputs: RecurrentInputs
+) -> Callable[[], object]:
+    return functools.partial(
+        module.run_recurrent_kda,  # pyrefly: ignore[missing-attribute]
+        **_flashinfer_kwargs(case, inputs),
+        backend="cute-dsl",
+    )
+
+
+def _tracked_flashinfer_cute_call(
+    module: ModuleType,
+    case: Case,
+    inputs: RecurrentInputs,
+    launch: Callable[[], object],
+) -> tuple[tuple[torch.Tensor, torch.Tensor], dict[str, Any]]:
+    one_warp_calls: list[dict[str, Any]] = []
+    grouped_calls: list[list[int]] = []
+    original_one_warp = module._get_compiled_kernel  # pyrefly: ignore[missing-attribute]
+    original_grouped = module._get_grouped_compiled  # pyrefly: ignore[missing-attribute]
+
+    def track_one_warp(*compile_args: object, **kwargs: object) -> object:
+        one_warp_calls.append(
+            {
+                "head_dim": compile_args[0],
+                "use_qk_l2norm": compile_args[1],
+                "use_gate_in_kernel": compile_args[2],
+                "has_dt_bias": compile_args[3],
+                "use_lower_bound": compile_args[4],
+                "use_cu_seqlens": compile_args[5],
+                "has_initial_state_source": compile_args[6],
+                "beta_is_logit": compile_args[7],
+                "num_tokens": compile_args[8],
+                "tile_rows": compile_args[9],
+                "dot_reduction_schedule": compile_args[10],
+                "zero_padded_output": compile_args[11],
+                "has_num_accepted_tokens": compile_args[12],
+            }
+        )
+        return original_one_warp(*compile_args, **kwargs)
+
+    def track_grouped(*compile_args: object, **kwargs: object) -> object:
+        grouped_key = compile_args[0]
+        if not isinstance(grouped_key, tuple):
+            raise AssertionError(f"unexpected grouped compile key: {grouped_key!r}")
+        grouped_calls.append([int(value) for value in grouped_key])
+        return original_grouped(*compile_args, **kwargs)
+
+    module._get_compiled_kernel = track_one_warp  # pyrefly: ignore[missing-attribute]
+    module._get_grouped_compiled = track_grouped  # pyrefly: ignore[missing-attribute]
+    try:
+        launch()
+    finally:
+        module._get_compiled_kernel = original_one_warp  # pyrefly: ignore[missing-attribute]
+        module._get_grouped_compiled = original_grouped  # pyrefly: ignore[missing-attribute]
+
+    if case.num_tokens == 1:
+        expected_key = {
+            "head_dim": HEAD_DIM,
+            "use_qk_l2norm": 1,
+            "use_gate_in_kernel": 1,
+            "has_dt_bias": 1,
+            "use_lower_bound": 0,
+            "use_cu_seqlens": 1,
+            "has_initial_state_source": 0,
+            "beta_is_logit": 1,
+            "num_tokens": 1,
+            "tile_rows": 16,
+            "dot_reduction_schedule": 1,
+            "zero_padded_output": 1,
+            "has_num_accepted_tokens": 0,
+        }
+        if one_warp_calls != [expected_key] or grouped_calls:
+            raise AssertionError(
+                f"{case.name} expected one packed tile16/dual-accumulator "
+                f"FlashInfer CuTe launch, got one_warp={one_warp_calls}, "
+                f"grouped={grouped_calls}"
+            )
+        schedule: dict[str, Any] = {
+            "route": "one-warp",
+            "compile_key": expected_key,
+        }
+    else:
+        expected_values = [
+            HEAD_DIM,
+            case.num_tokens,
+            case.num_heads,
+            case.num_heads,
+            2,
+            1,
+            int(case.beta_is_logit),
+            1,
+            0,
+        ]
+        if one_warp_calls or grouped_calls != [expected_values]:
+            raise AssertionError(
+                f"{case.name} expected one grouped-CTA FlashInfer CuTe launch "
+                f"with key {expected_values}, got one_warp={one_warp_calls}, "
+                f"grouped={grouped_calls}"
+            )
+        key_names = (
+            "head_dim",
+            "num_tokens",
+            "num_heads",
+            "num_value_heads",
+            "gate_mode",
+            "has_dt_bias",
+            "beta_is_logit",
+            "use_qk_l2norm",
+            "has_initial_state_source",
+        )
+        schedule = {
+            "route": "grouped-cta",
+            "compile_key": dict(zip(key_names, expected_values, strict=True)),
+            "compile_key_values": expected_values,
+        }
+    return (inputs.output, inputs.state), schedule
+
+
+def _check_result(
+    actual: tuple[torch.Tensor, torch.Tensor],
+    expected: tuple[torch.Tensor, torch.Tensor],
+    state_indices: torch.Tensor,
+    pristine_state: torch.Tensor,
+) -> dict[str, float | int | bool]:
+    output, state = actual
+    expected_output, expected_state = expected
+    output_max_abs = float((output.float() - expected_output.float()).abs().max())
+    active_slots = torch.unique(state_indices[state_indices >= 0].long())
+    active_state = state.index_select(0, active_slots)
+    expected_active_state = expected_state.index_select(0, active_slots)
+    state_max_abs = float(
+        (active_state.float() - expected_active_state.float()).abs().max()
+    )
+    torch.testing.assert_close(output, expected_output, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(
+        active_state,
+        expected_active_state,
+        atol=1e-2,
+        rtol=1e-2,
+    )
+    untouched_mask = torch.ones(state.shape[0], dtype=torch.bool, device=state.device)
+    untouched_mask[active_slots] = False
+    untouched_equal = torch.equal(state[untouched_mask], pristine_state[untouched_mask])
+    if not untouched_equal:
+        raise AssertionError("implementation modified an untouched checkpoint slot")
+    return {
+        "output_max_abs": output_max_abs,
+        "state_max_abs": state_max_abs,
+        "active_state_max_abs": state_max_abs,
+        "active_checkpoint_slots": active_slots.numel(),
+        "untouched_checkpoint_slots": untouched_mask.sum().item(),
+        "untouched_slots_bitwise_equal": untouched_equal,
+        "atol": 1e-2,
+        "rtol": 1e-2,
+    }
+
+
+def _effective_bytes(case: Case) -> int:
+    state_elements = (
+        (case.num_tokens + 1)
+        * case.num_sequences
+        * case.num_heads
+        * HEAD_DIM
+        * HEAD_DIM
+    )
+    token_elements = case.total_tokens * (
+        case.num_heads * 2 * HEAD_DIM + case.num_heads * (3 * HEAD_DIM + 1)
+    )
+    parameter_bytes = (case.num_heads + case.num_heads * HEAD_DIM) * 4
+    index_bytes = (
+        case.num_sequences * case.num_tokens
+        + case.num_sequences
+        + case.num_sequences
+        + 1
+    ) * 4
+    return 2 * (state_elements + token_elements) + parameter_bytes + index_bytes
+
+
+def _make_helion_kernel(args: argparse.Namespace) -> helion.Kernel:
+    return helion.kernel(
+        _helion_recurrent_kda_body,
+        static_shapes=False,
+        autotune_effort="full",
+        autotune_random_seed=args.autotune_seed,
+        ignore_warnings=[helion.exc.ProcessGroupNameNotFound],
+    )
+
+
+def _helion_codegen_expectation(case: Case) -> tuple[str, tuple[str, ...]]:
+    if case.num_tokens == 1:
+        return (
+            "split-single-token-rank1",
+            (
+                "split_t1_codegen_abi_version = 1",
+                "split_t1_rank1_helper_abi_version = 4",
+            ),
+        )
+    return (
+        "fixed-token-rank1",
+        (
+            "fixed_rank1_codegen_abi_version = 3",
+            "fixed_rank1_rank1_helper_abi_version = 4",
+        ),
+    )
+
+
+def _load_helion_config_map(path: Path) -> dict[str, str]:
+    raw = parse_json_object(path.read_text(encoding="utf-8"), "--helion-config-map")
+    unknown = sorted(set(raw) - set(CASES))
+    if unknown:
+        raise ValueError(f"unknown cases in --helion-config-map: {unknown}")
+    normalized: dict[str, str] = {}
+    for case_name, config in raw.items():
+        if isinstance(config, str):
+            normalized[case_name] = canonical_config_json(
+                config, f"--helion-config-map[{case_name!r}]"
+            )
+        elif isinstance(config, dict):
+            normalized[case_name] = json.dumps(
+                config, sort_keys=True, separators=(",", ":"), allow_nan=False
+            )
+        else:
+            raise ValueError(f"config for {case_name} must be a JSON object")
+    return normalized
+
+
+def _resolve_helion_config(
+    args: argparse.Namespace, case_name: str
+) -> tuple[str, str, str]:
+    if args.helion_config_map is not None:
+        configs = _load_helion_config_map(args.helion_config_map)
+        if case_name not in configs:
+            raise ValueError(f"--helion-config-map has no config for {case_name}")
+        source_hash = file_sha256(args.helion_config_map)
+        return (
+            configs[case_name],
+            f"{args.helion_config_map.resolve()}#{case_name}",
+            source_hash,
+        )
+    if args.helion_config is None:
+        raise ValueError("a pinned Helion config is required")
+    return (
+        canonical_config_json(args.helion_config, "--helion-config"),
+        args.helion_config_source or "inline-cli",
+        text_sha256(args.helion_config),
+    )
+
+
+def _paired_input_ownership(
+    pristine: RecurrentInputs, arms: dict[str, RecurrentInputs]
+) -> dict[str, Any]:
+    immutable_fields = (
+        "q",
+        "k",
+        "v",
+        "gate",
+        "beta",
+        "a_log",
+        "dt_bias",
+        "state_indices",
+        "cu_seqlens",
+        "num_accepted_tokens",
+    )
+    shared = {
+        field: all(
+            getattr(inputs, field) is getattr(pristine, field)
+            for inputs in arms.values()
+        )
+        for field in immutable_fields
+    }
+    if not all(shared.values()):
+        raise RuntimeError(f"paired immutable inputs are not shared: {shared}")
+    state_pointers = {
+        "pristine": pristine.state.data_ptr(),
+        **{name: inputs.state.data_ptr() for name, inputs in arms.items()},
+    }
+    output_pointers = {
+        "pristine": pristine.output.data_ptr(),
+        **{name: inputs.output.data_ptr() for name, inputs in arms.items()},
+    }
+    if len(set(state_pointers.values())) != len(state_pointers):
+        raise RuntimeError(f"paired state buffers alias: {state_pointers}")
+    if len(set(output_pointers.values())) != len(output_pointers):
+        raise RuntimeError(f"paired output buffers alias: {output_pointers}")
+    return {
+        "shared_immutable_fields": shared,
+        "private_state_buffers": True,
+        "private_output_buffers": True,
+        "state_pointers": state_pointers,
+        "output_pointers": output_pointers,
+    }
+
+
+def _cross_provider_comparison(
+    case: Case, baseline: RecurrentInputs, candidate: RecurrentInputs
+) -> dict[str, float | int | bool]:
+    active_slots = torch.unique(
+        baseline.state_indices[baseline.state_indices >= 0].long()
+    )
+    baseline_state = baseline.state.index_select(0, active_slots)
+    candidate_state = candidate.state.index_select(0, active_slots)
+    return {
+        "output_max_abs": float(
+            (baseline.output.float() - candidate.output.float()).abs().max()
+        ),
+        "active_state_max_abs": float(
+            (baseline_state.float() - candidate_state.float()).abs().max()
+        ),
+        "output_exact": bool(torch.equal(baseline.output, candidate.output)),
+        "active_state_exact": bool(torch.equal(baseline_state, candidate_state)),
+        "active_checkpoint_slots": active_slots.numel(),
+        "num_tokens": case.num_tokens,
+    }
+
+
+def _run_paired_recurrent_graph(args: argparse.Namespace) -> dict[str, Any]:
+    if os.environ.get("HELION_BACKEND") != "cute":
+        raise RuntimeError("set HELION_BACKEND=cute for Helion graph timing")
+    case = CASES[args.case]
+    config_json, config_source, config_source_sha256 = _resolve_helion_config(
+        args, case.name
+    )
+    source_before = _source_fingerprint(args)
+    validate_pinned_source("FlashInfer", source_before["flashinfer"])
+
+    pristine = _make_inputs(case, args.seed)
+    expected = _torch_reference(case, pristine.clone_mutable())
+    arm_inputs = {name: pristine.clone_mutable() for name in IMPLEMENTATIONS}
+    ownership = _paired_input_ownership(pristine, arm_inputs)
+
+    flashinfer_module = _load_flashinfer_recurrent(args.flashinfer_root.resolve())
+    flashinfer_inputs = arm_inputs["flashinfer-cute"]
+    flashinfer_launch = _make_flashinfer_launch(
+        flashinfer_module, case, flashinfer_inputs
+    )
+
+    helion_inputs = arm_inputs["helion-cute"]
+    helion_args = helion_inputs.helion_args(case)
+    helion_bound = _make_helion_kernel(args).bind(helion_args)
+    requested_config = helion.Config(
+        **parse_json_object(config_json, "pinned Helion config")
+    )
+    config = helion_bound.config_spec.normalized_config(requested_config)
+    helion_bound.set_config(config)
+    resolved_config = canonical_config_json(config.to_json(), "resolved Helion config")
+
+    def launch_helion(
+        bound_kernel: Callable[..., object] = cast(
+            "Callable[..., object]", helion_bound
+        ),
+        bound_args: tuple[object, ...] = helion_args,
+    ) -> object:
+        return bound_kernel(*bound_args)
+
+    def reset_flashinfer() -> None:
+        flashinfer_inputs.state.copy_(pristine.state)
+        flashinfer_inputs.output.zero_()
+
+    def reset_helion() -> None:
+        helion_inputs.state.copy_(pristine.state)
+        helion_inputs.output.zero_()
+
+    arms = (
+        PairedGraphArm("flashinfer-cute", flashinfer_launch, reset_flashinfer),
+        PairedGraphArm("helion-cute", launch_helion, reset_helion),
+    )
+
+    eager_correctness: dict[str, Any] = {}
+    reset_flashinfer()
+    flashinfer_actual, schedule = _tracked_flashinfer_cute_call(
+        flashinfer_module,
+        case,
+        flashinfer_inputs,
+        flashinfer_launch,
+    )
+    torch.cuda.synchronize()
+    eager_correctness["flashinfer-cute"] = _check_result(
+        flashinfer_actual,
+        expected,
+        pristine.state_indices,
+        pristine.state,
+    )
+    reset_helion()
+    launch_helion()
+    torch.cuda.synchronize()
+    eager_correctness["helion-cute"] = _check_result(
+        (helion_inputs.output, helion_inputs.state),
+        expected,
+        pristine.state_indices,
+        pristine.state,
+    )
+
+    plan_kind, source_markers = _helion_codegen_expectation(case)
+    generated_wrapper = verify_helion_generated_wrapper(
+        helion_bound,
+        config,
+        expected_plan_kind=plan_kind,
+        expected_source_markers=source_markers,
+    )
+    provider_metadata = {
+        "flashinfer-cute": {
+            "backend": "flashinfer-cute-dsl-recurrent",
+            "schedule": schedule,
+            "provenance": source_before["flashinfer"],
+        },
+        "helion-cute": {
+            "backend": "helion-cute",
+            "requested_config": json.loads(config_json),
+            "config": json.loads(resolved_config),
+            "config_sha256": text_sha256(resolved_config),
+            "config_source": config_source,
+            "config_source_sha256": config_source_sha256,
+            "generated_wrapper": generated_wrapper,
+        },
+    }
+
+    stream = torch.cuda.Stream()
+    captured = capture_paired_cuda_graphs(arms, stream)
+    graph_correctness: dict[str, Any] = {}
+    for arm in arms:
+        with torch.cuda.stream(stream):
+            arm.reset()
+            captured[arm.name].graph.replay()
+        stream.synchronize()
+        inputs = arm_inputs[arm.name]
+        graph_correctness[arm.name] = _check_result(
+            (inputs.output, inputs.state),
+            expected,
+            pristine.state_indices,
+            pristine.state,
+        )
+    cross_provider_correctness = _cross_provider_comparison(
+        case, flashinfer_inputs, helion_inputs
+    )
+
+    timing = measure_paired_cuda_graphs(
+        captured,
+        baseline="flashinfer-cute",
+        candidate="helion-cute",
+        measurement_cycles=args.graph_measurement_cycles,
+        primer_cycles=args.graph_primer_cycles,
+        cooldown_temp_c=args.cooldown_temp_c,
+        cooldown_timeout_s=args.cooldown_timeout_s,
+        stream=stream,
+    )
+    effective_bytes = _effective_bytes(case)
+    for values in timing["implementations"].values():
+        values["effective_gbps"] = effective_bytes / (values["median_ms"] * 1e6)
+
+    source_after = _source_fingerprint(args)
+    assert_stable(
+        "source fingerprint during paired graph run", source_before, source_after
+    )
+    if _resolve_helion_config(args, case.name) != (
+        config_json,
+        config_source,
+        config_source_sha256,
+    ):
+        raise RuntimeError("Helion config input changed during paired graph timing")
+    final_config = getattr(helion_bound, "_config", None)
+    if (
+        final_config is None
+        or canonical_config_json(final_config.to_json(), "final Helion config")
+        != resolved_config
+    ):
+        raise RuntimeError("Helion config changed during paired graph timing")
+    final_wrapper = verify_helion_generated_wrapper(
+        helion_bound,
+        final_config,
+        expected_plan_kind=plan_kind,
+        expected_source_markers=source_markers,
+    )
+    assert_stable(
+        "Helion generated wrapper during paired graph run",
+        generated_wrapper,
+        final_wrapper,
+    )
+
+    return {
+        "valid": True,
+        "case": case.name,
+        "implementations_order": list(IMPLEMENTATIONS),
+        "semantic_metadata": _case_semantics(case, args.seed),
+        "effective_bytes": effective_bytes,
+        "timed_state_semantics": "pristine-reset-before-each-cuda-graph-replay",
+        "correctness_state_semantics": "identical-pristine-clone-one-replay",
+        "correctness": {
+            "eager_vs_oracle": eager_correctness,
+            "graph_replay_vs_oracle": graph_correctness,
+            "cross_provider_after_one_graph": cross_provider_correctness,
+        },
+        "fairness_audit": {
+            "same_process": True,
+            "same_cuda_stream": True,
+            "same_cuda_event_timer": True,
+            "one_provider_invocation_per_graph": True,
+            "one_graph_replay_per_timed_interval": True,
+            "reset_outside_timing": True,
+            "cold_l2_before_every_replay": True,
+            "private_mutable_state_per_arm": True,
+            "private_output_per_arm": True,
+            "shared_immutable_inputs": True,
+            "balanced_position_schedule": True,
+            "outlier_policy": "none discarded",
+        },
+        "input_ownership": ownership,
+        "graph_capture": {
+            "graphs": len(captured),
+            "provider_invocations_per_graph": 1,
+            "graph_objects_kept_alive": all(
+                isinstance(item.graph, torch.cuda.CUDAGraph)
+                for item in captured.values()
+            ),
+        },
+        "providers": provider_metadata,
+        "source_fingerprint_before": source_before,
+        "source_fingerprint_after": source_after,
+        "environment": {
+            "helion_backend": os.environ.get("HELION_BACKEND"),
+            "helion_fast_math": os.environ.get("HELION_FAST_MATH"),
+            "helion_skip_cache": os.environ.get("HELION_SKIP_CACHE"),
+            "cute_dsl_arch": os.environ.get("CUTE_DSL_ARCH"),
+            "pythonhashseed": os.environ.get("PYTHONHASHSEED"),
+        },
+        "seed": args.seed,
+        "argv": sys.argv,
+        "gpu": gpu_info(),
+        **timing,
+    }
+
+
+def _create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--paired-cuda-graph", action="store_true")
+    parser.add_argument("--impls", default=",".join(IMPLEMENTATIONS))
+    parser.add_argument("--case", choices=DEFAULT_CASES, required=True)
+    parser.add_argument("--flashinfer-root", type=Path, required=True)
+    parser.add_argument("--flashinfer-sha", default=PINNED_FLASHINFER_SHA)
+    parser.add_argument("--autotune-seed", type=int, default=1337)
+    config_group = parser.add_mutually_exclusive_group(required=True)
+    config_group.add_argument("--helion-config")
+    config_group.add_argument(
+        "--helion-config-map",
+        "--helion-configs",
+        dest="helion_config_map",
+        type=Path,
+    )
+    parser.add_argument("--helion-config-source")
+    parser.add_argument("--graph-primer-cycles", type=int, default=2)
+    parser.add_argument("--graph-measurement-cycles", type=int, default=12)
+    parser.add_argument("--cache-mode", choices=("cold",), default="cold")
+    parser.add_argument("--cooldown-temp-c", type=float, default=DEFAULT_COOLDOWN_C)
+    parser.add_argument("--cooldown-timeout-s", type=float, default=600.0)
+    parser.add_argument("--seed", type=int, default=20260904)
+    parser.add_argument("--jsonl", type=Path)
+    return parser
+
+
+def _validate_cli_args(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> None:
+    implementations = tuple(value.strip() for value in args.impls.split(","))
+    if implementations != IMPLEMENTATIONS:
+        parser.error(f"--impls must be exactly {','.join(IMPLEMENTATIONS)}")
+    if not args.paired_cuda_graph:
+        parser.error("--paired-cuda-graph is required; legacy timing was removed")
+    if args.graph_primer_cycles <= 0:
+        parser.error("--graph-primer-cycles must be positive")
+    if args.graph_measurement_cycles < 2 or args.graph_measurement_cycles % 2:
+        parser.error("--graph-measurement-cycles must be an even integer >= 2")
+    if args.cooldown_timeout_s <= 0:
+        parser.error("--cooldown-timeout-s must be positive")
+    if not math.isfinite(args.cooldown_temp_c):
+        parser.error("--cooldown-temp-c must be finite")
+    if args.helion_config_source is not None and args.helion_config is None:
+        parser.error("--helion-config-source requires --helion-config")
+    try:
+        _resolve_helion_config(args, args.case)
+    except (OSError, UnicodeError, ValueError) as error:
+        parser.error(str(error))
+
+
+def main() -> None:
+    parser = _create_parser()
+    args = parser.parse_args()
+    _validate_cli_args(parser, args)
+    result = _run_paired_recurrent_graph(args)
+    if args.jsonl is not None:
+        args.jsonl.parent.mkdir(parents=True, exist_ok=True)
+        with args.jsonl.open("x", encoding="utf-8") as output_file:
+            output_file.write(json.dumps(result) + "\n")
+    print("RESULT_JSON: " + json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/cute/kda_benchmark_utils.py
+++ b/benchmarks/cute/kda_benchmark_utils.py
@@ -1,0 +1,578 @@
+"""Shared measurement helpers for KDA benchmark drivers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import math
+import os
+import re
+import statistics
+import subprocess
+import time
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import Protocol
+from typing import cast
+
+import torch
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+DEFAULT_COOLDOWN_C = 46.0
+
+
+@dataclass(frozen=True)
+class PairedGraphArm:
+    """One provider with private mutable buffers for paired graph timing."""
+
+    name: str
+    launch: Callable[[], object]
+    reset: Callable[[], None]
+
+
+@dataclass(frozen=True)
+class _CapturedGraphArm:
+    arm: PairedGraphArm
+    graph: torch.cuda.CUDAGraph
+
+
+class _GeneratedSourceBackend(Protocol):
+    def generated_source_hash(self, compiled_fn: object) -> str | None: ...
+
+
+class _GeneratedSourceEnvironment(Protocol):
+    backend: _GeneratedSourceBackend
+
+
+class _GeneratedWrapperBound(Protocol):
+    _run: object | None
+    env: _GeneratedSourceEnvironment
+
+    def to_triton_code(self, config: object) -> str: ...
+
+
+def verify_helion_generated_wrapper(
+    bound: object,
+    config: object,
+    *,
+    expected_plan_kind: str,
+    expected_source_markers: tuple[str, ...],
+    expected_source_patterns: tuple[str, ...] = (),
+    compiled_fn: object | None = None,
+) -> dict[str, Any]:
+    """Verify that the compiled Helion wrapper used the expected CuTe plan."""
+
+    if not expected_plan_kind or not expected_source_markers:
+        raise ValueError("Helion wrapper verification requires a plan and markers")
+    typed_bound = cast("_GeneratedWrapperBound", bound)
+    source = typed_bound.to_triton_code(config)
+    source_hash = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    compiled = typed_bound._run if compiled_fn is None else compiled_fn
+    if compiled is None:
+        raise RuntimeError("Helion bound kernel has no compiled wrapper")
+    compiled_source_hash = typed_bound.env.backend.generated_source_hash(compiled)
+    if compiled_source_hash != source_hash:
+        raise RuntimeError(
+            "Helion compiled-wrapper source identity mismatch: "
+            f"compiled={compiled_source_hash}, regenerated={source_hash}"
+        )
+
+    stripped_lines = [line.strip() for line in source.splitlines()]
+    marker_counts = {
+        marker: stripped_lines.count(marker) for marker in expected_source_markers
+    }
+    invalid_markers = {
+        marker: count for marker, count in marker_counts.items() if count != 1
+    }
+    pattern_counts = {
+        pattern: sum(re.fullmatch(pattern, line) is not None for line in stripped_lines)
+        for pattern in expected_source_patterns
+    }
+    invalid_patterns = {
+        pattern: count for pattern, count in pattern_counts.items() if count != 1
+    }
+    if invalid_markers or invalid_patterns:
+        raise RuntimeError(
+            f"Helion expected {expected_plan_kind} generated-wrapper markers "
+            "exactly once, got "
+            f"literal={invalid_markers}, regex={invalid_patterns}"
+        )
+    return {
+        "plan_kind": expected_plan_kind,
+        "source_sha256": source_hash,
+        "source_bytes": len(source.encode("utf-8")),
+        "source_lines": len(source.splitlines()),
+        "expected_source_markers": list(expected_source_markers),
+        "source_marker_counts": marker_counts,
+        "expected_source_patterns": list(expected_source_patterns),
+        "source_pattern_counts": pattern_counts,
+        "compiled_source_identity_verified": True,
+    }
+
+
+def file_sha256(path: Path) -> str:
+    """Hash one source artifact without loading it all into memory."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as input_file:
+        for chunk in iter(lambda: input_file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def text_sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def parse_json_object(value: str, option: str) -> dict[str, Any]:
+    """Parse a finite JSON object while rejecting duplicate keys."""
+
+    def reject_nonfinite(constant: str) -> None:
+        raise ValueError(f"{option} contains non-finite JSON value {constant}")
+
+    def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in result:
+                raise ValueError(f"{option} contains duplicate key {key!r}")
+            result[key] = item
+        return result
+
+    parsed = json.loads(
+        value,
+        parse_constant=reject_nonfinite,
+        object_pairs_hook=reject_duplicate_keys,
+    )
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{option} must contain a JSON object")
+    return parsed
+
+
+def canonical_config_json(value: str, option: str) -> str:
+    return json.dumps(
+        parse_json_object(value, option),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def _git_output(root: Path, *arguments: str, text: bool = True) -> str | bytes:
+    return subprocess.run(
+        ("git", *arguments),
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=text,
+    ).stdout
+
+
+def _git_untracked_python_sha256(root: Path, pathspecs: tuple[str, ...]) -> str:
+    scoped_pathspecs = pathspecs or (":(glob)**/*.py",)
+    output = _git_output(
+        root,
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+        "-z",
+        "--",
+        *scoped_pathspecs,
+        text=False,
+    )
+    assert isinstance(output, bytes)
+    paths = sorted(
+        path for path in output.split(b"\0") if path and path.endswith(b".py")
+    )
+    digest = hashlib.sha256()
+    for encoded_path in paths:
+        digest.update(encoded_path)
+        digest.update(b"\0")
+        path = root / os.fsdecode(encoded_path)
+        with path.open("rb") as source:
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(chunk)
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def source_provenance(
+    root: Path,
+    source_files: dict[str, Path],
+    *,
+    expected_commit: str | None = None,
+    pathspecs: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Fingerprint a checkout, including tracked and untracked Python edits."""
+
+    root = root.resolve()
+    status_command = ["status", "--porcelain", "--untracked-files=all"]
+    if pathspecs:
+        status_command.extend(("--", *pathspecs))
+    status_output = _git_output(root, *status_command)
+    assert isinstance(status_output, str)
+    status = status_output.splitlines()
+
+    diff_command = ["diff", "--binary", "HEAD", "--", *pathspecs]
+    diff = _git_output(root, *diff_command, text=False)
+    assert isinstance(diff, bytes)
+    commit = _git_output(root, "rev-parse", "HEAD")
+    remote = subprocess.run(
+        ("git", "remote", "get-url", "origin"),
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert isinstance(commit, str)
+    commit = commit.strip()
+    return {
+        "root": str(root),
+        "commit": commit,
+        "dirty": bool(status),
+        "status": status,
+        "status_includes_untracked": True,
+        "pathspecs": list(pathspecs),
+        "tracked_diff_sha256": hashlib.sha256(diff).hexdigest(),
+        "untracked_python_sha256": _git_untracked_python_sha256(root, pathspecs),
+        "remote": remote or None,
+        "expected_commit": expected_commit,
+        "commit_matches_pin": (
+            None if expected_commit is None else commit == expected_commit
+        ),
+        "pinned_clean": bool(expected_commit == commit and not status),
+        "sources": {
+            name: {"path": str(path.resolve()), "sha256": file_sha256(path.resolve())}
+            for name, path in sorted(source_files.items())
+        },
+    }
+
+
+def validate_pinned_source(name: str, provenance: dict[str, Any]) -> None:
+    expected_commit = provenance["expected_commit"]
+    if expected_commit is None:
+        raise RuntimeError(f"{name} source requires an explicit commit pin")
+    if not provenance["commit_matches_pin"]:
+        raise RuntimeError(
+            f"expected {name} SHA {expected_commit}, got {provenance['commit']}"
+        )
+    if provenance["dirty"]:
+        raise RuntimeError(
+            f"{name} source must be clean; git status was {provenance['status']}"
+        )
+
+
+def assert_stable(label: str, before: object, after: object) -> None:
+    if before != after:
+        raise RuntimeError(f"{label} changed: before={before}, after={after}")
+
+
+def _physical_gpu_index() -> str:
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES", "")
+    first = visible.split(",", 1)[0].strip()
+    return first or "0"
+
+
+def _gpu_field(field: str) -> float | None:
+    try:
+        output = subprocess.run(
+            (
+                "nvidia-smi",
+                "-i",
+                _physical_gpu_index(),
+                f"--query-gpu={field}",
+                "--format=csv,noheader,nounits",
+            ),
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        ).stdout.strip()
+        return float(output.splitlines()[0])
+    except (IndexError, OSError, subprocess.SubprocessError, ValueError):
+        return None
+
+
+def gpu_info() -> dict[str, Any]:
+    properties = torch.cuda.get_device_properties(torch.cuda.current_device())
+    return {
+        "gpu": properties.name,
+        "compute_capability": list(torch.cuda.get_device_capability()),
+        "multiprocessor_count": properties.multi_processor_count,
+        "l2_cache_bytes": l2_cache_bytes(properties),
+        "power_limit_w": _gpu_field("power.limit"),
+        "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES", ""),
+        "torch_version": torch.__version__,
+        "torch_cuda_version": torch.version.cuda,
+    }
+
+
+def l2_cache_bytes(properties: object) -> int:
+    value = getattr(properties, "L2_cache_size", None)
+    if not isinstance(value, int) or value <= 0:
+        raise RuntimeError(
+            "PyTorch CUDA device properties did not provide a positive "
+            "L2_cache_size; refusing to claim cold-L2 timing"
+        )
+    return value
+
+
+def wait_for_cooldown(target_c: float, timeout_s: float) -> dict[str, Any]:
+    torch.cuda.synchronize()
+    start = _gpu_field("temperature.gpu")
+    current = start
+    started = time.monotonic()
+    while current is not None and current > target_c:
+        if time.monotonic() - started >= timeout_s:
+            break
+        time.sleep(5)
+        current = _gpu_field("temperature.gpu")
+    if current is None:
+        raise RuntimeError("GPU temperature is unavailable; benchmark is invalid")
+    if current > target_c:
+        raise TimeoutError(
+            f"GPU remained at {current} C above the {target_c} C limit after "
+            f"{time.monotonic() - started:.1f} s"
+        )
+    return {
+        "start_temp_c": start,
+        "end_temp_c": current,
+        "waited_s": round(time.monotonic() - started, 1),
+        "target_c": target_c,
+        "reached_target": True,
+    }
+
+
+def paired_graph_order(
+    cycle_index: int, baseline: str, candidate: str
+) -> tuple[str, str, str, str]:
+    """Return a balanced ABBA/BAAB order for one measurement cycle."""
+
+    if cycle_index % 2 == 0:
+        return (baseline, candidate, candidate, baseline)
+    return (candidate, baseline, baseline, candidate)
+
+
+def capture_paired_cuda_graphs(
+    arms: tuple[PairedGraphArm, PairedGraphArm],
+    stream: torch.cuda.Stream,
+) -> dict[str, _CapturedGraphArm]:
+    """Capture exactly one provider invocation in each private CUDA graph."""
+
+    captured: dict[str, _CapturedGraphArm] = {}
+    for arm in arms:
+        # CUDA graph capture must be warmed on a non-default stream. Both the
+        # warmup and reset are outside every subsequently measured interval.
+        with torch.cuda.stream(stream):
+            arm.reset()
+            arm.launch()
+        stream.synchronize()
+        with torch.cuda.stream(stream):
+            arm.reset()
+        stream.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            arm.launch()
+        stream.synchronize()
+        captured[arm.name] = _CapturedGraphArm(arm=arm, graph=graph)
+    return captured
+
+
+def _percentile(values: list[float], probability: float) -> float:
+    if not values:
+        raise ValueError("cannot take a percentile of an empty sample")
+    ordered = sorted(values)
+    position = probability * (len(ordered) - 1)
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    weight = position - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def _sample_summary(values: list[float]) -> dict[str, float | int]:
+    if not values:
+        raise ValueError("cannot summarize an empty sample")
+    median = statistics.median(values)
+    return {
+        "count": len(values),
+        "min": min(values),
+        "p10": _percentile(values, 0.10),
+        "p25": _percentile(values, 0.25),
+        "median": median,
+        "p75": _percentile(values, 0.75),
+        "p90": _percentile(values, 0.90),
+        "max": max(values),
+        "mad": statistics.median(abs(value - median) for value in values),
+    }
+
+
+def _geometric_mean(values: list[float]) -> float:
+    if not values or any(value <= 0.0 for value in values):
+        raise ValueError("geometric mean requires positive values")
+    return math.exp(statistics.fmean(math.log(value) for value in values))
+
+
+def measure_paired_cuda_graphs(
+    captured: dict[str, _CapturedGraphArm],
+    *,
+    baseline: str,
+    candidate: str,
+    measurement_cycles: int,
+    primer_cycles: int,
+    cooldown_temp_c: float,
+    cooldown_timeout_s: float,
+    stream: torch.cuda.Stream,
+) -> dict[str, Any]:
+    """Measure one graph replay at a time with a balanced cold-L2 schedule."""
+
+    if set(captured) != {baseline, candidate}:
+        raise ValueError("paired timing requires exactly the named two graph arms")
+    if measurement_cycles < 2 or measurement_cycles % 2:
+        raise ValueError("paired graph measurement cycles must be an even integer >= 2")
+    if primer_cycles < 1:
+        raise ValueError("paired graph primer cycles must be positive")
+
+    properties = torch.cuda.get_device_properties(torch.cuda.current_device())
+    cache_bytes = l2_cache_bytes(properties)
+    flush = torch.zeros(2 * cache_bytes, device="cuda", dtype=torch.uint8)
+
+    def prepare_and_replay(name: str) -> None:
+        captured[name].arm.reset()
+        flush.add_(1)
+        captured[name].graph.replay()
+
+    for cycle_index in range(primer_cycles):
+        with torch.cuda.stream(stream):
+            for name in paired_graph_order(cycle_index, baseline, candidate):
+                prepare_and_replay(name)
+    stream.synchronize()
+    cooldown = wait_for_cooldown(cooldown_temp_c, cooldown_timeout_s)
+
+    blocks: list[dict[str, Any]] = []
+    samples_by_name = {baseline: [], candidate: []}
+    all_pairs: list[dict[str, Any]] = []
+    for cycle_index in range(measurement_cycles):
+        order = paired_graph_order(cycle_index, baseline, candidate)
+        events = [
+            (
+                torch.cuda.Event(enable_timing=True),
+                torch.cuda.Event(enable_timing=True),
+            )
+            for _ in order
+        ]
+        with torch.cuda.stream(stream):
+            for name, (start, end) in zip(order, events, strict=True):
+                # State/output restoration and a 2x-L2 sweep precede the start
+                # event on the same stream and are therefore outside timing.
+                captured[name].arm.reset()
+                flush.add_(1)
+                start.record(stream)
+                captured[name].graph.replay()
+                end.record(stream)
+        events[-1][1].synchronize()
+
+        observations: list[dict[str, Any]] = []
+        for position, (name, (start, end)) in enumerate(
+            zip(order, events, strict=True)
+        ):
+            latency_ms = float(start.elapsed_time(end))
+            if not math.isfinite(latency_ms) or latency_ms <= 0.0:
+                raise RuntimeError(
+                    f"invalid paired CUDA-graph timing sample: {latency_ms}"
+                )
+            samples_by_name[name].append(latency_ms)
+            observations.append(
+                {
+                    "implementation": name,
+                    "position": position,
+                    "latency_ms": latency_ms,
+                }
+            )
+
+        pairs: list[dict[str, Any]] = []
+        for offset in (0, 2):
+            first, second = observations[offset : offset + 2]
+            by_name = {
+                first["implementation"]: first["latency_ms"],
+                second["implementation"]: second["latency_ms"],
+            }
+            baseline_ms = float(by_name[baseline])
+            candidate_ms = float(by_name[candidate])
+            pair = {
+                "cycle_index": cycle_index,
+                "pair_in_cycle": offset // 2,
+                "order": (
+                    "baseline-first"
+                    if first["implementation"] == baseline
+                    else "candidate-first"
+                ),
+                "baseline_ms": baseline_ms,
+                "candidate_ms": candidate_ms,
+                "candidate_speedup_over_baseline": baseline_ms / candidate_ms,
+                "candidate_over_baseline_latency_ratio": candidate_ms / baseline_ms,
+            }
+            pairs.append(pair)
+            all_pairs.append(pair)
+        blocks.append(
+            {
+                "cycle_index": cycle_index,
+                "order": list(order),
+                "observations": observations,
+                "pairs": pairs,
+            }
+        )
+
+    speedups = [float(pair["candidate_speedup_over_baseline"]) for pair in all_pairs]
+    latency_ratios = [
+        float(pair["candidate_over_baseline_latency_ratio"]) for pair in all_pairs
+    ]
+    return {
+        "timer": "torch.cuda.Event around one CUDA-graph replay",
+        "timing_mode": "cuda-graph-one-invocation",
+        "ordering_mode": "same-process balanced ABBA/BAAB crossover",
+        "measurement_cycles": measurement_cycles,
+        "primer_cycles": primer_cycles,
+        "samples_per_implementation": 2 * measurement_cycles,
+        "l2_cache_bytes": cache_bytes,
+        "l2_flush_bytes": flush.numel(),
+        "cache_mode": "cold",
+        "state_reset": "pristine-copy-and-output-zero-before-each-replay",
+        "l2_flush_placement": "2x-L2-sweep-before-start-event-for-every-replay",
+        "cooldown": cooldown,
+        "implementations": {
+            name: {
+                "median_ms": statistics.median(samples),
+                "best_ms": min(samples),
+                "samples_ms": samples,
+                "distribution_ms": _sample_summary(samples),
+            }
+            for name, samples in samples_by_name.items()
+        },
+        "paired_statistics": {
+            "baseline": baseline,
+            "candidate": candidate,
+            "pairs": len(all_pairs),
+            "candidate_faster_pairs": sum(value > 1.0 for value in speedups),
+            "candidate_speedup_over_baseline_geomean": _geometric_mean(speedups),
+            "candidate_over_baseline_latency_ratio_geomean": _geometric_mean(
+                latency_ratios
+            ),
+            "speedup_distribution": _sample_summary(speedups),
+            "by_order": {
+                order: _sample_summary(
+                    [
+                        float(pair["candidate_speedup_over_baseline"])
+                        for pair in all_pairs
+                        if pair["order"] == order
+                    ]
+                )
+                for order in ("baseline-first", "candidate-first")
+            },
+        },
+        "blocks": blocks,
+    }

--- a/benchmarks/cute/kda_prefill_kernels.py
+++ b/benchmarks/cute/kda_prefill_kernels.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import torch
+
+import helion
+import helion.language as hl
+
+BT: int = 16
+DK: int = 128
+DV: int = 128
+CPC: int = 4
+LOG2_E: float = 1.4426950408889634
+KDA_PREPARE_CONFIG = helion.Config(
+    block_sizes=[],
+    num_warps=4,
+    num_stages=2,
+    indexing="pointer",
+)
+
+
+def _bf16(value: torch.Tensor) -> torch.Tensor:
+    return value.to(torch.bfloat16).float()
+
+
+def _block_inverse(lower: torch.Tensor) -> torch.Tensor:
+    """The two-block FP16 inverse arithmetic used by the BT16 schedule."""
+
+    row = hl.arange(BT)
+    same_half = (row[:, None] < 8) == (row[None, :] < 8)
+    lower_half = (row[:, None] >= 8) & (row[None, :] < 8)
+    diagonal = torch.where(same_half, lower, 0.0)
+    coupling = torch.where(lower_half, lower, 0.0)
+    diagonal2 = hl.dot(
+        diagonal.to(torch.float16),
+        diagonal.T.to(torch.float16),
+        out_dtype=torch.float32,
+    )
+    diagonal4 = hl.dot(
+        diagonal2.to(torch.float16),
+        diagonal2.T.to(torch.float16),
+        out_dtype=torch.float32,
+    )
+    eye = (row[:, None] == row[None, :]).float()
+    inverse = eye - diagonal.to(torch.float16).float()
+    inverse = inverse.to(torch.float16).float() + hl.dot(
+        inverse.to(torch.float16),
+        diagonal2.T.to(torch.float16),
+        out_dtype=torch.float32,
+    )
+    inverse = inverse.to(torch.float16).float() + hl.dot(
+        inverse.to(torch.float16),
+        diagonal4.T.to(torch.float16),
+        out_dtype=torch.float32,
+    )
+    first = hl.dot(
+        inverse.to(torch.float16),
+        coupling.T.to(torch.float16),
+        out_dtype=torch.float32,
+    )
+    lower_left = hl.dot(
+        first.to(torch.float16),
+        inverse.T.to(torch.float16),
+        out_dtype=torch.float32,
+    )
+    return torch.where(lower_half, -lower_left, inverse).to(torch.bfloat16)
+
+
+@helion.kernel(
+    backend="cute",
+    static_shapes=True,
+    fast_math=True,
+    config=KDA_PREPARE_CONFIG,
+)
+def kda_chunk_prepare(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    gate: torch.Tensor,
+    beta_logits: torch.Tensor,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    cu_chunks: torch.Tensor,
+    chunk_to_seq: torch.Tensor,
+    kd: torch.Tensor,
+    qd: torch.Tensor,
+    ak: torch.Tensor,
+    aq: torch.Tensor,
+    g_total: torch.Tensor,
+    scale: float | None,
+    gate_scale_log2: float,
+) -> None:
+    """Semantic carrier for the exact five-factor prepare contract."""
+
+    tokens = q.size(1)
+    heads = hl.specialize(q.size(2))
+    chunks = chunk_to_seq.size(0)
+    groups = (chunks + CPC - 1) // CPC
+    q_rows = q.view(tokens * heads, DK)
+    k_rows = k.view(tokens * heads, DK)
+    gate_rows = gate.view(tokens * heads, DK)
+    beta_rows = beta_logits.view(tokens * heads)
+    kd_rows = kd.view(heads * chunks * BT, DK)
+    qd_rows = qd.view(heads * chunks * BT, DK)
+    ak_rows = ak.view(heads * chunks * BT, DK)
+    aq_rows = aq.view(heads * chunks, BT * BT)
+    gt_rows = g_total.view(heads * chunks, DK)
+
+    for tile_group, tile_head in hl.tile(
+        [groups, heads],
+        block_size=[1, 1],
+    ):
+        for local_chunk in range(CPC):
+            chunk = tile_group.id * CPC + local_chunk
+            if chunk < chunks:
+                sequence = chunk_to_seq[chunk].long()
+                sequence_begin = cu_seqlens[sequence].long()
+                sequence_end = cu_seqlens[sequence + 1].long()
+                chunk_begin = sequence_begin + (chunk - cu_chunks[sequence]) * BT
+                token_lane = hl.arange(BT)
+                feature = hl.arange(DK)
+                token = chunk_begin + token_lane
+                valid = token < sequence_end
+                input_row = token * heads + tile_head.id
+                factor_row = (tile_head.id * chunks + chunk) * BT + token_lane
+
+                q_raw = hl.load(
+                    q_rows,
+                    [input_row[:, None], feature[None, :]],
+                    extra_mask=valid[:, None],
+                ).float()
+                k_raw = hl.load(
+                    k_rows,
+                    [input_row[:, None], feature[None, :]],
+                    extra_mask=valid[:, None],
+                ).float()
+                gate_raw = hl.load(
+                    gate_rows,
+                    [input_row[:, None], feature[None, :]],
+                    extra_mask=valid[:, None],
+                ).float()
+                dt = dt_bias[tile_head.id, feature].float()
+                log_decay_scale = torch.exp2(a_log[tile_head.id].float() * LOG2_E)
+                gate_increment = gate_scale_log2 * (
+                    torch.tanh(log_decay_scale * (gate_raw + dt[None, :]) * 0.5) * 0.5
+                    + 0.5
+                )
+                gate_increment = torch.where(valid[:, None], gate_increment, 0.0)
+                gate_prefix = torch.cumsum(gate_increment, dim=0)
+                exp_gate = torch.exp2(torch.clamp(gate_prefix, min=-126.0))
+                gamma = torch.where((token_lane == BT - 1)[:, None], exp_gate, 0.0).sum(
+                    0
+                )
+
+                q_ss = (q_raw * q_raw).sum(-1)
+                k_ss = (k_raw * k_raw).sum(-1)
+                q_inv = torch.rsqrt(torch.clamp(q_ss, min=1.0e-24))
+                k_inv = torch.rsqrt(torch.clamp(k_ss, min=1.0e-24))
+                q_norm = _bf16(q_raw * q_inv[:, None])
+                k_norm = k_raw * k_inv[:, None]
+                exp_gate_bf16 = _bf16(exp_gate)
+                kd_value = _bf16(_bf16(k_norm) * exp_gate_bf16)
+                ki_value = _bf16(k_norm * torch.reciprocal(exp_gate))
+                qd_value = _bf16(q_norm * exp_gate_bf16)
+                if scale is not None:
+                    scale_bf16 = (
+                        torch.full_like(q_inv, scale).to(torch.bfloat16).float()
+                    )
+                    qd_value = _bf16(qd_value * scale_bf16[:, None])
+
+                beta = torch.sigmoid(
+                    hl.load(beta_rows, [input_row], extra_mask=valid).float()
+                )
+                kk = hl.dot(
+                    kd_value.to(torch.bfloat16),
+                    ki_value.T.to(torch.bfloat16),
+                    out_dtype=torch.float32,
+                )
+                qk = hl.dot(
+                    qd_value.to(torch.bfloat16),
+                    ki_value.T.to(torch.bfloat16),
+                    out_dtype=torch.float32,
+                )
+                causal = token_lane[:, None] >= token_lane[None, :]
+                strict = token_lane[:, None] > token_lane[None, :]
+                lower = torch.where(strict, kk * beta[:, None], 0.0)
+                inverse = _block_inverse(lower)
+                inverse_beta = (
+                    inverse.float() * beta[None, :].to(torch.bfloat16).float()
+                ).to(torch.bfloat16)
+                qk = torch.where(causal, qk, 0.0).to(torch.bfloat16)
+                aq_value = hl.dot(
+                    qk,
+                    inverse_beta,
+                    out_dtype=torch.float32,
+                ).to(torch.bfloat16)
+                kg = (ki_value * gamma[None, :].to(torch.bfloat16).float()).to(
+                    torch.bfloat16
+                )
+                ak_value = hl.dot(
+                    inverse_beta.T,
+                    kg,
+                    out_dtype=torch.float32,
+                ).to(torch.bfloat16)
+
+                if scale is None:
+                    hl.store(
+                        kd_rows,
+                        [factor_row[:, None], (feature ^ 8)[None, :]],
+                        kd_value.to(torch.bfloat16),
+                    )
+                    hl.store(
+                        qd_rows,
+                        [factor_row[:, None], (feature ^ 8)[None, :]],
+                        qd_value.to(torch.bfloat16),
+                    )
+                else:
+                    hl.store(
+                        kd_rows,
+                        [factor_row[:, None], feature[None, :]],
+                        kd_value.to(torch.bfloat16),
+                    )
+                    hl.store(
+                        qd_rows,
+                        [factor_row[:, None], feature[None, :]],
+                        qd_value.to(torch.bfloat16),
+                    )
+                ak_physical_row = (tile_head.id * chunks + chunk) * BT + (
+                    token_lane ^ 8
+                )
+                hl.store(
+                    ak_rows,
+                    [ak_physical_row[:, None], feature[None, :]],
+                    ak_value,
+                )
+                storage_col = token_lane[None, :] ^ 8
+                byte_offset = 2 * (token_lane[:, None] * BT + storage_col)
+                pair_index = (byte_offset ^ (((byte_offset >> 7) & 1) << 4)) // 2
+                aq_rows[tile_head.id * chunks + chunk, pair_index] = aq_value
+                gt_rows[tile_head.id * chunks + chunk, feature] = gamma
+
+
+KDA_RECURRENCE_CONFIG = helion.Config(
+    block_sizes=[64],
+    num_warps=8,
+    num_stages=2,
+    indexing="pointer",
+    pid_type="flat",
+)
+
+
+@helion.kernel(backend="cute", static_shapes=True, config=KDA_RECURRENCE_CONFIG)
+def kda_chunk_recurrence(
+    kd: torch.Tensor,
+    qd: torch.Tensor,
+    ak: torch.Tensor,
+    aq: torch.Tensor,
+    g_total: torch.Tensor,
+    values: torch.Tensor,
+    output: torch.Tensor,
+    state: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    cu_chunks: torch.Tensor,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Semantic carrier for the exact five-factor BT16 recurrence/output path.
+
+    ``ak`` and ``aq`` expose the physical images written by the matching prepare
+    carrier.  The explicit inverse index maps below make this function's eager
+    meaning the logical four-contraction recurrence instead of treating those
+    images as ordinary row-major matrices.
+    """
+
+    heads = hl.specialize(values.size(2))
+    value_width = hl.specialize(values.size(3))
+    key_width = hl.specialize(kd.size(3))
+    total_chunks = aq.size(2)
+    sequences = cu_seqlens.size(0) - 1
+
+    kd_rows = kd.view(-1, key_width)
+    qd_rows = qd.view(-1, key_width)
+    ak_rows = ak.view(-1, key_width)
+    aq_rows = aq.view(-1, BT * BT)
+    gt_rows = g_total.view(-1, key_width)
+    value_rows = values.view(-1, value_width)
+    output_rows = output.view(-1, value_width)
+    block_v = hl.register_block_size(64, value_width)
+
+    for tile_sequence, tile_head, tile_v in hl.tile(
+        [sequences, heads, value_width], block_size=[1, 1, block_v]
+    ):
+        begin = cu_seqlens[tile_sequence.id].long()
+        end = cu_seqlens[tile_sequence.id + 1].long()
+        chunk_begin = cu_chunks[tile_sequence.id].long()
+        state_value = state[
+            tile_sequence.id,
+            tile_head.id,
+            tile_v.index,
+            :,
+        ].float()
+
+        for token_tile in hl.tile(end - begin, block_size=BT):
+            global_chunk = chunk_begin + token_tile.id
+            token = begin + token_tile.index
+            valid = token < end
+            row = token * heads + tile_head.id
+            factor_base = (tile_head.id * total_chunks + global_chunk) * BT
+            factor_row = factor_base + token_tile.index
+            feature = hl.arange(key_width)
+
+            physical_feature = feature ^ 8
+            kd_value = kd_rows[
+                factor_row[:, None],
+                physical_feature[None, :],
+            ]
+            projected = hl.dot(
+                kd_value,
+                state_value.T.to(kd.dtype),
+                out_dtype=torch.float32,
+            )
+            value = hl.load(
+                value_rows,
+                [row, tile_v],
+                extra_mask=valid[:, None],
+            ).float()
+            residual = _bf16(value - projected)
+
+            qd_value = qd_rows[
+                factor_row[:, None],
+                physical_feature[None, :],
+            ]
+            result = hl.dot(
+                qd_value,
+                state_value.T.to(qd.dtype),
+                out_dtype=torch.float32,
+            )
+
+            logical_row = token_tile.index[:, None]
+            logical_col = hl.arange(BT)[None, :]
+            storage_col = logical_col ^ 8
+            byte_offset = 2 * (logical_row * BT + storage_col)
+            pair_index = (byte_offset ^ (((byte_offset >> 7) & 1) << 4)) // 2
+            aq_value = aq_rows[
+                tile_head.id * total_chunks + global_chunk,
+                pair_index,
+            ]
+            result = hl.dot(
+                aq_value,
+                residual.to(aq.dtype),
+                acc=result,
+                out_dtype=torch.float32,
+            )
+            hl.store(
+                output_rows,
+                [row, tile_v],
+                result * scale,
+                extra_mask=valid[:, None],
+            )
+
+            decay = gt_rows[
+                tile_head.id * total_chunks + global_chunk,
+                :,
+            ]
+            ak_value = ak_rows[
+                (factor_base + (token_tile.index ^ 8))[:, None],
+                feature[None, :],
+            ]
+            update = hl.dot(
+                residual.T.to(ak.dtype),
+                ak_value,
+                out_dtype=torch.float32,
+            )
+            state_value = _bf16(state_value * decay[None, :] + update)
+
+        state[
+            tile_sequence.id,
+            tile_head.id,
+            tile_v.index,
+            :,
+        ] = state_value.to(state.dtype)
+
+    return output, state
+
+
+__all__ = [
+    "BT",
+    "CPC",
+    "DK",
+    "DV",
+    "KDA_PREPARE_CONFIG",
+    "KDA_RECURRENCE_CONFIG",
+    "kda_chunk_prepare",
+    "kda_chunk_recurrence",
+]

--- a/benchmarks/cute/kda_prefill_staged.py
+++ b/benchmarks/cute/kda_prefill_staged.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import accumulate
+from itertools import pairwise
+import operator
+from typing import TYPE_CHECKING
+from typing import Literal
+from typing import TypeVar
+from typing import cast
+
+from benchmarks.cute.kda_prefill_kernels import BT
+from benchmarks.cute.kda_prefill_kernels import DK
+from benchmarks.cute.kda_prefill_kernels import kda_chunk_prepare
+from benchmarks.cute.kda_prefill_kernels import kda_chunk_recurrence
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Sequence
+
+
+_REGION_ALIGNMENT = 256
+_R = TypeVar("_R")
+KdaStagedTopology = Literal["origin_aux", "serial"]
+
+
+@dataclass(frozen=True)
+class StagedLongestPartition:
+    """Stable longest-segment partition of cumulative sequence offsets."""
+
+    offsets: tuple[int, ...]
+    longest_sequence: int
+    rest_ranges: tuple[tuple[int, int], ...]
+
+    @property
+    def longest_range(self) -> tuple[int, int]:
+        return self.longest_sequence, self.longest_sequence + 1
+
+
+def staged_longest_partition(offsets: Sequence[int]) -> StagedLongestPartition:
+    """Split cumulative offsets into the longest segment and contiguous rest.
+
+    Ties are resolved by sequence order. The returned rest ranges preserve
+    contiguity, so callers can build zero-copy views or local metadata for the
+    ranges before CUDA graph capture.
+    """
+
+    try:
+        normalized = tuple(operator.index(value) for value in offsets)
+    except TypeError as error:
+        raise TypeError("offsets must contain integers") from error
+    if len(normalized) < 2:
+        raise ValueError("offsets must describe at least one segment")
+    if any(end < begin for begin, end in pairwise(normalized)):
+        raise ValueError("offsets must be nondecreasing")
+    if any(end == begin for begin, end in pairwise(normalized)):
+        raise ValueError("offsets must describe nonempty segments")
+
+    longest_sequence = max(
+        range(len(normalized) - 1),
+        key=lambda index: normalized[index + 1] - normalized[index],
+    )
+    rest_ranges = tuple(
+        sequence_range
+        for sequence_range in (
+            (0, longest_sequence),
+            (longest_sequence + 1, len(normalized) - 1),
+        )
+        if sequence_range[0] < sequence_range[1]
+    )
+    return StagedLongestPartition(normalized, longest_sequence, rest_ranges)
+
+
+@dataclass
+class CuteOriginAuxDag:
+    """Resources for a reusable prefix -> origin/auxiliary CUDA launch DAG.
+
+    Create one instance per independently captured graph slot and keep it alive
+    for the graph's lifetime. ``launch`` enqueues the prefix on the current
+    stream, gives the origin branch launch priority, runs the auxiliary branch
+    on the owned stream, and joins that branch back to the origin stream.
+    """
+
+    auxiliary_stream: torch.cuda.Stream
+    fork_event: torch.cuda.Event
+    done_event: torch.cuda.Event
+
+    @classmethod
+    def create(cls, device: torch.device | int | None = None) -> CuteOriginAuxDag:
+        return cls(
+            auxiliary_stream=torch.cuda.Stream(device=device),
+            fork_event=torch.cuda.Event(enable_timing=False),
+            done_event=torch.cuda.Event(enable_timing=False),
+        )
+
+    def launch(
+        self,
+        prefix: Callable[[], object],
+        origin_branch: Callable[[], _R],
+        auxiliary_branch: Callable[[], object],
+    ) -> _R:
+        with torch.cuda.device(self.auxiliary_stream.device):
+            origin_stream = torch.cuda.current_stream()
+            prefix()
+            self.fork_event.record(origin_stream)
+            self.auxiliary_stream.wait_event(self.fork_event)
+
+            result = origin_branch()
+            with torch.cuda.stream(self.auxiliary_stream):
+                auxiliary_branch()
+                self.done_event.record()
+            origin_stream.wait_event(self.done_event)
+            return result
+
+
+@dataclass(frozen=True)
+class KdaGroupHostMetadata:
+    """Host metadata for one contiguous range of packed sequences."""
+
+    sequence_range: tuple[int, int]
+    cu_seqlens: tuple[int, ...]
+    cu_chunks: tuple[int, ...]
+    chunk_to_seq: tuple[int, ...]
+
+    @property
+    def total_chunks(self) -> int:
+        return self.cu_chunks[-1]
+
+
+@dataclass(frozen=True)
+class KdaGroupMetadata:
+    """Device metadata and its immutable graph-cache identity."""
+
+    host: KdaGroupHostMetadata
+    cu_seqlens: torch.Tensor
+    cu_chunks: torch.Tensor
+    chunk_to_seq: torch.Tensor
+
+
+@dataclass(frozen=True)
+class KdaFactorWorkspace:
+    """Five factor views over one aligned packed allocation."""
+
+    storage: torch.Tensor
+    kd: torch.Tensor
+    qd: torch.Tensor
+    ak: torch.Tensor
+    aq: torch.Tensor
+    g_total: torch.Tensor
+
+
+@dataclass(frozen=True)
+class KdaStagedGroup:
+    metadata: KdaGroupMetadata
+    workspace: KdaFactorWorkspace
+
+
+@dataclass
+class KdaStagedResources:
+    """Per-graph-slot resources for staged packed KDA prefill."""
+
+    critical: KdaStagedGroup
+    auxiliary: tuple[KdaStagedGroup, ...]
+    dag: CuteOriginAuxDag
+
+
+def kda_group_host_metadata(
+    offsets: Sequence[int], sequence_range: tuple[int, int]
+) -> KdaGroupHostMetadata:
+    """Build local chunk ordinals while retaining global token offsets."""
+
+    partition = staged_longest_partition(offsets)
+    sequence_begin, sequence_end = sequence_range
+    sequence_count = len(partition.offsets) - 1
+    if not 0 <= sequence_begin < sequence_end <= sequence_count:
+        raise ValueError(
+            f"invalid sequence range {sequence_range!r} for {sequence_count} sequences"
+        )
+
+    cu_seqlens = partition.offsets[sequence_begin : sequence_end + 1]
+    chunk_counts = tuple(
+        (end - begin + BT - 1) // BT for begin, end in pairwise(cu_seqlens)
+    )
+    cu_chunks = (0, *accumulate(chunk_counts))
+    chunk_to_seq = tuple(
+        local_sequence
+        for local_sequence, chunk_count in enumerate(chunk_counts)
+        for _ in range(chunk_count)
+    )
+    return KdaGroupHostMetadata(
+        sequence_range=sequence_range,
+        cu_seqlens=cu_seqlens,
+        cu_chunks=cu_chunks,
+        chunk_to_seq=chunk_to_seq,
+    )
+
+
+def materialize_kda_group_metadata(
+    host: KdaGroupHostMetadata, device: torch.device | str
+) -> KdaGroupMetadata:
+    """Materialize immutable group metadata before graph capture."""
+
+    return KdaGroupMetadata(
+        host=host,
+        cu_seqlens=torch.tensor(host.cu_seqlens, dtype=torch.int32, device=device),
+        cu_chunks=torch.tensor(host.cu_chunks, dtype=torch.int32, device=device),
+        chunk_to_seq=torch.tensor(host.chunk_to_seq, dtype=torch.int32, device=device),
+    )
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) // alignment * alignment
+
+
+def allocate_kda_factor_workspace(
+    heads: int, total_chunks: int, device: torch.device | str
+) -> KdaFactorWorkspace:
+    """Allocate the exact packed v2 workspace layout used by both kernels."""
+
+    rows = total_chunks * BT
+    vector_bytes = heads * rows * DK * 2
+    aq_bytes = heads * total_chunks * BT * BT * 2
+    g_total_bytes = heads * total_chunks * DK * 4
+    sizes = (vector_bytes, vector_bytes, vector_bytes, aq_bytes, g_total_bytes)
+    offsets: list[int] = []
+    cursor = 0
+    for size in sizes:
+        cursor = _align_up(cursor, _REGION_ALIGNMENT)
+        offsets.append(cursor)
+        cursor += size
+    size = _align_up(cursor, _REGION_ALIGNMENT)
+    raw = torch.empty(size + _REGION_ALIGNMENT, dtype=torch.uint8, device=device)
+    pad = (-raw.data_ptr()) % _REGION_ALIGNMENT
+    storage = raw[pad : pad + size]
+
+    def view(index: int, dtype: torch.dtype, shape: tuple[int, ...]) -> torch.Tensor:
+        offset = offsets[index]
+        return storage[offset : offset + sizes[index]].view(dtype).view(shape)
+
+    return KdaFactorWorkspace(
+        storage=storage,
+        kd=view(0, torch.bfloat16, (1, heads, rows, DK)),
+        qd=view(1, torch.bfloat16, (1, heads, rows, DK)),
+        ak=view(2, torch.bfloat16, (1, heads, rows, DK)),
+        aq=view(3, torch.bfloat16, (1, heads, total_chunks, BT * BT)),
+        g_total=view(4, torch.float32, (1, heads, total_chunks, DK)),
+    )
+
+
+def create_staged_kda_resources(
+    offsets: Sequence[int],
+    *,
+    heads: int,
+    device: torch.device | str,
+) -> KdaStagedResources:
+    """Create metadata, private workspaces, and DAG state for one graph slot."""
+
+    partition = staged_longest_partition(offsets)
+
+    def create_group(sequence_range: tuple[int, int]) -> KdaStagedGroup:
+        metadata = materialize_kda_group_metadata(
+            kda_group_host_metadata(partition.offsets, sequence_range), device
+        )
+        workspace = allocate_kda_factor_workspace(
+            heads, metadata.host.total_chunks, device
+        )
+        return KdaStagedGroup(metadata, workspace)
+
+    return KdaStagedResources(
+        critical=create_group(partition.longest_range),
+        auxiliary=tuple(create_group(item) for item in partition.rest_ranges),
+        dag=CuteOriginAuxDag.create(torch.device(device)),
+    )
+
+
+def launch_staged_kda_prefill(
+    resources: KdaStagedResources,
+    *,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    gate: torch.Tensor,
+    beta_logits: torch.Tensor,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    values: torch.Tensor,
+    output: torch.Tensor,
+    state: torch.Tensor,
+    scale: float,
+    gate_scale_log2: float,
+    topology: KdaStagedTopology = "origin_aux",
+    prepare_kernels: Sequence[Callable[..., object]] | None = None,
+    recurrence_kernels: Sequence[Callable[..., object]] | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Launch the staged longest-sequence KDA pipeline into caller storage.
+
+    ``state`` must be in packed sequence order. Inputs and output keep their
+    global token indexing; only factor workspaces and chunk ordinals are local
+    to each contiguous sequence group.
+    """
+
+    groups = (resources.critical, *resources.auxiliary)
+    if prepare_kernels is None:
+        prepare_kernels = (kda_chunk_prepare,) * len(groups)
+    if recurrence_kernels is None:
+        recurrence_kernels = (kda_chunk_recurrence,) * len(groups)
+    if len(prepare_kernels) != len(groups) or len(recurrence_kernels) != len(groups):
+        raise ValueError("one prepare and recurrence kernel are required per group")
+
+    def prepare(group: KdaStagedGroup, kernel: Callable[..., object]) -> None:
+        metadata = group.metadata
+        workspace = group.workspace
+        kernel(
+            q,
+            k,
+            gate,
+            beta_logits,
+            a_log,
+            dt_bias,
+            metadata.cu_seqlens,
+            metadata.cu_chunks,
+            metadata.chunk_to_seq,
+            workspace.kd,
+            workspace.qd,
+            workspace.ak,
+            workspace.aq,
+            workspace.g_total,
+            None,
+            gate_scale_log2,
+        )
+
+    def recurrence(
+        group: KdaStagedGroup, kernel: Callable[..., object]
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        metadata = group.metadata
+        workspace = group.workspace
+        sequence_begin, sequence_end = metadata.host.sequence_range
+        result = kernel(
+            workspace.kd,
+            workspace.qd,
+            workspace.ak,
+            workspace.aq,
+            workspace.g_total,
+            values,
+            output,
+            state[sequence_begin:sequence_end],
+            metadata.cu_seqlens,
+            metadata.cu_chunks,
+            scale,
+        )
+        if not isinstance(result, tuple) or len(result) != 2:
+            raise TypeError("recurrence kernel must return (output, state)")
+        return cast("tuple[torch.Tensor, torch.Tensor]", result)
+
+    if topology not in ("origin_aux", "serial"):
+        raise ValueError(f"unsupported staged KDA topology: {topology!r}")
+    if topology == "origin_aux" and len(resources.auxiliary) > 1:
+        raise ValueError(
+            "origin_aux topology supports at most one contiguous auxiliary range; "
+            "use serial when the longest sequence is interior"
+        )
+
+    if topology == "serial" or not resources.auxiliary:
+        for group, prepare_kernel, recurrence_kernel in zip(
+            groups, prepare_kernels, recurrence_kernels, strict=True
+        ):
+            prepare(group, prepare_kernel)
+            recurrence(group, recurrence_kernel)
+        return output, state
+
+    critical = resources.critical
+
+    def auxiliary_branch() -> None:
+        for group, prepare_kernel, recurrence_kernel in zip(
+            resources.auxiliary,
+            prepare_kernels[1:],
+            recurrence_kernels[1:],
+            strict=True,
+        ):
+            prepare(group, prepare_kernel)
+            recurrence(group, recurrence_kernel)
+
+    resources.dag.launch(
+        lambda: prepare(critical, prepare_kernels[0]),
+        lambda: recurrence(critical, recurrence_kernels[0]),
+        auxiliary_branch,
+    )
+    return output, state
+
+
+__all__ = [
+    "CuteOriginAuxDag",
+    "KdaFactorWorkspace",
+    "KdaGroupHostMetadata",
+    "KdaGroupMetadata",
+    "KdaStagedGroup",
+    "KdaStagedResources",
+    "KdaStagedTopology",
+    "StagedLongestPartition",
+    "allocate_kda_factor_workspace",
+    "create_staged_kda_resources",
+    "kda_group_host_metadata",
+    "launch_staged_kda_prefill",
+    "materialize_kda_group_metadata",
+    "staged_longest_partition",
+]

--- a/test/test_compare_kda_prefill_backends.py
+++ b/test/test_compare_kda_prefill_backends.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import inspect
+import sys
+from types import ModuleType
+from types import SimpleNamespace
+
+from benchmarks.cute import compare_kda_prefill_backends as prefill
+import pytest
+import torch
+
+
+def _inputs() -> prefill.KDAInputs:
+    value = torch.ones(1)
+    return prefill.KDAInputs(
+        q=value,
+        k=value,
+        v=value,
+        raw_gate=value,
+        raw_beta=value,
+        a_log=value,
+        dt_bias=value,
+        initial_state=value.clone(),
+        cu_seqlens=None,
+    )
+
+
+def test_clone_mutable_shares_inputs_and_clones_only_state() -> None:
+    inputs = _inputs()
+    clone = inputs.clone_mutable()
+
+    assert clone.q is inputs.q
+    assert clone.k is inputs.k
+    assert clone.v is inputs.v
+    assert clone.raw_gate is inputs.raw_gate
+    assert clone.raw_beta is inputs.raw_beta
+    assert clone.initial_state is not inputs.initial_state
+    torch.testing.assert_close(clone.initial_state, inputs.initial_state)
+
+
+def test_surface_contains_only_reportable_cases_and_providers() -> None:
+    assert tuple(prefill.CASES) == ("h12_fixed_512", "h12_packed_mixed")
+    assert tuple(prefill.CASES) == prefill.OFFICIAL_CASES
+    assert prefill.IMPLEMENTATIONS == (
+        "helion-cute",
+        "flashinfer-cake",
+        "flashinfer-cute",
+    )
+    assert prefill.CASES["h12_fixed_512"].seq_lens == (512,)
+    assert prefill.CASES["h12_packed_mixed"].seq_lens == (
+        1300,
+        547,
+        2048,
+        963,
+        271,
+        3063,
+    )
+    assert all(
+        case.expected_cake_variant == "bt16_prepare_chain_m64"
+        for case in prefill.CASES.values()
+    )
+    assert {
+        name: config.as_dict() for name, config in prefill.PINNED_HELION_CONFIGS.items()
+    } == {
+        "h12_fixed_512": {
+            "staged_topology": "serial",
+            "critical_prepare_schedule": "split_alias_cpc1",
+            "recurrence_dv_partitions": 4,
+            "recurrence_register_cap": None,
+        },
+        "h12_packed_mixed": {
+            "staged_topology": "origin_aux",
+            "critical_prepare_schedule": "split_alias_cpc2",
+            "auxiliary_prepare_schedule": "split_alias_cpc2",
+            "recurrence_dv_partitions": 2,
+            "recurrence_register_cap": None,
+        },
+    }
+
+
+def test_executable_surface_is_self_contained_and_fixed(tmp_path) -> None:
+    parser = prefill._build_parser()
+    args = parser.parse_args(
+        [
+            "--paired-cuda-graph",
+            "--flashinfer-root",
+            str(tmp_path / "flashinfer"),
+        ]
+    )
+
+    prefill._validate_args(parser, args)
+    assert args.cases == ",".join(prefill.OFFICIAL_CASES)
+    assert args.impls == ",".join(prefill.IMPLEMENTATIONS)
+    assert "run_kda_prefill_cold_autotune" not in inspect.getsource(prefill.main)
+
+
+def test_flashinfer_provenance_covers_cake_and_cute_sources(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured = {}
+
+    def fake_git_files(root, pathspecs):
+        captured["pathspecs"] = pathspecs
+        return {
+            "flashinfer/kda_kernels/kda_chunked_bt16.py": (
+                root / "flashinfer/kda_kernels/kda_chunked_bt16.py"
+            )
+        }
+
+    monkeypatch.setattr(prefill, "_git_files", fake_git_files)
+    sources = prefill._flashinfer_sources(tmp_path)
+
+    assert captured["pathspecs"] == (
+        "csrc/kda",
+        "flashinfer/cute_dsl",
+        "flashinfer/kda_kernels",
+    )
+    assert "flashinfer/kda_prefill.py" in sources
+    assert "flashinfer/kda_prefill_cute.py" in sources
+    assert "flashinfer/kda_kernels/kda_chunked_bt16.py" in sources
+
+
+@pytest.mark.parametrize(
+    "prefill_case", prefill.CASES.values(), ids=lambda case: case.name
+)
+def test_semantic_metadata_records_reportable_contract(prefill_case) -> None:
+    metadata = prefill._semantic_metadata(prefill_case)
+
+    assert metadata["qk_l2norm_epsilon"] == 1.0e-24
+    assert metadata["gate_mode"] == "lower-bound-sigmoid"
+    assert metadata["canonical_state_dtype"] == "bfloat16"
+    assert metadata["timing"] == "one-call-captured-graph-cuda-events-with-cold-l2"
+    assert metadata["mutation_isolation"] == (
+        "private-state-and-output-per-captured-graph"
+    )
+
+
+def test_loader_rejects_preloaded_namespace_from_another_checkout(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    name = "test_kda_prefill_namespace"
+    existing = ModuleType(name)
+    existing.__path__ = [str(tmp_path / "wrong")]  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, name, existing)
+
+    with pytest.raises(ImportError, match="outside the requested checkout"):
+        prefill._install_namespace(name, tmp_path / "expected")
+
+
+def test_loader_rejects_preloaded_module_from_another_checkout(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    name = "test_kda_prefill_module"
+    existing = ModuleType(name)
+    existing.__file__ = str(tmp_path / "wrong.py")
+    monkeypatch.setitem(sys.modules, name, existing)
+
+    with pytest.raises(ImportError, match="outside the requested checkout"):
+        prefill._load_module(name, tmp_path / "expected.py")
+
+
+def test_safe_gate_route_accepts_only_combined_or_prepare_chain() -> None:
+    assert prefill._resolve_safe_gate_modules(
+        [{"variant": "bt16_prepare_chain_m64_s8", "target": "sm100"}]
+    ) == (
+        "bt16_prepare_chain_m64",
+        "sm100",
+        ["bt16_prepare_chain_m64_s8"],
+    )
+    assert prefill._resolve_safe_gate_modules(
+        [
+            {"variant": "bt16_prepare_beta_tma", "target": "sm100"},
+            {"variant": "bt16_chain_m64_s9", "target": "sm100"},
+        ]
+    ) == (
+        "bt16_prepare_chain_m64",
+        "sm100",
+        ["bt16_prepare_beta_tma", "bt16_chain_m64_s9"],
+    )
+    with pytest.raises(AssertionError, match="ordered BT16 prepare/chain"):
+        prefill._resolve_safe_gate_modules(
+            [{"variant": "m128_h12_long", "target": "sm100"}]
+        )
+
+
+def test_flashinfer_invocation_forwards_the_canonical_contract() -> None:
+    calls = []
+
+    class FlashInfer:
+        @staticmethod
+        def recurrent_kda(**kwargs):
+            calls.append(kwargs)
+            return kwargs["output"], None
+
+    inputs = _inputs()
+    output = torch.empty_like(inputs.v)
+    result_output, result_state = prefill._invoke_flashinfer(
+        FlashInfer(), prefill.CASES["h12_fixed_512"], "cake"
+    )(inputs, output)
+
+    assert result_output is output
+    assert result_state is inputs.initial_state
+    assert calls == [
+        {
+            "q": inputs.q,
+            "k": inputs.k,
+            "v": inputs.v,
+            "g": inputs.raw_gate,
+            "beta": inputs.raw_beta,
+            "A_log": inputs.a_log,
+            "dt_bias": inputs.dt_bias,
+            "scale": prefill.HEAD_DIM**-0.5,
+            "initial_state": inputs.initial_state,
+            "output_final_state": False,
+            "use_qk_l2norm_in_kernel": True,
+            "use_gate_in_kernel": True,
+            "lower_bound": prefill.SAFE_LOWER_BOUND,
+            "cu_seqlens": None,
+            "ssm_state_indices": None,
+            "output": output,
+            "beta_is_logit": True,
+            "state_checkpoints": None,
+            "checkpoint_cu_starts": None,
+            "checkpoint_every_n_tokens": 0,
+            "backend": "cake",
+        }
+    ]
+
+
+def test_route_recorder_validates_cake_module_and_target() -> None:
+    prefill_module = SimpleNamespace(
+        _get_flash_kda_prefill_module=lambda variant, target: object(),
+        _select_flash_kda_prefill_target=lambda _device: "sm100",
+    )
+    cute_module = SimpleNamespace(_run_cute_dsl_kda_prefill=lambda **_kwargs: None)
+    module = SimpleNamespace(
+        _kda_prefill=prefill_module,
+        _kda_prefill_cute=cute_module,
+    )
+    inputs = _inputs()
+    metadata = {}
+
+    def invoke(call_inputs, output):
+        module._kda_prefill._get_flash_kda_prefill_module(
+            "bt16_prepare_chain_m64_s8", "sm100"
+        )
+        return output, call_inputs.initial_state
+
+    wrapped = prefill._record_flashinfer_route(
+        module,
+        invoke,
+        metadata,
+        case=prefill.CASES["h12_fixed_512"],
+        expected_route="cake-safe-gate",
+    )
+    wrapped(inputs, torch.empty_like(inputs.v))
+
+    assert metadata["resolved_route"] == "cake-safe-gate"
+    assert metadata["cake_logical_variant"] == "bt16_prepare_chain_m64"
+    assert metadata["cake_target"] == "sm100"
+    assert metadata["cake_physical_variants"] == ["bt16_prepare_chain_m64_s8"]

--- a/test/test_kda_decode_benchmarks.py
+++ b/test/test_kda_decode_benchmarks.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+import subprocess
+import sys
+from types import SimpleNamespace
+
+from benchmarks.cute import compare_kda_decode_backends as packed
+from benchmarks.cute import compare_kda_recurrent_backends as recurrent
+from benchmarks.cute import kda_benchmark_utils as benchmark_utils
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_benchmark_imports_resolve_inside_checkout() -> None:
+    for module in (packed, recurrent, benchmark_utils):
+        assert module.__file__ is not None
+        assert Path(module.__file__).resolve().is_relative_to(REPO_ROOT)
+    assert packed.helion.__file__ is not None
+    assert Path(packed.helion.__file__).resolve().is_relative_to(REPO_ROOT)
+
+
+@pytest.mark.parametrize(
+    "script",
+    (
+        "compare_kda_decode_backends.py",
+        "compare_kda_recurrent_backends.py",
+    ),
+)
+def test_benchmark_direct_entrypoint_imports_clean_checkout(
+    script: str, tmp_path: Path
+) -> None:
+    subprocess.run(
+        [sys.executable, str(REPO_ROOT / "benchmarks" / "cute" / script), "--help"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_sglang_policy_constant_is_read_from_pinned_source(tmp_path: Path) -> None:
+    source = tmp_path / "__init__.py"
+    source.write_text("KDA_SMALL_VALUE_HEAD_THRESHOLD = 17\n")
+    assert (
+        packed._read_source_int_constant(source, "KDA_SMALL_VALUE_HEAD_THRESHOLD") == 17
+    )
+    source.write_text("KDA_SMALL_VALUE_HEAD_THRESHOLD = compute_threshold()\n")
+    with pytest.raises(ValueError, match="expected one literal integer"):
+        packed._read_source_int_constant(source, "KDA_SMALL_VALUE_HEAD_THRESHOLD")
+
+
+def test_paired_graph_order_is_balanced() -> None:
+    assert benchmark_utils.paired_graph_order(0, "baseline", "candidate") == (
+        "baseline",
+        "candidate",
+        "candidate",
+        "baseline",
+    )
+    assert benchmark_utils.paired_graph_order(1, "baseline", "candidate") == (
+        "candidate",
+        "baseline",
+        "baseline",
+        "candidate",
+    )
+
+
+def test_source_provenance_includes_untracked_python(tmp_path: Path) -> None:
+    subprocess.run(("git", "init", "-q"), cwd=tmp_path, check=True)
+    package = tmp_path / "package"
+    package.mkdir()
+    tracked = package / "tracked.py"
+    tracked.write_text("VALUE = 1\n")
+    subprocess.run(("git", "add", "package/tracked.py"), cwd=tmp_path, check=True)
+    subprocess.run(
+        (
+            "git",
+            "-c",
+            "user.name=KDA Test",
+            "-c",
+            "user.email=kda@example.invalid",
+            "commit",
+            "-qm",
+            "initial",
+        ),
+        cwd=tmp_path,
+        check=True,
+    )
+    clean = benchmark_utils.source_provenance(
+        tmp_path, {"tracked": tracked}, pathspecs=("package",)
+    )
+    (package / "untracked.py").write_text("VALUE = 2\n")
+    dirty = benchmark_utils.source_provenance(
+        tmp_path, {"tracked": tracked}, pathspecs=("package",)
+    )
+
+    assert clean["dirty"] is False
+    assert dirty["dirty"] is True
+    assert dirty["status_includes_untracked"] is True
+    assert dirty["untracked_python_sha256"] != clean["untracked_python_sha256"]
+
+
+def test_source_provenance_scopes_untracked_python(tmp_path: Path) -> None:
+    subprocess.run(("git", "init", "-q"), cwd=tmp_path, check=True)
+    package = tmp_path / "package"
+    package.mkdir()
+    tracked = package / "tracked.py"
+    tracked.write_text("VALUE = 1\n")
+    subprocess.run(("git", "add", "package/tracked.py"), cwd=tmp_path, check=True)
+    subprocess.run(
+        (
+            "git",
+            "-c",
+            "user.name=KDA Test",
+            "-c",
+            "user.email=kda@example.invalid",
+            "commit",
+            "-qm",
+            "initial",
+        ),
+        cwd=tmp_path,
+        check=True,
+    )
+    clean = benchmark_utils.source_provenance(
+        tmp_path, {"tracked": tracked}, pathspecs=("package",)
+    )
+    (tmp_path / "outside.py").write_text("VALUE = 2\n")
+    unchanged = benchmark_utils.source_provenance(
+        tmp_path, {"tracked": tracked}, pathspecs=("package",)
+    )
+
+    assert unchanged["dirty"] is False
+    assert unchanged["untracked_python_sha256"] == clean["untracked_python_sha256"]
+
+
+def _fake_bound(source: str, compiled_hash: str | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        _run=object(),
+        env=SimpleNamespace(
+            backend=SimpleNamespace(
+                generated_source_hash=lambda compiled: compiled_hash
+            )
+        ),
+        to_triton_code=lambda config: source,
+    )
+
+
+def test_generated_wrapper_verification_records_exact_source_identity() -> None:
+    source = "expected_plan_abi_version = 7\n_bf16x2_12_abi_version = 1\n"
+    source_hash = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    identity = benchmark_utils.verify_helion_generated_wrapper(
+        _fake_bound(source, source_hash),
+        object(),
+        expected_plan_kind="expected-plan",
+        expected_source_markers=("expected_plan_abi_version = 7",),
+        expected_source_patterns=(r"_bf16x2_[0-9]+_abi_version = 1",),
+    )
+
+    assert identity["plan_kind"] == "expected-plan"
+    assert identity["source_sha256"] == source_hash
+    assert identity["source_marker_counts"] == {"expected_plan_abi_version = 7": 1}
+    assert identity["source_pattern_counts"] == {r"_bf16x2_[0-9]+_abi_version = 1": 1}
+    assert identity["compiled_source_identity_verified"] is True
+
+
+def test_generated_wrapper_verification_accepts_direct_compiled_callable() -> None:
+    source = "expected_plan_abi_version = 7\n"
+    source_hash = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    bound = _fake_bound(source, source_hash)
+    bound._run = None
+
+    identity = benchmark_utils.verify_helion_generated_wrapper(
+        bound,
+        object(),
+        expected_plan_kind="expected-plan",
+        expected_source_markers=("expected_plan_abi_version = 7",),
+        compiled_fn=object(),
+    )
+
+    assert identity["compiled_source_identity_verified"] is True
+
+
+@pytest.mark.parametrize(
+    ("compiled_hash", "marker", "match"),
+    (
+        ("wrong-hash", "expected_plan_abi_version = 7", "identity mismatch"),
+        (None, "expected_plan_abi_version = 7", "identity mismatch"),
+        ("source-hash", "missing_plan_abi_version = 1", "markers"),
+    ),
+)
+def test_generated_wrapper_verification_rejects_unproven_plan(
+    compiled_hash: str | None, marker: str, match: str
+) -> None:
+    source = "expected_plan_abi_version = 7\n"
+    source_hash = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    resolved_hash = source_hash if compiled_hash == "source-hash" else compiled_hash
+    with pytest.raises(RuntimeError, match=match):
+        benchmark_utils.verify_helion_generated_wrapper(
+            _fake_bound(source, resolved_hash),
+            object(),
+            expected_plan_kind="expected-plan",
+            expected_source_markers=(marker,),
+        )
+
+
+@pytest.mark.parametrize(
+    ("batch_size", "config", "expected"),
+    (
+        (
+            1,
+            {},
+            ("single-token-rank1", ("rank1_helper_abi_version = 4",), ()),
+        ),
+        (
+            256,
+            {
+                "block_sizes": [128],
+                "cute_async_load_stages": 5,
+                "cute_async_load_group_rows": 2,
+                "cute_async_store_policy": "l2_evict_last",
+                "cute_bf16x2_recurrence": True,
+                "cute_vector_widths": [8, 1, 1, 1],
+                "num_threads": [8, 16],
+            },
+            (
+                "generic-async-state-ring-bf16x2",
+                (
+                    (
+                        "from helion._compiler.cute.l2_policy import "
+                        "store_u32x4_l2_evict_last as "
+                        "_cute_store_u32x4_l2_evict_last"
+                    ),
+                    "cute.arch.cp_async_wait_group(0)",
+                ),
+                (
+                    (
+                        r"_async_state_[0-9]+_smem = "
+                        r"cutlass\.Array\(cutlass\.Uint16, 10240, "
+                        r"space=cutlass\.AddressSpace\.smem, alignment=128\)"
+                    ),
+                    (
+                        r"_async_state_[0-9]+_scalar_pairs = "
+                        r"cute\.make_rmem_tensor\(8, cutlass\.Uint32\)"
+                    ),
+                    r"_bf16x2_[0-9]+_abi_version = 1",
+                    r"_cute_store_u32x4_l2_evict_last\(.*\)",
+                ),
+            ),
+        ),
+        (
+            256,
+            {
+                "cute_async_load_stages": 0,
+                "cute_async_store_policy": "default",
+                "cute_bf16x2_recurrence": False,
+            },
+            ("generic-decode", ("@cute.kernel",), ()),
+        ),
+        (
+            256,
+            {
+                "block_sizes": [128],
+                "cute_async_load_stages": 4,
+                "cute_async_load_group_rows": 2,
+                "cute_async_store_policy": "l2_evict_last",
+                "cute_bf16x2_recurrence": True,
+                "cute_vector_widths": [8, 1, 1, 1],
+                "num_threads": [8, 16],
+            },
+            ("generic-decode", ("@cute.kernel",), ()),
+        ),
+    ),
+)
+def test_packed_codegen_expectations_cover_claimed_rows(
+    batch_size: int,
+    config: dict[str, object],
+    expected: tuple[str, tuple[str, ...], tuple[str, ...]],
+) -> None:
+    assert packed._helion_codegen_expectation(batch_size, config) == expected
+
+
+@pytest.mark.parametrize(
+    ("case_name", "expected"),
+    (
+        (
+            "t1-unbounded-b15-h32",
+            (
+                "split-single-token-rank1",
+                (
+                    "split_t1_codegen_abi_version = 1",
+                    "split_t1_rank1_helper_abi_version = 4",
+                ),
+            ),
+        ),
+        (
+            "t3-lower-bound-n8-h16",
+            (
+                "fixed-token-rank1",
+                (
+                    "fixed_rank1_codegen_abi_version = 3",
+                    "fixed_rank1_rank1_helper_abi_version = 4",
+                ),
+            ),
+        ),
+    ),
+)
+def test_recurrent_codegen_expectations_cover_claimed_rows(
+    case_name: str, expected: tuple[str, tuple[str, ...]]
+) -> None:
+    assert recurrent._helion_codegen_expectation(recurrent.CASES[case_name]) == expected
+
+
+def test_cli_scope_is_only_canonical_paired_comparisons() -> None:
+    assert packed.DEFAULT_BATCH_SIZES == (1, 256)
+    assert packed.IMPLEMENTATIONS == ("flashinfer-cake", "helion-cute")
+    assert tuple(recurrent.CASES) == recurrent.DEFAULT_CASES
+    assert recurrent.IMPLEMENTATIONS == ("flashinfer-cute", "helion-cute")
+
+
+@pytest.mark.parametrize(
+    "value",
+    ('{"num_warps": 4, "num_warps": 8}', '{"num_warps": NaN}', "[]"),
+)
+def test_config_parser_rejects_ambiguous_json(value: str) -> None:
+    with pytest.raises(ValueError):
+        benchmark_utils.canonical_config_json(value, "test config")
+
+
+def test_recurrent_config_map_uses_strict_json(tmp_path: Path) -> None:
+    config_map = tmp_path / "configs.json"
+    config_map.write_text('{"t1-unbounded-b15-h32": {"num_warps": 4, "num_warps": 8}}')
+    with pytest.raises(ValueError, match="duplicate key"):
+        recurrent._load_helion_config_map(config_map)

--- a/test/test_kda_prefill_staged.py
+++ b/test/test_kda_prefill_staged.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+
+from benchmarks.cute import kda_prefill_staged
+from benchmarks.cute.kda_prefill_staged import CuteOriginAuxDag
+from benchmarks.cute.kda_prefill_staged import KdaStagedResources
+from benchmarks.cute.kda_prefill_staged import allocate_kda_factor_workspace
+from benchmarks.cute.kda_prefill_staged import kda_group_host_metadata
+from benchmarks.cute.kda_prefill_staged import staged_longest_partition
+import pytest
+import torch
+
+
+@pytest.mark.parametrize(
+    ("offsets", "longest", "rest"),
+    (
+        ((0, 3), 0, ()),
+        ((0, 4, 7, 12), 2, ((0, 2),)),
+        ((11, 14, 20, 22), 1, ((0, 1), (2, 3))),
+        ((0, 5, 10), 0, ((1, 2),)),
+    ),
+)
+def test_staged_longest_partition(
+    offsets: tuple[int, ...],
+    longest: int,
+    rest: tuple[tuple[int, int], ...],
+) -> None:
+    plan = staged_longest_partition(offsets)
+
+    assert plan.longest_sequence == longest
+    assert plan.longest_range == (longest, longest + 1)
+    assert plan.rest_ranges == rest
+
+
+@pytest.mark.parametrize("offsets", ((), (0,), (0, 2, 1), (0, 5, 5), (0, 0, 0)))
+def test_staged_longest_partition_rejects_invalid_offsets(
+    offsets: tuple[int, ...],
+) -> None:
+    with pytest.raises(ValueError):
+        staged_longest_partition(offsets)
+
+
+def test_staged_longest_partition_rejects_non_integer_offsets() -> None:
+    with pytest.raises(TypeError, match="must contain integers"):
+        staged_longest_partition((0, 1.5))  # type: ignore[arg-type]
+
+
+def test_cute_origin_aux_dag_launch_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    operations: list[str] = []
+
+    class FakeStream:
+        device = torch.device("cuda", 0)
+
+        def wait_event(self, event: Any) -> None:
+            operations.append(f"aux_wait:{event.name}")
+
+    class FakeOriginStream:
+        def wait_event(self, event: Any) -> None:
+            operations.append(f"origin_wait:{event.name}")
+
+    class FakeEvent:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def record(self, stream: Any = None) -> None:
+            operations.append(
+                f"record:{self.name}:{'current' if stream is None else 'origin'}"
+            )
+
+    auxiliary_stream = FakeStream()
+    origin_stream = FakeOriginStream()
+
+    @contextmanager
+    def use_stream(stream: Any):
+        assert stream is auxiliary_stream
+        operations.append("enter_aux")
+        try:
+            yield
+        finally:
+            operations.append("exit_aux")
+
+    @contextmanager
+    def use_device(device: Any):
+        assert device == auxiliary_stream.device
+        operations.append("enter_device")
+        try:
+            yield
+        finally:
+            operations.append("exit_device")
+
+    monkeypatch.setattr(torch.cuda, "device", use_device)
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: origin_stream)
+    monkeypatch.setattr(torch.cuda, "stream", use_stream)
+    dag = CuteOriginAuxDag(
+        auxiliary_stream=auxiliary_stream,  # type: ignore[arg-type]
+        fork_event=FakeEvent("fork"),  # type: ignore[arg-type]
+        done_event=FakeEvent("done"),  # type: ignore[arg-type]
+    )
+
+    result = dag.launch(
+        lambda: operations.append("prefix"),
+        lambda: operations.append("origin") or "result",
+        lambda: operations.append("auxiliary"),
+    )
+
+    assert result == "result"
+    assert operations == [
+        "enter_device",
+        "prefix",
+        "record:fork:origin",
+        "aux_wait:fork",
+        "origin",
+        "enter_aux",
+        "auxiliary",
+        "record:done:current",
+        "exit_aux",
+        "origin_wait:done",
+        "exit_device",
+    ]
+
+
+def test_packed_mixed_staged_group_metadata() -> None:
+    offsets = (0, 1300, 1847, 3895, 4858, 5129, 8192)
+    partition = staged_longest_partition(offsets)
+
+    assert partition.longest_sequence == 5
+    assert partition.longest_range == (5, 6)
+    assert partition.rest_ranges == ((0, 5),)
+
+    critical = kda_group_host_metadata(offsets, partition.longest_range)
+    rest = kda_group_host_metadata(offsets, partition.rest_ranges[0])
+    assert critical.cu_seqlens == (5129, 8192)
+    assert critical.cu_chunks == (0, 192)
+    assert critical.chunk_to_seq == (0,) * 192
+    assert rest.cu_seqlens == (0, 1300, 1847, 3895, 4858, 5129)
+    assert rest.cu_chunks == (0, 82, 117, 245, 306, 323)
+    assert tuple(rest.chunk_to_seq.count(index) for index in range(5)) == (
+        82,
+        35,
+        128,
+        61,
+        17,
+    )
+
+
+def test_group_metadata_rejects_invalid_range() -> None:
+    with pytest.raises(ValueError, match="invalid sequence range"):
+        kda_group_host_metadata((0, 8, 16), (1, 3))
+
+
+def test_factor_workspace_is_aligned_and_packed() -> None:
+    workspace = allocate_kda_factor_workspace(2, 3, "cpu")
+
+    assert workspace.storage.data_ptr() % 256 == 0
+    assert workspace.kd.shape == (1, 2, 48, 128)
+    assert workspace.qd.shape == workspace.kd.shape
+    assert workspace.ak.shape == workspace.kd.shape
+    assert workspace.aq.shape == (1, 2, 3, 256)
+    assert workspace.g_total.shape == (1, 2, 3, 128)
+    storage = workspace.storage.untyped_storage()._cdata
+    assert {
+        workspace.kd.untyped_storage()._cdata,
+        workspace.qd.untyped_storage()._cdata,
+        workspace.ak.untyped_storage()._cdata,
+        workspace.aq.untyped_storage()._cdata,
+        workspace.g_total.untyped_storage()._cdata,
+    } == {storage}
+
+
+def test_interior_longest_rejects_origin_aux_and_launches_serial(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    offsets = (0, 4, 12, 14, 17)
+    partition = staged_longest_partition(offsets)
+    groups = tuple(
+        kda_prefill_staged.KdaStagedGroup(
+            kda_prefill_staged.materialize_kda_group_metadata(
+                kda_group_host_metadata(offsets, sequence_range), "cpu"
+            ),
+            allocate_kda_factor_workspace(1, 2, "cpu"),
+        )
+        for sequence_range in (partition.longest_range, *partition.rest_ranges)
+    )
+    operations: list[tuple[str, tuple[int, int]]] = []
+    metadata_ranges = {
+        id(group.metadata.cu_seqlens): group.metadata.host.sequence_range
+        for group in groups
+    }
+
+    def fake_prepare(*args: Any) -> None:
+        operations.append(("prepare", metadata_ranges[id(args[6])]))
+
+    def fake_recurrence(*args: Any) -> tuple[torch.Tensor, torch.Tensor]:
+        operations.append(("recurrence", metadata_ranges[id(args[8])]))
+        return args[6], args[7]
+
+    class FakeDag:
+        def launch(self, prefix: Any, origin: Any, auxiliary: Any) -> object:
+            prefix()
+            result = origin()
+            auxiliary()
+            return result
+
+    monkeypatch.setattr(kda_prefill_staged, "kda_chunk_prepare", fake_prepare)
+    monkeypatch.setattr(kda_prefill_staged, "kda_chunk_recurrence", fake_recurrence)
+    resources = KdaStagedResources(
+        critical=groups[0],
+        auxiliary=groups[1:],
+        dag=FakeDag(),  # type: ignore[arg-type]
+    )
+    q = torch.empty(1, offsets[-1], 1, 128)
+    values = torch.empty_like(q)
+    output = torch.empty_like(q)
+    state = torch.empty(len(offsets) - 1, 1, 128, 128)
+
+    with pytest.raises(ValueError, match="longest sequence is interior"):
+        kda_prefill_staged.launch_staged_kda_prefill(
+            resources,
+            q=q,
+            k=q,
+            gate=q,
+            beta_logits=torch.empty(1, offsets[-1], 1),
+            a_log=torch.empty(1),
+            dt_bias=torch.empty(1, 128),
+            values=values,
+            output=output,
+            state=state,
+            scale=128**-0.5,
+            gate_scale_log2=-5.0,
+        )
+    assert operations == []
+
+    actual_output, actual_state = kda_prefill_staged.launch_staged_kda_prefill(
+        resources,
+        q=q,
+        k=q,
+        gate=q,
+        beta_logits=torch.empty(1, offsets[-1], 1),
+        a_log=torch.empty(1),
+        dt_bias=torch.empty(1, 128),
+        values=values,
+        output=output,
+        state=state,
+        scale=128**-0.5,
+        gate_scale_log2=-5.0,
+        topology="serial",
+    )
+
+    assert actual_output is output
+    assert actual_state is state
+    assert operations == [
+        ("prepare", (1, 2)),
+        ("recurrence", (1, 2)),
+        ("prepare", (0, 1)),
+        ("recurrence", (0, 1)),
+        ("prepare", (2, 4)),
+        ("recurrence", (2, 4)),
+    ]
+
+    operations.clear()
+
+    def injected_prepare(*args: Any) -> None:
+        operations.append(("injected_prepare", metadata_ranges[id(args[6])]))
+
+    def injected_recurrence(*args: Any) -> tuple[torch.Tensor, torch.Tensor]:
+        operations.append(("injected_recurrence", metadata_ranges[id(args[8])]))
+        return args[6], args[7]
+
+    kda_prefill_staged.launch_staged_kda_prefill(
+        resources,
+        q=q,
+        k=q,
+        gate=q,
+        beta_logits=torch.empty(1, offsets[-1], 1),
+        a_log=torch.empty(1),
+        dt_bias=torch.empty(1, 128),
+        values=values,
+        output=output,
+        state=state,
+        scale=128**-0.5,
+        gate_scale_log2=-5.0,
+        topology="serial",
+        prepare_kernels=(injected_prepare,) * len(groups),
+        recurrence_kernels=(injected_recurrence,) * len(groups),
+    )
+    assert operations == [
+        ("injected_prepare", (1, 2)),
+        ("injected_recurrence", (1, 2)),
+        ("injected_prepare", (0, 1)),
+        ("injected_recurrence", (0, 1)),
+        ("injected_prepare", (2, 4)),
+        ("injected_recurrence", (2, 4)),
+    ]
+
+    operations.clear()
+    one_aux_resources = KdaStagedResources(
+        critical=groups[0],
+        auxiliary=(groups[1],),
+        dag=FakeDag(),  # type: ignore[arg-type]
+    )
+    kda_prefill_staged.launch_staged_kda_prefill(
+        one_aux_resources,
+        q=q,
+        k=q,
+        gate=q,
+        beta_logits=torch.empty(1, offsets[-1], 1),
+        a_log=torch.empty(1),
+        dt_bias=torch.empty(1, 128),
+        values=values,
+        output=output,
+        state=state,
+        scale=128**-0.5,
+        gate_scale_log2=-5.0,
+        topology="origin_aux",
+        prepare_kernels=(injected_prepare,) * 2,
+        recurrence_kernels=(injected_recurrence,) * 2,
+    )
+    assert operations == [
+        ("injected_prepare", (1, 2)),
+        ("injected_recurrence", (1, 2)),
+        ("injected_prepare", (0, 1)),
+        ("injected_recurrence", (0, 1)),
+    ]
+
+    with pytest.raises(ValueError, match="unsupported staged KDA topology"):
+        kda_prefill_staged.launch_staged_kda_prefill(
+            resources,
+            q=q,
+            k=q,
+            gate=q,
+            beta_logits=torch.empty(1, offsets[-1], 1),
+            a_log=torch.empty(1),
+            dt_bias=torch.empty(1, 128),
+            values=values,
+            output=output,
+            state=state,
+            scale=128**-0.5,
+            gate_scale_log2=-5.0,
+            topology="invalid",  # type: ignore[arg-type]
+        )
+
+    operations.clear()
+
+    class FailingDag:
+        def launch(self, prefix: Any, origin: Any, auxiliary: Any) -> object:
+            raise AssertionError("single-group launch must not enter the staged DAG")
+
+    fixed_resources = KdaStagedResources(
+        critical=groups[0],
+        auxiliary=(),
+        dag=FailingDag(),  # type: ignore[arg-type]
+    )
+    kda_prefill_staged.launch_staged_kda_prefill(
+        fixed_resources,
+        q=q,
+        k=q,
+        gate=q,
+        beta_logits=torch.empty(1, offsets[-1], 1),
+        a_log=torch.empty(1),
+        dt_bias=torch.empty(1, 128),
+        values=values,
+        output=output,
+        state=state,
+        scale=128**-0.5,
+        gate_scale_log2=-5.0,
+        prepare_kernels=(injected_prepare,),
+        recurrence_kernels=(injected_recurrence,),
+    )
+    assert operations == [
+        ("injected_prepare", (1, 2)),
+        ("injected_recurrence", (1, 2)),
+    ]
+
+
+def _require_sm100_runtime() -> torch.device:
+    from helion._compat import requires_cuda_version
+
+    if not torch.cuda.is_available() or not requires_cuda_version("13"):
+        pytest.skip("staged KDA runtime test requires CUDA >= 13")
+    pytest.importorskip("cutlass.cute")
+    device = torch.device("cuda", torch.cuda.current_device())
+    if torch.cuda.get_device_capability(device)[0] != 10:
+        pytest.skip("staged KDA runtime test requires SM100")
+    return device
+
+
+@torch.inference_mode()
+def _safe_gate_token_reference(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    gate: torch.Tensor,
+    beta_logits: torch.Tensor,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    values: torch.Tensor,
+    initial_state: torch.Tensor,
+    *,
+    lower_bound: float,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    q_f32 = q.float()
+    k_f32 = k.float()
+    q_f32 *= torch.rsqrt(q_f32.square().sum(-1, keepdim=True).clamp_min(1.0e-24))
+    k_f32 *= torch.rsqrt(k_f32.square().sum(-1, keepdim=True).clamp_min(1.0e-24))
+    q_f32 = q_f32.to(torch.bfloat16).float()
+    k_f32 = k_f32.to(torch.bfloat16).float()
+    decay = torch.exp(
+        lower_bound
+        * torch.sigmoid(
+            torch.exp(a_log)[None, None, :, None]
+            * (gate.float() + dt_bias[None, None, :, :])
+        )
+    )
+    beta = torch.sigmoid(beta_logits.float()).to(torch.bfloat16).float()
+    state = initial_state.float()
+    output = torch.empty_like(values, dtype=torch.float32)
+
+    for token in range(q.size(1)):
+        state *= decay[:, token].unsqueeze(-2)
+        prediction = torch.einsum("bhvk,bhk->bhv", state, k_f32[:, token])
+        residual = (values[:, token].float() - prediction) * beta[:, token, :, None]
+        state += residual.unsqueeze(-1) * k_f32[:, token].unsqueeze(-2)
+        output[:, token] = torch.einsum("bhvk,bhk->bhv", state, q_f32[:, token]) * scale
+        if (token + 1) % 16 == 0:
+            state = state.to(torch.bfloat16).float()
+
+    return output, state.to(torch.bfloat16)


### PR DESCRIPTION
Stacked PRs:
 * #3591
 * #3590
 * #3589
 * #3588
 * __->__#3587


--- --- ---

### benchmarks: add reproducible KDA comparisons

This adds correctness-checked benchmark harnesses for the KDA workloads used
by the rest of the stack. Packed one-token decode is compared with CAKE,
recurrent and speculative decode with FlashInfer CuTe, and prefill with both
CAKE and FlashInfer CuTe. The harness shares the same CUDA-graph timing,
cold-L2 flushing, state isolation, and result checks across providers.

This PR only adds the benchmark infrastructure. The optimized Helion paths are
introduced later in the stack, so the performance commands should be run from
the stack head.

#### Latest GB300 results

Lower is better.

| Workload | Baseline | Baseline (µs) | Helion (µs) | Speedup |
| --- | --- | ---: | ---: | ---: |
| Packed decode B1 H12 | CAKE | 8.928 | 8.352 | **1.1524×** |
| Packed decode B256 H12 | CAKE | 37.664 | 37.664 | **1.0040×** |
| Recurrent decode T1 B15 H32 | FlashInfer CuTe | 16.672 | 13.024 | **1.2201×** |
| Speculative decode T3 N8 H16 | FlashInfer CuTe | 15.104 | 13.056 | **1.1438×** |
| Fixed prefill T512 H12 | CAKE | 33.520 | 29.408 | **1.1398×** |
| Fixed prefill T512 H12 | FlashInfer CuTe | 37.632 | 29.424 | **1.2790×** |
| Packed-mixed prefill H12 | CAKE | 142.048 | 123.040 | **1.1545×** |
| Packed-mixed prefill H12 | FlashInfer CuTe | 139.968 | 123.040 | **1.1376×** |

Using the fastest baseline for each of the six workloads, baseline mean latency
is 41.976 µs and Helion mean latency is 37.424 µs. The geometric mean of the
six case ratios is **1.1310×**. Packed B256 is effectively a tie; both prefill
cases clear the 1.10× target against their fastest tested baseline.

These were measured on an NVIDIA GB300 at 1400 W with PyTorch 2.13.0+cu130 and
CUDA 13.0. Decode uses 64 balanced paired samples; prefill uses interleaved
four-slot graph replay in a fresh process. Every provider is checked against
the same semantic oracle, mutable state and outputs are private, resets happen
outside the timed interval, L2 is flushed before each replay, and no outliers
are removed.

The decode numbers were rerun on the submitted stack head. The prefill numbers
are the latest clean exhaustive-search results. The committed benchmark can
replay the winning configurations, but the orchestration used for the 25- and
250-candidate searches is intentionally not part of this stack.