### PR TITLE
[cutedsl] Make tuning and runtime specialization reproducible

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -93,8 +93,12 @@ class RuntimeInputSpecialization:
     """Internal runtime-input projection used to extend a kernel cache key.
 
     ``classifier_identity`` distinguishes classifier semantics when compiler
-    discovery registers the same named projection more than once. Runtime cache
-    state is deliberately excluded from descriptor equality.
+    discovery registers the same named projection more than once.
+    ``reusable_tensor_properties`` is an optional promise that the classifier's
+    result depends only on the named storage properties (plus tensor metadata
+    already covered by eager dispatch guards), never on tensor contents.  It
+    lets repeated calls with the exact same tensors reuse a prevalidated result.
+    Runtime cache state is deliberately excluded from descriptor equality.
     """
 
     sources: tuple[Source, ...]
@@ -102,6 +106,9 @@ class RuntimeInputSpecialization:
     classifier: typing.Callable[[typing.Sequence[object]], typing.Hashable] = (
         dataclasses.field(compare=False, repr=False)
     )
+    reusable_tensor_properties: frozenset[
+        typing.Literal["data_ptr", "storage_span"]
+    ] = frozenset()
 
 
 def _is_supported_tensor_input_source(source: Source) -> bool:
@@ -398,6 +405,12 @@ class CompileEnvironment:
             Source, TensorDescriptorLayoutGuard
         ] = {}
         self.runtime_input_specializations: dict[str, RuntimeInputSpecialization] = {}
+        # Immutable classifier outputs captured from the arguments that created
+        # this BoundKernel.  Codegen may run later and obtain those arguments
+        # through weak references, after their storage metadata has changed.
+        # Runtime-dependent optimizations must match this snapshot before they
+        # consume a live alignment or aliasing fact.
+        self.bound_runtime_input_specialization_results: dict[str, typing.Hashable] = {}
         self._tensor_input_source_cache: dict[int, Source | None] = {}
         self.jagged_tile_parent_ids: dict[int, list[int]] = {}
         self.jagged_tile_mask_shapes: dict[int, list[torch.SymInt]] = {}
@@ -663,6 +676,42 @@ class CompileEnvironment:
         previous = self.runtime_input_specializations.setdefault(key, specialization)
         if previous != specialization:
             raise RuntimeError(f"conflicting runtime input specializations for {key!r}")
+
+    def snapshot_runtime_input_specialization_results(
+        self,
+        root_values: typing.Mapping[str, object],
+    ) -> None:
+        """Capture storage facts used by runtime-dependent code generation.
+
+        Content-dependent classifiers are intentionally excluded. The codegen
+        consumers need only facts described by ``reusable_tensor_properties``;
+        filtering avoids an extra device read for worklist classifiers.
+        """
+        self.bound_runtime_input_specialization_results = {
+            key: specialization.classifier(
+                tuple(
+                    _replay_tensor_input_source(source, root_values)
+                    for source in specialization.sources
+                )
+            )
+            for key, specialization in self.runtime_input_specializations.items()
+            if specialization.reusable_tensor_properties
+            and all(
+                _is_supported_tensor_input_source(source)
+                for source in specialization.sources
+            )
+        }
+
+    def runtime_input_specialization_matches_bound(
+        self,
+        key: str,
+        result: typing.Hashable,
+    ) -> bool:
+        """Whether a live classifier result matches this bound's cache identity."""
+        return (
+            key in self.bound_runtime_input_specialization_results
+            and self.bound_runtime_input_specialization_results[key] == result
+        )
 
     def tensor_descriptor_layout_signature(
         self, fake_tensor: torch.Tensor

--- a/helion/_compiler/cute/memory_ops.py
+++ b/helion/_compiler/cute/memory_ops.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import ast
 import contextlib
 import functools
+import itertools
 import logging
 import operator
 from typing import TYPE_CHECKING
@@ -18,12 +19,15 @@ from typing import Any
 from typing import cast
 
 import torch
+from torch._dynamo.source import LocalSource
+from torch._subclasses import FakeTensor
 from torch.fx.node import map_arg
 
 from ... import exc
 from ...language import _decorators
 from ...language.memory_ops import _CUTE_L2_LAST_SUFFIX
 from ...language.memory_ops import _CUTE_VECTOR_DTYPES
+from ...language.memory_ops import _CUTE_VECTOR_MAX_BYTES
 from ...language.memory_ops import _CUTE_VECTOR_UNROLL_CARRIER
 from ...language.memory_ops import _CUTE_VECTOR_UNROLL_DTYPES
 from ...language.memory_ops import _codegen_cute_store_permute_lane_loops
@@ -49,13 +53,242 @@ from ...language.memory_ops import store
 from ..ast_extension import expr_from_string
 from ..ast_extension import statement_from_string
 from ..compile_environment import CompileEnvironment
+from ..compile_environment import RuntimeInputSpecialization
+from ..compile_environment import _replay_tensor_input_source
 from .cute_epilogue import analyze_tcgen05_unary_epilogue_chain
 from .cute_fx_walk import reach_tcgen05_matmul_anchors
 
 if TYPE_CHECKING:
+    from collections.abc import Hashable
+    from collections.abc import Sequence
+
+    from torch._guards import Source
+
     from ..inductor_lowering import CodegenState
 
 log = logging.getLogger(__name__)
+
+
+def _persistent_vec_alignment_signature(values: Sequence[object]) -> Hashable:
+    """Cache-key facts needed by persistent vector alignment/extent checks."""
+    if (
+        len(values) != 1
+        or not isinstance(values[0], torch.Tensor)
+        or isinstance(values[0], FakeTensor)
+    ):
+        return None
+    tensor = values[0]
+    element_size = tensor.element_size()
+    max_vector_elements = max(_CUTE_VECTOR_MAX_BYTES // element_size, 1)
+    return (
+        int(tensor.data_ptr()) % _CUTE_VECTOR_MAX_BYTES,
+        tuple(int(size) % max_vector_elements for size in tensor.shape),
+        tuple(
+            (
+                int(stride) == 1,
+                (int(stride) * element_size) % _CUTE_VECTOR_MAX_BYTES,
+            )
+            for stride in tensor.stride()
+        ),
+    )
+
+
+_PERSISTENT_VEC_ALIGNMENT_SPECIALIZATION_KEY = "cute_persistent_vec_alignment_matrix_v2"
+
+
+def _persistent_vec_alignment_matrix_signature(
+    values: Sequence[object],
+) -> Hashable:
+    return tuple(_persistent_vec_alignment_signature((value,)) for value in values)
+
+
+def register_persistent_vec_alignment_specializations(
+    env: CompileEnvironment,
+) -> None:
+    """Specialize persistent-vector candidates on runtime pointer alignment.
+
+    Dynamic FakeTensors intentionally carry symbolic storage offsets.  The
+    branch-local vectorizer therefore consults the real input tensor during
+    codegen.  Register the corresponding address/stride residue in the bound
+    kernel cache key before any config is compiled, so a later unaligned view
+    can never reuse code emitted for an aligned tensor.
+    """
+    sources = tuple(
+        source
+        for tensor in env.input_sources
+        if tensor.dtype in _CUTE_VECTOR_DTYPES
+        and (source := env.tensor_input_source(tensor)) is not None
+    )
+    if not sources:
+        return
+    env.register_runtime_input_specialization(
+        _PERSISTENT_VEC_ALIGNMENT_SPECIALIZATION_KEY,
+        RuntimeInputSpecialization(
+            sources=sources,
+            classifier_identity=(
+                "byte_alignment_matrix_v2",
+                _CUTE_VECTOR_MAX_BYTES,
+                tuple(map(repr, sources)),
+            ),
+            classifier=_persistent_vec_alignment_matrix_signature,
+            reusable_tensor_properties=frozenset(("data_ptr",)),
+        ),
+    )
+
+
+def runtime_tensor_has_specialized_alignment(
+    env: CompileEnvironment,
+    tensor: torch.Tensor,
+    required_alignment: int,
+) -> bool:
+    """Return a cache-key-backed runtime base-pointer alignment proof."""
+    if required_alignment <= 0 or _CUTE_VECTOR_MAX_BYTES % required_alignment:
+        return False
+    runtime_tensor = env.runtime_value_for_tensor(tensor)
+    if not isinstance(runtime_tensor, torch.Tensor) or isinstance(
+        runtime_tensor, FakeTensor
+    ):
+        return False
+    source = env.tensor_input_source(tensor)
+    specialization = env.runtime_input_specializations.get(
+        _PERSISTENT_VEC_ALIGNMENT_SPECIALIZATION_KEY
+    )
+    if source is None or specialization is None or source not in specialization.sources:
+        return False
+    runtime_values = tuple(
+        _replay_tensor_input_source(item, env.runtime_arg_values_by_name)
+        for item in specialization.sources
+    )
+    facts = specialization.classifier(runtime_values)
+    return (
+        env.runtime_input_specialization_matches_bound(
+            _PERSISTENT_VEC_ALIGNMENT_SPECIALIZATION_KEY,
+            facts,
+        )
+        and int(runtime_tensor.data_ptr()) % required_alignment == 0
+    )
+
+
+def _tensor_storage_disjoint_matrix_signature(
+    values: Sequence[object],
+) -> Hashable:
+    """Classify every pair while reading each tensor's storage only once."""
+    spans: list[tuple[torch.device, int, int] | None] = []
+    for value in values:
+        if not isinstance(value, torch.Tensor) or isinstance(value, FakeTensor):
+            spans.append(None)
+            continue
+        storage = value.untyped_storage()
+        start = int(storage.data_ptr())
+        spans.append((value.device, start, start + storage.nbytes()))
+
+    result: list[bool] = []
+    for left, right in itertools.combinations(spans, 2):
+        if left is None or right is None:
+            result.append(False)
+        elif left[1] == left[2] or right[1] == right[2] or left[0] != right[0]:
+            result.append(True)
+        else:
+            result.append(left[2] <= right[1] or right[2] <= left[1])
+    return tuple(result)
+
+
+def _tensor_alias_sources(env: CompileEnvironment) -> tuple[Source, ...]:
+    sources: list[Source] = []
+    # Enumerate direct host tensor arguments by their argument names rather
+    # than only asking FakeTensor -> Source.  FakeTensorConverter deliberately
+    # reuses one FakeTensor when the same real tensor is passed in two argument
+    # slots.  That makes the reverse mapping ambiguous, but the two explicit
+    # argument Sources remain distinct and must both participate in the
+    # cache-specialized alias matrix.
+    from ..host_function import HostFunction
+
+    for name, value in HostFunction.current().params.arguments.items():
+        if isinstance(value, torch.Tensor):
+            sources.append(LocalSource(name, is_input=True))
+    for tensor in env.input_sources:
+        source = env.tensor_input_source(tensor)
+        if source is not None and source not in sources:
+            sources.append(source)
+    return tuple(sources)
+
+
+_TENSOR_DISJOINT_MATRIX_SPECIALIZATION_KEY = "cute_tensor_storage_disjoint_matrix_v1"
+
+
+def register_cute_tensor_alias_specializations(env: CompileEnvironment) -> None:
+    """Cache-key runtime alias facts used by CuTe memory reordering passes.
+
+    Different kernel argument names are not a non-aliasing proof: callers may
+    pass the same tensor or overlapping views.  Recording the storage-overlap
+    predicate in the bound-kernel key lets codegen use a positive runtime fact
+    without reusing that code for a later aliasing launch.
+    """
+    sources = _tensor_alias_sources(env)
+    if len(sources) < 2:
+        return
+    env.register_runtime_input_specialization(
+        _TENSOR_DISJOINT_MATRIX_SPECIALIZATION_KEY,
+        RuntimeInputSpecialization(
+            sources=sources,
+            classifier_identity=(
+                "storage_span_disjoint_matrix_v1",
+                tuple(map(repr, sources)),
+            ),
+            classifier=_tensor_storage_disjoint_matrix_signature,
+            reusable_tensor_properties=frozenset(("storage_span",)),
+        ),
+    )
+
+
+def runtime_tensors_are_proven_disjoint(
+    env: CompileEnvironment,
+    left: torch.Tensor,
+    right: torch.Tensor,
+) -> bool:
+    """Return a cache-specialized positive runtime storage-disjointness fact."""
+    left_source = env.tensor_input_source(left)
+    right_source = env.tensor_input_source(right)
+    if left_source is None or right_source is None:
+        return False
+    return runtime_tensor_sources_are_proven_disjoint(
+        env,
+        left_source,
+        right_source,
+    )
+
+
+def runtime_tensor_sources_are_proven_disjoint(
+    env: CompileEnvironment,
+    left_source: Source,
+    right_source: Source,
+) -> bool:
+    """Return a cache-specialized storage fact for explicit input Sources."""
+    if left_source == right_source:
+        return False
+    specialization = env.runtime_input_specializations.get(
+        _TENSOR_DISJOINT_MATRIX_SPECIALIZATION_KEY
+    )
+    sources = _tensor_alias_sources(env)
+    if specialization is None or specialization.sources != sources:
+        return False
+    runtime_values = tuple(
+        _replay_tensor_input_source(source, env.runtime_arg_values_by_name)
+        for source in sources
+    )
+    facts = specialization.classifier(runtime_values)
+    if not isinstance(
+        facts, tuple
+    ) or not env.runtime_input_specialization_matches_bound(
+        _TENSOR_DISJOINT_MATRIX_SPECIALIZATION_KEY,
+        facts,
+    ):
+        return False
+    wanted = frozenset((left_source, right_source))
+    for pair, fact in zip(itertools.combinations(sources, 2), facts, strict=False):
+        if frozenset(pair) == wanted:
+            return fact is True
+    return False
 
 
 def _log_cute_layout(state: CodegenState, op_name: str) -> None:

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -1275,7 +1275,10 @@ class PopulationBasedSearch(BaseSearch):
             "enabled": True,
             # 2: the non-isolated finalist shootout uses paired interleaved
             # timing instead of sequential steady windows.
-            "timing_version": 2,
+            # 3: an in-process fallback for a mutated-argument kernel gives
+            # every finalist private storage, preventing cross-config L2
+            # eviction-priority leakage.
+            "timing_version": 3,
             "top_k": self._final_rebenchmark_top_k(),
             "target_ms": self._final_rebenchmark_target_ms(),
             "isolated": self._final_rebenchmark_use_isolated(),
@@ -2038,6 +2041,7 @@ class PopulationBasedSearch(BaseSearch):
             use_isolated=use_isolated,
             confirm_suspicious=use_isolated,
             use_interleaved=not use_isolated,
+            candidate_private_args=use_isolated,
         )
         live_finalists = [member for member in finalists if math.isfinite(member.perf)]
         if not live_finalists:
@@ -2096,6 +2100,7 @@ class PopulationBasedSearch(BaseSearch):
         use_isolated: bool = True,
         confirm_suspicious: bool = True,
         use_interleaved: bool = True,
+        candidate_private_args: bool = False,
     ) -> None:
         """
         Re-benchmark a list of population members to avoid outliers.
@@ -2103,6 +2108,8 @@ class PopulationBasedSearch(BaseSearch):
         Args:
             members: The list of population members to rebenchmark.
             desc: Description for the progress bar.
+            candidate_private_args: When an isolated worker is unavailable,
+                keep mutated argument storage private to each candidate.
         """
         if len(members) < 2:
             return
@@ -2124,6 +2131,7 @@ class PopulationBasedSearch(BaseSearch):
             repeat = min(repeat, int(capstr))
         repeat = max(1, repeat)
 
+        in_process_isolation = False
         if use_isolated and self.settings.autotune_benchmark_fn is None:
             isolated_results = self.benchmark_provider.benchmark_isolated(
                 [m.fn for m in members],
@@ -2149,18 +2157,54 @@ class PopulationBasedSearch(BaseSearch):
                     failure_statuses=failure_statuses,
                 )
                 return
+            if candidate_private_args and dist.is_initialized():
+                self.log.warning(
+                    "Candidate-private mutated-argument isolation is unavailable "
+                    "for distributed in-process rebenchmarking."
+                )
+            in_process_isolation = candidate_private_args and not dist.is_initialized()
 
         if len(self.benchmark_provider.mutated_arg_indices) > 0:
-            benchmark_args = _clone_args(
-                self.args,
-                self.kernel.env.process_group_name,
-                idx_to_clone=self.benchmark_provider.mutated_arg_indices,
-            )
+            if in_process_isolation:
+                # A single recycled clone lets a later candidate inherit L2
+                # eviction priority from an earlier candidate that touched the
+                # same addresses (for example, an ``l2_last`` store). Keep a
+                # sacrificial clone alive to absorb the allocator's recycled
+                # addresses, then give every finalist private live tensor
+                # storage, including inputs that the kernel only reads.
+                isolated_args: list[Sequence[object]] = []
+                try:
+                    isolated_args = [
+                        _clone_args(
+                            self.args,
+                            self.kernel.env.process_group_name,
+                            idx_to_clone=None,
+                        )
+                        for _ in range(len(members) + 1)
+                    ]
+                    benchmark_args_by_member = isolated_args[1:]
+                except torch.OutOfMemoryError as error:
+                    isolated_args.clear()
+                    raise exc.AutotuneError(
+                        "Unable to allocate candidate-private mutated arguments "
+                        "for in-process finalist isolation. Reduce "
+                        f"{_FINAL_REBENCHMARK_TOP_K_ENV} and retry."
+                    ) from error
+            else:
+                benchmark_args = _clone_args(
+                    self.args,
+                    self.kernel.env.process_group_name,
+                    idx_to_clone=self.benchmark_provider.mutated_arg_indices,
+                )
+                benchmark_args_by_member = [benchmark_args] * len(members)
         else:
-            benchmark_args = self.args
+            benchmark_args_by_member = [self.args] * len(members)
 
         def make_rebenchmark_callable(
-            member: PopulationMember, *, clear_each_call: bool
+            member: PopulationMember,
+            benchmark_args: Sequence[object],
+            *,
+            clear_each_call: bool,
         ) -> Callable[[], object]:
             run_member = functools.partial(member.fn, *benchmark_args)
 
@@ -2179,7 +2223,14 @@ class PopulationBasedSearch(BaseSearch):
         try:
             if use_interleaved or self.settings.autotune_benchmark_fn is not None:
                 iterator = [
-                    make_rebenchmark_callable(m, clear_each_call=True) for m in members
+                    make_rebenchmark_callable(
+                        member,
+                        benchmark_args,
+                        clear_each_call=True,
+                    )
+                    for member, benchmark_args in zip(
+                        members, benchmark_args_by_member, strict=True
+                    )
                 ]
                 benchmark_function: Callable[..., list[float]]
                 if self.settings.autotune_benchmark_fn is not None:
@@ -2204,7 +2255,14 @@ class PopulationBasedSearch(BaseSearch):
                     new_timings = benchmark_function(iterator, repeat=repeat)
             else:
                 iterator = [
-                    make_rebenchmark_callable(m, clear_each_call=False) for m in members
+                    make_rebenchmark_callable(
+                        member,
+                        benchmark_args,
+                        clear_each_call=False,
+                    )
+                    for member, benchmark_args in zip(
+                        members, benchmark_args_by_member, strict=True
+                    )
                 ]
                 steady_bench = (
                     _backend.get_do_bench() if _backend is not None else None

--- a/helion/autotuner/benchmark_job.py
+++ b/helion/autotuner/benchmark_job.py
@@ -19,7 +19,23 @@ from .precompile_future import _load_compiled_fn
 from .precompile_future import _unload_compiled_fn
 
 if TYPE_CHECKING:
+    from ..runtime.kernel import CompiledConfig
     from .precompile_future import SerializedCompiledFunction
+
+
+class CompiledFunctionLoadError(Exception):
+    """The benchmark worker could not reconstruct a generated wrapper."""
+
+
+def _load_compiled_fn_for_worker(
+    fn_spec: SerializedCompiledFunction,
+) -> CompiledConfig:
+    try:
+        return _load_compiled_fn(fn_spec)
+    except Exception as error:
+        raise CompiledFunctionLoadError(
+            f"{type(error).__qualname__}: {error}"
+        ) from error
 
 
 @dataclasses.dataclass
@@ -36,7 +52,7 @@ class BenchmarkJob:
         # Subprocess inherits parent stderr; capture so Triton runtime
         # diagnostics don't leak to the user's terminal.
         with capture_output():
-            fn = _load_compiled_fn(self.fn_spec)
+            fn = _load_compiled_fn_for_worker(self.fn_spec)
             try:
                 args = load_trusted_kernel_args(self.args_path)
                 bench = do_bench_generic if self.use_wall_clock else do_bench
@@ -81,7 +97,7 @@ class AccuracyCheckJob:
     def __call__(self) -> AccuracyCheckResult:
         # Keep compile/launch diagnostics out of the autotune progress stream.
         with capture_output():
-            fn = _load_compiled_fn(self.fn_spec)
+            fn = _load_compiled_fn_for_worker(self.fn_spec)
             try:
                 args = load_trusted_kernel_args(self.args_path)
                 baseline_output = _load_trusted_baseline_output(self.baseline_path)

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -37,6 +37,7 @@ from .accuracy import is_fp8_dtype
 from .benchmark_job import AccuracyCheckJob
 from .benchmark_job import AccuracyCheckResult
 from .benchmark_job import BenchmarkJob
+from .benchmark_job import CompiledFunctionLoadError
 from .benchmark_worker import BenchmarkSubprocessError
 from .benchmark_worker import BenchmarkTimeout
 from .benchmark_worker import BenchmarkWorker
@@ -248,47 +249,105 @@ def _clone_args(
     process_group_name: str | None,
     idx_to_clone: Sequence[int] | None = None,
 ) -> Sequence[object]:
+    """Clone selected tensor leaves while preserving their alias topology.
+
+    If a selected ordinary tensor shares storage with another tensor argument,
+    clone that whole argument alias group.  This keeps view offsets, strides,
+    mixed-dtype storage aliases, and duplicate references intact while still
+    isolating the cloned group from both the caller and other candidates.
     """
-    Clone the given arguments, but cloning only the tensors specified by
-      idx_to_clone. If idx_to_clone is None, clone all tensors.
-    """
+
+    clone_indices = None if idx_to_clone is None else set(idx_to_clone)
 
     def _should_clone(idx: int) -> bool:
-        return idx_to_clone is None or idx in idx_to_clone
+        return clone_indices is None or idx in clone_indices
 
     args_flat, tree_spec = tree_flatten(args)
-    old_arg_to_new_arg = {}
+    tensor_replacements: dict[int, torch.Tensor] = {}
+    signal_pad_replacements: dict[int, int] = {}
+    symmetric_tensor_ids: set[int] = set()
 
     for i, arg in enumerate(args_flat):
         if _should_clone(i) and is_symm_mem_tensor(arg, process_group_name):
-            new_arg = _clone_symm_mem_tensor(arg, process_group_name)
-            old_arg_to_new_arg[get_signal_pad_ptrs_dev(arg, process_group_name)] = (
-                get_signal_pad_ptrs_dev(new_arg, process_group_name)
-            )
-            old_arg_to_new_arg[arg] = new_arg  # pyrefly: ignore[unsupported-operation]
+            arg_id = id(arg)
+            symmetric_tensor_ids.add(arg_id)
+            if arg_id not in tensor_replacements:
+                new_arg = _clone_symm_mem_tensor(arg, process_group_name)
+                signal_pad_replacements[
+                    get_signal_pad_ptrs_dev(arg, process_group_name)
+                ] = get_signal_pad_ptrs_dev(new_arg, process_group_name)
+                tensor_replacements[arg_id] = new_arg
+
+    def _storage_id(tensor: torch.Tensor) -> int | None:
+        if tensor.layout is not torch.strided:
+            return None
+        try:
+            return tensor.untyped_storage()._cdata
+        except RuntimeError:
+            return None
+
+    # A partial selection must include all ordinary tensor arguments that alias
+    # a selected tensor.  Otherwise an in-place candidate sees a different
+    # alias relationship from the original invocation.
+    selected_storage_ids: set[int] = set()
+    selected_tensor_ids: set[int] = set()
+    for i, arg in enumerate(args_flat):
+        if (
+            _should_clone(i)
+            and isinstance(arg, torch.Tensor)
+            and id(arg) not in symmetric_tensor_ids
+        ):
+            selected_tensor_ids.add(id(arg))
+            storage_id = _storage_id(arg)
+            if storage_id is not None:
+                selected_storage_ids.add(storage_id)
+
+    ordinary_tensors: list[torch.Tensor] = []
+    seen_tensor_ids: set[int] = set()
+    for arg in args_flat:
+        if not isinstance(arg, torch.Tensor) or id(arg) in tensor_replacements:
+            continue
+        arg_id = id(arg)
+        storage_id = _storage_id(arg)
+        if arg_id not in selected_tensor_ids and (
+            storage_id is None or storage_id not in selected_storage_ids
+        ):
+            continue
+        if arg_id not in seen_tensor_ids:
+            seen_tensor_ids.add(arg_id)
+            ordinary_tensors.append(arg)
+
+    storage_groups: dict[tuple[str, int], list[torch.Tensor]] = {}
+    for tensor in ordinary_tensors:
+        storage_id = _storage_id(tensor)
+        key = (
+            ("storage", storage_id)
+            if storage_id is not None
+            else ("tensor", id(tensor))
+        )
+        storage_groups.setdefault(key, []).append(tensor)
+
+    for tensors in storage_groups.values():
+        if len(tensors) == 1 and tensors[0].is_contiguous():
+            # Retain the ordinary fast path (and its observable clone
+            # semantics) when there is no cross-argument alias topology to
+            # preserve.
+            clones = [tensors[0].detach().clone()]
+        else:
+            # Deepcopy aliased detached tensors together: PyTorch memoizes their
+            # storage, preserving cross-view aliases, offsets, strides, and
+            # mixed dtypes. It also preserves a lone non-contiguous layout.
+            clones = copy.deepcopy([tensor.detach() for tensor in tensors])
+        for tensor, clone in zip(tensors, clones, strict=True):
+            clone.requires_grad_(tensor.requires_grad)
+            tensor_replacements[id(tensor)] = clone
 
     for i, arg in enumerate(args_flat):
-        if arg in old_arg_to_new_arg:
-            args_flat[i] = old_arg_to_new_arg[arg]
+        if isinstance(arg, torch.Tensor) and id(arg) in tensor_replacements:
+            args_flat[i] = tensor_replacements[id(arg)]
             continue
-        if not isinstance(arg, torch.Tensor):
-            continue
-        if _should_clone(i):
-            if arg.is_contiguous():
-                clone = arg.detach().clone()
-            else:
-                # A kernel bound on a non-contiguous arg hardcodes that arg's
-                # load strides into the compiled kernel as compile-time
-                # constants. ``arg.detach().clone()`` returns a contiguous
-                # tensor with a different layout and smaller storage, so those
-                # hardcoded strides would address the wrong (or out-of-bounds)
-                # memory when the autotuner accuracy baseline reruns the kernel
-                # on the clone. ``copy.deepcopy`` does a storage-level copy that
-                # reproduces the original size, stride, and offset, and also
-                # handles broadcast/expanded views.
-                clone = copy.deepcopy(arg.detach())
-            clone.requires_grad_(arg.requires_grad)
-            args_flat[i] = clone
+        if isinstance(arg, int) and arg in signal_pad_replacements:
+            args_flat[i] = signal_pad_replacements[arg]
 
     return tree_unflatten(args_flat, tree_spec)
 
@@ -529,6 +588,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
     # Class-level default: tests construct partially-initialized providers, so
     # the picklability flag must resolve even before setup()/__init__ set it.
     _args_unpicklable: bool = False
+    _subprocess_wrapper_unloadable: bool = False
 
     def __init__(
         self,
@@ -555,6 +615,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         self._precompile_tmpdir: tempfile.TemporaryDirectory[str] | None = None
         self._precompile_args_path: str | None = None
         self._args_unpicklable: bool = False
+        self._subprocess_wrapper_unloadable: bool = False
         self._precompile_baseline_path: str | None = None
         self._precompile_result_counter: count[int] = count()
         self._benchmark_worker: BenchmarkWorker | None = None
@@ -1014,6 +1075,8 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         if not self.settings.autotune_benchmark_subprocess:
             return False
         if self._args_unpicklable:
+            return False
+        if self._subprocess_wrapper_unloadable:
             return False
         if dist.is_initialized():
             return False
@@ -1914,13 +1977,17 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             rtol=self._effective_rtol,
             scale_atol=self._scale_atol,
         )
-        return cast(
-            "AccuracyCheckResult",
-            self._benchmark_worker.run(
-                job,
-                timeout=float(self.settings.autotune_benchmark_timeout),
-            ),
-        )
+        try:
+            return cast(
+                "AccuracyCheckResult",
+                self._benchmark_worker.run(
+                    job,
+                    timeout=float(self.settings.autotune_benchmark_timeout),
+                ),
+            )
+        except CompiledFunctionLoadError as error:
+            self._disable_unloadable_benchmark_worker(error)
+            return None
 
     def _run_subprocess_benchmark_job(
         self,
@@ -1930,7 +1997,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         rep: int,
         fixed_repetitions: int | None = None,
     ) -> float | None:
-        if self._precompile_args_path is None:
+        if self._precompile_args_path is None or self._subprocess_wrapper_unloadable:
             return None
         try:
             fn_spec = _serialize_compiled_fn(fn)
@@ -1949,11 +2016,32 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             probe_long_kernel=self._probe_long_cute_flash_kernel(),
             fixed_repetitions=fixed_repetitions,
         )
-        return float(
-            self._benchmark_worker.run(
-                job,
-                timeout=float(self.settings.autotune_benchmark_timeout),
+        try:
+            return float(
+                self._benchmark_worker.run(
+                    job,
+                    timeout=float(self.settings.autotune_benchmark_timeout),
+                )
             )
+        except CompiledFunctionLoadError as error:
+            self._disable_unloadable_benchmark_worker(error)
+            return None
+
+    def _disable_unloadable_benchmark_worker(
+        self, error: CompiledFunctionLoadError
+    ) -> None:
+        # A generated wrapper can depend on a source module that exists only in
+        # the parent process (for example a module loaded under a synthetic
+        # namespace). This says nothing about whether the config itself is valid,
+        # so let callers use their existing in-process fallback and stop sending
+        # later candidates through the incompatible worker.
+        self._subprocess_wrapper_unloadable = True
+        if self._benchmark_worker is not None:
+            self._benchmark_worker.shutdown()
+            self._benchmark_worker = None
+        self.log.debug(
+            f"Benchmark worker could not load the generated wrapper; "
+            f"falling back in-process: {error}"
         )
 
     def benchmark_isolated(
@@ -1998,6 +2086,13 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                     continue
                 self.log.debug(f"{desc} subprocess raised: {type(e).__name__}: {e}")
                 timing = None
+            # A wrapper-load failure disables the worker because later
+            # candidates may depend on the same unavailable source module.
+            # Treat the whole isolated batch as unavailable so the caller
+            # rebenchmarks every finalist in-process instead of mixing partial
+            # fresh timings with stale population measurements.
+            if self._subprocess_wrapper_unloadable:
+                return None
             timings.append(None if timing is None else float(timing))
         return timings
 

--- a/helion/autotuner/precompile_future.py
+++ b/helion/autotuner/precompile_future.py
@@ -238,10 +238,15 @@ def _register_source_module(name: str, file: str) -> None:
     module = importlib.util.module_from_spec(spec)
     # Register BEFORE exec so self-references / decorators resolve by name.
     sys.modules[name] = module
-    # Leave a best-effort partial module rather than crashing the worker; if the
-    # import is actually needed the generated exec will surface a clear error.
-    with contextlib.suppress(Exception):
+    try:
         spec.loader.exec_module(module)
+    except BaseException:
+        # Never leave a partially initialized module behind.  A long-lived
+        # benchmark worker may otherwise let a later generated wrapper import
+        # the broken module successfully and fail only when it reads a missing
+        # global, incorrectly making a valid candidate look broken.
+        sys.modules.pop(name, None)
+        raise
 
 
 def _load_compiled_fn(fn_spec: SerializedCompiledFunction) -> CompiledConfig:

--- a/helion/runtime/cute/launcher.py
+++ b/helion/runtime/cute/launcher.py
@@ -1872,6 +1872,12 @@ class _CuteCUDAGraph(torch.cuda.CUDAGraph):
         self._helion_resources.record_replay_streams()
         super().replay()
 
+    def reset(self) -> None:
+        # Descriptor storage must outlive every graph node that holds its raw
+        # address, so destroy the graph before dropping retained ownership.
+        super().reset()
+        self._helion_resources.release()
+
 
 _CUTE_ACTIVE_CUDA_GRAPH: contextvars.ContextVar[_CuteCUDAGraph | None] = (
     contextvars.ContextVar("helion_cute_active_cuda_graph", default=None)
@@ -3943,10 +3949,26 @@ def _retain_cute_capture_owned_launch_tensors(
     owned_tensors: tuple[torch.Tensor, ...],
 ) -> None:
     """Keep raw-pointer launch tensors alive for captured graph replays."""
-    capture_contexts = tuple(
-        context for context in grouped_launch_contexts if context[3] is not None
-    )
-    if not capture_contexts or not owned_tensors:
+    if not owned_tensors:
+        return
+    contexts = list(grouped_launch_contexts)
+    contexts_by_device = {
+        (context[0], context[1]): context for context in grouped_launch_contexts
+    }
+    # Grouped tcgen05 plans already contribute their stream/capture context.
+    # Other launcher-owned allocations (notably KDA's raw TensorMap descriptor
+    # storage) have no grouped plan, so derive the missing contexts from the
+    # tensors whose pointers the captured launch embeds.
+    for tensor in owned_tensors:
+        device_key = (tensor.device.type, tensor.device.index)
+        if device_key in contexts_by_device:
+            continue
+        stream_handle, capture_id = _cuda_stream_capture_context(tensor.device)
+        context = (*device_key, stream_handle, capture_id)
+        contexts_by_device[device_key] = context
+        contexts.append(context)
+    capture_contexts = tuple(context for context in contexts if context[3] is not None)
+    if not capture_contexts:
         return
     cache = cast(
         "dict[tuple[_CuteGroupedLaunchContext, ...], dict[int, torch.Tensor]]",
@@ -4871,6 +4893,11 @@ def default_cute_launcher(
         cute_compile_options,
     )
     if last_launch is not None:
+        _retain_cute_capture_owned_launch_tensors(
+            cute_kernel,
+            grouped_launch_contexts=last_launch.arg_guard.grouped_launch_contexts,
+            owned_tensors=last_launch.launch.owned_tensors,
+        )
         _record_cute_owned_launch_tensors(last_launch.launch.owned_tensors)
         return cast("Any", last_launch.compiled)(
             *last_launch.launch.launch_args,

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -351,6 +351,133 @@ class _SpecializationAlias:
         )
 
 
+@dataclasses.dataclass(frozen=True)
+class _PreparedMetadataSpecializationExtractor:
+    """Specialization already implied by ``_make_prepared_arg_guard``."""
+
+    extractor: Callable[[Sequence[object]], Hashable]
+
+    def __call__(self, args: Sequence[object]) -> Hashable:
+        return self.extractor(args)
+
+
+@dataclasses.dataclass(frozen=True)
+class _RuntimeInputSpecializationExtractor:
+    """Runtime classifier together with its source projections."""
+
+    source_extractors: tuple[Callable[[Sequence[object]], Hashable], ...]
+    classifier: Callable[[Sequence[object]], Hashable]
+    reusable_tensor_properties: frozenset[str]
+    specialization_key: str | None = None
+
+    def source_values(self, args: Sequence[object]) -> tuple[object, ...]:
+        return tuple(extract(args) for extract in self.source_extractors)
+
+    def __call__(self, args: Sequence[object]) -> Hashable:
+        return self.classifier(self.source_values(args))
+
+
+def _partition_prepared_extra_guards(
+    args: tuple[object, ...],
+    extra_guards: tuple[tuple[Callable[[Sequence[object]], Hashable], Hashable], ...],
+) -> tuple[
+    Callable[[tuple[object, ...]], bool] | None,
+    tuple[tuple[Callable[[Sequence[object]], Hashable], Hashable], ...],
+    tuple[tuple[Callable[[Sequence[object]], Hashable], Hashable], ...],
+]:
+    """Split guards into always-check and exact-tensor reusable projections.
+
+    Tensor shape/stride/dtype/device facts are already checked by the prepared
+    argument guard.  A runtime classifier may additionally opt in to reuse
+    when its exact source tensors still have the same pointer/storage facts.
+    Classifiers that depend on tensor contents (or arbitrary Python state)
+    remain in the always-check set.
+    """
+    always_check: list[tuple[Callable[[Sequence[object]], Hashable], Hashable]] = []
+    reusable: list[tuple[Callable[[Sequence[object]], Hashable], Hashable]] = []
+    # One source projection is enough for duplicate tensor objects: the
+    # prepared argument guard independently preserves the input alias topology.
+    tensor_entries: dict[
+        int,
+        tuple[
+            Callable[[Sequence[object]], Hashable],
+            torch.Tensor,
+            set[str],
+        ],
+    ] = {}
+    for extractor, expected in extra_guards:
+        if isinstance(extractor, _PreparedMetadataSpecializationExtractor):
+            continue
+        if (
+            not isinstance(extractor, _RuntimeInputSpecializationExtractor)
+            or not extractor.reusable_tensor_properties
+            or not extractor.reusable_tensor_properties <= {"data_ptr", "storage_span"}
+        ):
+            always_check.append((extractor, expected))
+            continue
+        try:
+            source_values = extractor.source_values(args)
+        except Exception:
+            always_check.append((extractor, expected))
+            continue
+        if not source_values or any(
+            type(value) not in (torch.Tensor, torch.nn.Parameter)
+            for value in source_values
+        ):
+            always_check.append((extractor, expected))
+            continue
+        reusable.append((extractor, expected))
+        for source_extractor, value in zip(
+            extractor.source_extractors, source_values, strict=True
+        ):
+            assert isinstance(value, torch.Tensor)
+            entry = tensor_entries.get(id(value))
+            if entry is None:
+                tensor_entries[id(value)] = (
+                    source_extractor,
+                    value,
+                    set(extractor.reusable_tensor_properties),
+                )
+            else:
+                entry[2].update(extractor.reusable_tensor_properties)
+
+    if not reusable:
+        return None, tuple(always_check), ()
+
+    namespace: dict[str, object] = {}
+    checks: list[str] = []
+    try:
+        for index, (extractor, tensor, properties) in enumerate(
+            tensor_entries.values()
+        ):
+            namespace[f"extract_{index}"] = extractor
+            namespace[f"ref_{index}"] = weakref.ref(tensor)
+            value_name = f"value_{index}"
+            item_checks = [
+                f"(({value_name} := extract_{index}(args)) is ref_{index}())"
+            ]
+            if "data_ptr" in properties:
+                namespace[f"data_ptr_{index}"] = int(tensor.data_ptr())
+                item_checks.append(f"{value_name}.data_ptr() == data_ptr_{index}")
+            if "storage_span" in properties:
+                storage = tensor.untyped_storage()
+                namespace[f"storage_ptr_{index}"] = int(storage.data_ptr())
+                namespace[f"storage_nbytes_{index}"] = storage.nbytes()
+                storage_name = f"storage_{index}"
+                item_checks.extend(
+                    (
+                        f"(({storage_name} := {value_name}.untyped_storage()).data_ptr() == storage_ptr_{index})",
+                        f"{storage_name}.nbytes() == storage_nbytes_{index}",
+                    )
+                )
+            checks.append(f"({' and '.join(item_checks)})")
+        reuse_guard = eval(f"lambda args: {' and '.join(checks)}", namespace)
+    except Exception:
+        always_check.extend(reusable)
+        return None, tuple(always_check), ()
+    return reuse_guard, tuple(always_check), tuple(reusable)
+
+
 def _make_prepared_arg_guard(
     kernel: Kernel,
     args: tuple[object, ...],
@@ -478,6 +605,10 @@ class _PreparedCall:
         "_extra_guards",
         "_is_distributed",
         "_matches_args",
+        "_reset_generation",
+        "_reusable_extra_guards",
+        "_specialization_generation",
+        "_tensor_storage_reuse_guard",
         "bound",
     )
 
@@ -495,7 +626,13 @@ class _PreparedCall:
         self._matches_args = _make_prepared_arg_guard(bound.kernel, args)
         self._dist_initialized = dist_initialized
         self._is_distributed = is_distributed
-        self._extra_guards = extra_guards
+        (
+            self._tensor_storage_reuse_guard,
+            self._extra_guards,
+            self._reusable_extra_guards,
+        ) = _partition_prepared_extra_guards(args, extra_guards)
+        self._specialization_generation = bound.kernel._specialization_generation
+        self._reset_generation = bound.kernel._reset_generation
         self.bound = bound
 
     @classmethod
@@ -533,7 +670,11 @@ class _PreparedCall:
 
     def matches(self, kernel: Kernel, args: tuple[object, ...]) -> bool:
         try:
-            if not self._matches_args(args):
+            if (
+                self._reset_generation != kernel._reset_generation
+                or self._specialization_generation != kernel._specialization_generation
+                or not self._matches_args(args)
+            ):
                 return False
             dist_initialized = dist.is_initialized()
             # ``kernel_uses_symm_mem`` and declared distributed intent are both
@@ -550,7 +691,16 @@ class _PreparedCall:
             for extractor, expected in self._extra_guards:
                 if extractor(args) != expected:
                     return False
-            return True
+            if self._tensor_storage_reuse_guard is None or not (
+                self._tensor_storage_reuse_guard(args)
+            ):
+                for extractor, expected in self._reusable_extra_guards:
+                    if extractor(args) != expected:
+                        return False
+            return (
+                self._reset_generation == kernel._reset_generation
+                and self._specialization_generation == kernel._specialization_generation
+            )
         except Exception:
             # Guard evaluation is an optional fast path. Falling through lets
             # the normal dispatch machinery preserve its own error semantics.
@@ -857,6 +1007,7 @@ class Kernel(Generic[_R]):
         signature: tuple[Hashable, ...],
         *,
         extra_fns: list[Callable[[Sequence[object]], Hashable]] | None = None,
+        snapshot_runtime_results: bool = False,
     ) -> BoundKernelInMemoryCacheKey:
         from ..autotuner.base_cache import BoundKernelInMemoryCacheKey
 
@@ -923,6 +1074,11 @@ class Kernel(Generic[_R]):
                     and self._compiler_seed_specialize_extra.get(signature)
                     is active_compiler_seed_fns
                 ):
+                    if snapshot_runtime_results:
+                        bound_kernel._record_runtime_input_specialization_results(
+                            active_extra_fns,
+                            extra_results,
+                        )
                     return cache_key
 
     def _extend_bound_kernel_specializations(
@@ -1017,7 +1173,24 @@ class Kernel(Generic[_R]):
                 if cached_bound._base_spec_key == signature:
                     self._dispatch_cache.pop(fast_key)
             self._prepared_call = None
-            self._bound_kernels[updated_cache_key] = bound_kernel
+            if bound_kernel._record_runtime_input_specialization_results(
+                updated_extractors,
+                current_results,
+            ):
+                self._bound_kernels[updated_cache_key] = bound_kernel
+            else:
+                # A BoundKernel's generated programs may already consume its
+                # construction-time storage facts.  If those facts changed
+                # while a late specialization was discovered, do not migrate
+                # the existing programs to the new cache identity.  Retire the
+                # bound through the same generation check used by reset(); a
+                # later call will bind and compile against the extended schema.
+                bound_kernel._reset_generation = self._reset_generation - 1
+                bound_kernel._direct_prepared_call = None
+                bound_kernel._run = None
+                bound_kernel._config = None
+                bound_kernel._compile_cache.clear()
+                bound_kernel._cache_path_map.clear()
             return True
 
     def _compute_is_distributed(
@@ -1320,7 +1493,17 @@ class Kernel(Generic[_R]):
                         args,
                         signature,
                         extra_fns=extra_fns,
+                        snapshot_runtime_results=(
+                            signature == bound_kernel._base_spec_key
+                        ),
                     )
+                elif signature == bound_kernel._base_spec_key:
+                    published_extra_fns = self._specialize_extra.get(signature)
+                    if published_extra_fns is not None:
+                        bound_kernel._record_runtime_input_specialization_results(
+                            published_extra_fns,
+                            cache_key.extra_results,
+                        )
                 self._bound_kernels[cache_key] = bound_kernel
             return bound_kernel
 
@@ -1944,6 +2127,10 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         self._reset_generation = kernel._reset_generation
         # Extending this bound's schema evicts all of its dispatch mappings.
         self._dispatch_generation: int | None = None
+        # ``Kernel.__call__`` owns a shared prepared fast path, but callers may
+        # also retain and invoke a BoundKernel directly (benchmark harnesses do
+        # this deliberately). Keep the latest validated direct-call guard here.
+        self._direct_prepared_call: _PreparedCall | None = None
         self._cache_managed = cache_managed
         if is_distributed is None:
             dist_initialized = dist.is_initialized()
@@ -2066,6 +2253,10 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                         self.env,
                         self.host_function.device_ir,
                     )
+                    if not self._cache_managed:
+                        self.env.snapshot_runtime_input_specialization_results(
+                            runtime_args
+                        )
                 self._compiler_seed_specialization_extractors = (
                     _compiler_seed_specialization_extractors(
                         compiler_seed_specialization_facts(
@@ -2748,7 +2939,10 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         extracted_strides: set[TensorPropertySource] = set()
         for v in sorted(self.env.specialized_vars, key=lambda v: v.name):
             source = self.env.shape_env.var_to_sources[v][0]
-            extractors.append(make_extractor(source))
+            extractor = make_extractor(source)
+            if isinstance(source, TensorPropertySource):
+                extractor = _PreparedMetadataSpecializationExtractor(extractor)
+            extractors.append(extractor)
             if (
                 isinstance(source, TensorPropertySource)
                 and source.prop == TensorProperty.STRIDE
@@ -2758,7 +2952,9 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         for source in sorted(self.env.specialized_strides, key=repr):
             if source in extracted_strides:
                 continue
-            extractors.append(make_extractor(source))
+            extractors.append(
+                _PreparedMetadataSpecializationExtractor(make_extractor(source))
+            )
         implicit_config = self._fixed_config_for_td_layout_guards()
         for source, guard in sorted(
             self.env.tensor_descriptor_layout_guards.items(),
@@ -2786,30 +2982,53 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                     _element_size,
                 )
 
-            extractors.append(td_layout_extractor)
+            extractors.append(
+                _PreparedMetadataSpecializationExtractor(td_layout_extractor)
+            )
 
-        for _key, specialization in sorted(
+        for key, specialization in sorted(
             self.env.runtime_input_specializations.items(),
         ):
             source_extractors = tuple(
                 make_extractor(source) for source in specialization.sources
             )
 
-            def runtime_input_specialization_extractor(
-                args: Sequence[object],
-                _source_extractors: tuple[
-                    Callable[[Sequence[object]], Hashable], ...
-                ] = source_extractors,
-                _classifier: Callable[
-                    [Sequence[object]], Hashable
-                ] = specialization.classifier,
-            ) -> Hashable:
-                return _classifier(
-                    tuple(extract(args) for extract in _source_extractors)
+            extractors.append(
+                _RuntimeInputSpecializationExtractor(
+                    source_extractors,
+                    specialization.classifier,
+                    frozenset(specialization.reusable_tensor_properties),
+                    key,
                 )
-
-            extractors.append(runtime_input_specialization_extractor)
+            )
         return extractors
+
+    def _record_runtime_input_specialization_results(
+        self,
+        extractors: Sequence[Callable[[Sequence[object]], Hashable]],
+        results: Sequence[Hashable],
+    ) -> bool:
+        """Initialize immutable reusable facts from an exact cache-key evaluation."""
+        expected_keys = {
+            key
+            for key, specialization in self.env.runtime_input_specializations.items()
+            if specialization.reusable_tensor_properties
+        }
+        observed = {
+            extractor.specialization_key: result
+            for extractor, result in zip(extractors, results, strict=True)
+            if isinstance(extractor, _RuntimeInputSpecializationExtractor)
+            and extractor.specialization_key is not None
+            and extractor.reusable_tensor_properties
+        }
+        if observed.keys() != expected_keys:
+            return False
+        previous = self.env.bound_runtime_input_specialization_results
+        if previous and previous != observed:
+            return False
+        if not previous:
+            self.env.bound_runtime_input_specialization_results = observed
+        return True
 
     @contextlib.contextmanager
     def _runtime_arg_values_for_codegen(self) -> Generator[None, None, None]:
@@ -2957,6 +3176,22 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         Returns:
             _R: The result of the kernel execution.
         """
+        if (
+            self._cache_managed
+            and self._reset_generation != self.kernel._reset_generation
+        ):
+            return self.kernel.bind(args)(*args)
+        is_compiling = torch.compiler.is_compiling()
+        if (
+            not is_compiling
+            and self._cache_managed
+            and (prepared := self._direct_prepared_call) is not None
+            and prepared.bound is self
+            and prepared.matches(self.kernel, args)
+            and self._run is not None
+        ):
+            return self._run(*args)
+
         if self._cache_managed and self._compiler_seed_specialization_extractors:
             device_results: tuple[Hashable | None, ...] | None = None
             new_compiler_seed_device = False
@@ -3021,7 +3256,39 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                     assert self._run is not None
                     self.maybe_log_repro(log.warning, args)
 
-        return self._run(*args)
+        result = self._run(*args)
+        if not is_compiling and self._cache_managed:
+            self._prepare_direct_call(args)
+        return result
+
+    def _prepare_direct_call(self, args: tuple[object, ...]) -> None:
+        """Publish a monomorphic fast path for repeated BoundKernel calls."""
+        run = self._run
+        if (
+            run is None
+            or self.kernel._key_fn is not None
+            or not self.env.backend.supports_eager_prepared_call
+            or not self.kernel._has_specialization_extras
+        ):
+            return
+        try:
+            fast_entry = self.kernel._fast_dispatch_key_and_guards(args)
+            if fast_entry is None:
+                return
+            with self.kernel._bind_lock:
+                if (
+                    self._reset_generation != self.kernel._reset_generation
+                    or self.kernel._bind(args) is not self
+                    or self._run is not run
+                ):
+                    return
+                entry = self.kernel._prepare_dispatch_entry(args, self, fast_entry)
+                if entry is not None and entry[0] is not None:
+                    self._direct_prepared_call = entry[0]
+        except Exception:
+            # Preparation runs after the real kernel call.  It is optional and
+            # must not turn a successful launch into a user-visible failure.
+            return
 
     def backend_cache_key(self, config: ConfigLike | None = None) -> str | None:
         """

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -100,6 +100,7 @@ from helion.autotuner.local_cache import StrictLocalAutotuneCache
 from helion.autotuner.local_cache import _cute_flash_search_policy_hash
 from helion.autotuner.logger import AutotuneLogEntry
 from helion.autotuner.logger import AutotuningLogger
+from helion.autotuner.metrics import AutotuneMetrics
 from helion.autotuner.metrics import KernelMetadata
 from helion.autotuner.pattern_search import InitialPopulationStrategy
 from helion.autotuner.random_search import RandomSearch
@@ -983,7 +984,7 @@ class TestAutotuneIgnoreErrors(TestCase):
         "fork" not in mp.get_all_start_methods(),
         reason="fork start method is unavailable on this platform",
     )
-    def test_fork_precompile_avoids_cuda_reinit(self):
+    def test_fork_precompile_avoids_device_reinit(self):
         settings = Settings(
             autotune_precompile="fork",
             autotune_log_level=logging.CRITICAL,
@@ -993,6 +994,7 @@ class TestAutotuneIgnoreErrors(TestCase):
 
         parent_pid = os.getpid()
         lazy_calls: list[int] = []
+        device_module = torch.get_device_module(DEVICE)
 
         def fake_lazy_init() -> None:
             lazy_calls.append(os.getpid())
@@ -1009,7 +1011,7 @@ class TestAutotuneIgnoreErrors(TestCase):
         def fake_compiled_fn(
             *fn_args: object, _launcher: Callable[..., object]
         ) -> None:
-            torch.cuda._lazy_init()
+            device_module._lazy_init()  # pyrefly: ignore[missing-attribute]
             _launcher("fake_kernel", (1,), *fn_args)
 
         with (
@@ -1017,7 +1019,7 @@ class TestAutotuneIgnoreErrors(TestCase):
                 "helion.autotuner.precompile_future.make_precompiler",
                 side_effect=fake_make_precompiler,
             ),
-            patch("torch.cuda._lazy_init", side_effect=fake_lazy_init),
+            patch.object(device_module, "_lazy_init", side_effect=fake_lazy_init),
         ):
             future = search.benchmark_provider._create_precompile_future(
                 "cfg", fake_compiled_fn
@@ -10049,12 +10051,14 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             use_isolated: bool = True,
             confirm_suspicious: bool = True,
             use_interleaved: bool = True,
+            candidate_private_args: bool = False,
         ) -> None:
             self.assertIn("Final verification", desc)
             self.assertEqual(target_ms, 5000.0)
             self.assertFalse(use_isolated)
             self.assertFalse(confirm_suspicious)
             self.assertTrue(use_interleaved)
+            self.assertFalse(candidate_private_args)
             for member in members:
                 member.perfs.append(10.0 if member is stable else 12.0)
 
@@ -10235,7 +10239,9 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             use_isolated: bool = True,
             confirm_suspicious: bool = True,
             use_interleaved: bool = True,
+            candidate_private_args: bool = False,
         ) -> None:
+            self.assertFalse(candidate_private_args)
             for member in members:
                 member.perfs.append(10.04 if member is pinned else 10.0)
 
@@ -10275,7 +10281,9 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             use_isolated: bool = True,
             confirm_suspicious: bool = True,
             use_interleaved: bool = True,
+            candidate_private_args: bool = False,
         ) -> None:
+            self.assertFalse(candidate_private_args)
             for member in members:
                 member.perfs.append(10.04 if member is pinned else 10.0)
 
@@ -10336,12 +10344,14 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             use_isolated: bool = True,
             confirm_suspicious: bool = True,
             use_interleaved: bool = True,
+            candidate_private_args: bool = False,
         ) -> None:
             self.assertIn("Final verification", desc)
             self.assertEqual(target_ms, 5000.0)
             self.assertTrue(use_isolated)
             self.assertTrue(confirm_suspicious)
             self.assertFalse(use_interleaved)
+            self.assertTrue(candidate_private_args)
             for member in members:
                 member.perfs.append(9.5 if member is member_a else 10.0)
 
@@ -10564,6 +10574,141 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         self.assertEqual(member_a.perfs, [100.0, 51.0])
         self.assertEqual(member_b.perfs, [101.0, 52.0])
         self.assertEqual(clear.call_count, 2)
+
+    def test_rebenchmark_isolates_mutated_args_when_worker_unavailable(self) -> None:
+        settings = Settings(autotune_log_level=logging.CRITICAL)
+        search = PopulationBasedSearch.__new__(PopulationBasedSearch)
+        search.settings = settings
+        original = torch.zeros(1)
+        search.args = (original,)
+        search.log = AutotuningLogger(settings)
+        search.best_perf_so_far = 100.0
+        search.benchmark_provider = SimpleNamespace(
+            mutated_arg_indices=[0],
+            benchmark_isolated=lambda _fns, *, warmup, rep, desc: None,
+        )
+        search.kernel = SimpleNamespace(env=SimpleNamespace(process_group_name=None))
+        observed_pointers: dict[str, list[int]] = {"a": [], "b": []}
+
+        def fn_a(value: torch.Tensor) -> None:
+            observed_pointers["a"].append(value.data_ptr())
+            value.add_(1)
+
+        def fn_b(value: torch.Tensor) -> None:
+            observed_pointers["b"].append(value.data_ptr())
+            value.add_(1)
+
+        def steady_bench(
+            fn: Callable[[], object],
+            *,
+            warmup: int,
+            rep: int,
+            return_mode: str,
+            process_group_name: str | None = None,
+        ) -> float:
+            fn()
+            return 50.0
+
+        search.config_spec = SimpleNamespace(
+            backend=SimpleNamespace(get_do_bench=lambda: steady_bench)
+        )
+        member_a = PopulationMember(fn_a, [100.0], (), helion.Config(num_warps=4))
+        member_b = PopulationMember(fn_b, [101.0], (), helion.Config(num_warps=8))
+
+        with patch(
+            "helion.autotuner.base_search._clone_args",
+            side_effect=lambda args, process_group_name, idx_to_clone: tuple(
+                value.clone()
+                if idx_to_clone is None or index in idx_to_clone
+                else value
+                for index, value in enumerate(args)
+            ),
+        ) as clone_args:
+            search.rebenchmark(
+                [member_a, member_b],
+                target_ms=1000.0,
+                use_isolated=True,
+                confirm_suspicious=False,
+                use_interleaved=False,
+                candidate_private_args=True,
+            )
+
+        self.assertEqual(clone_args.call_count, 3)
+        self.assertTrue(
+            all(
+                call.kwargs["idx_to_clone"] is None
+                for call in clone_args.call_args_list
+            )
+        )
+        self.assertNotEqual(observed_pointers["a"], observed_pointers["b"])
+        self.assertNotEqual(observed_pointers["a"], [original.data_ptr()])
+        self.assertNotEqual(observed_pointers["b"], [original.data_ptr()])
+        self.assertTrue(torch.equal(original, torch.zeros_like(original)))
+
+    def test_rebenchmark_falls_back_when_isolated_wrapper_is_unloadable(self) -> None:
+        settings = Settings(autotune_log_level=logging.CRITICAL)
+        provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
+        provider.settings = settings
+        provider.log = Mock()
+        provider.mutated_arg_indices = []
+        provider._autotune_metrics = AutotuneMetrics()
+        provider._subprocess_wrapper_unloadable = False
+        provider._subprocess_benchmark_enabled = lambda: True
+        isolated_calls = 0
+
+        def unloadable_wrapper(
+            _fn: object,
+            *,
+            warmup: int,
+            rep: int,
+        ) -> None:
+            nonlocal isolated_calls
+            isolated_calls += 1
+            provider._subprocess_wrapper_unloadable = True
+            return None
+
+        provider._run_subprocess_benchmark_job = unloadable_wrapper
+
+        search = PopulationBasedSearch.__new__(PopulationBasedSearch)
+        search.settings = settings
+        search.args = ()
+        search.log = AutotuningLogger(settings)
+        search.best_perf_so_far = 100.0
+        search.benchmark_provider = provider
+        search.kernel = SimpleNamespace(env=SimpleNamespace(process_group_name=None))
+        in_process_calls = 0
+
+        def steady_bench(
+            fn: Callable[[], object],
+            *,
+            warmup: int,
+            rep: int,
+            return_mode: str,
+            process_group_name: str | None = None,
+        ) -> float:
+            nonlocal in_process_calls
+            fn()
+            in_process_calls += 1
+            return 50.0 + in_process_calls
+
+        search.config_spec = SimpleNamespace(
+            backend=SimpleNamespace(get_do_bench=lambda: steady_bench)
+        )
+        member_a = PopulationMember(lambda: None, [100.0], (), helion.Config())
+        member_b = PopulationMember(lambda: None, [101.0], (), helion.Config())
+
+        search.rebenchmark(
+            [member_a, member_b],
+            target_ms=1000.0,
+            use_isolated=True,
+            confirm_suspicious=False,
+            use_interleaved=False,
+        )
+
+        self.assertEqual(isolated_calls, 1)
+        self.assertEqual(in_process_calls, 2)
+        self.assertEqual(member_a.perfs, [100.0, 51.0])
+        self.assertEqual(member_b.perfs, [101.0, 52.0])
 
     def test_final_rebenchmark_respects_custom_benchmark_fn(
         self,
@@ -15655,8 +15800,6 @@ class TestSelectedSourceMetrics(TestCase):
         population_search: bool = True,
         source_tracking_enabled: bool = True,
     ) -> tuple[BaseSearch, helion.Config]:
-        from helion.autotuner.metrics import AutotuneMetrics
-
         config = helion.Config(block_sizes=[64])
         fn = SimpleNamespace(source_hash="selected-source")
         search_type = PopulationBasedSearch if population_search else BaseSearch

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -8709,7 +8709,17 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         )
         with (
             patch_cute_mma_support(),
-            patch("torch.cuda.get_device_capability", return_value=(10, 0)),
+            patch(
+                "helion.runtime.kernel.target_device_capability",
+                return_value=(10, 0),
+            ),
+            patch(
+                "helion._compiler.compile_environment.target_device_capability",
+                return_value=(10, 0),
+            ),
+            patch("helion.language.loops.use_tileir_tunables", return_value=False),
+            patch("helion.language.loops._supports_warp_specialize", return_value=True),
+            patch("helion._compat._supports_tensor_descriptor", return_value=True),
         ):
             bound = cute_matmul_bias_residual_gelu.bind(args)
 
@@ -9267,12 +9277,6 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         )
         with (
             patch_cute_mma_support(),
-            patch("torch.cuda.get_device_capability", return_value=(10, 0)),
-            # target_device_capability is memoized (is_hip / _is_hip pattern),
-            # so torch.cuda.get_device_capability alone no longer reaches its
-            # consumers. Patch each seam the bind path reads: the bound-kernel
-            # cache key (runtime.kernel) and the ConfigSpec arch capability,
-            # which CompileEnvironment captures onto config_spec at build time.
             patch(
                 "helion.runtime.kernel.target_device_capability",
                 return_value=(10, 0),
@@ -9281,11 +9285,13 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 "helion._compiler.compile_environment.target_device_capability",
                 return_value=(10, 0),
             ),
+            patch("helion.language.loops.use_tileir_tunables", return_value=False),
+            patch("helion.language.loops._supports_warp_specialize", return_value=True),
+            patch("helion._compat._supports_tensor_descriptor", return_value=True),
         ):
             bound = cute_matmul_bias_residual_gelu.bind(args)
         with (
             patch_cute_mma_support(),
-            patch("torch.cuda.get_device_capability", return_value=(9, 0)),
             patch(
                 "helion.runtime.kernel.target_device_capability",
                 return_value=(9, 0),
@@ -9294,6 +9300,12 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 "helion._compiler.compile_environment.target_device_capability",
                 return_value=(9, 0),
             ),
+            patch("helion.language.loops.use_tileir_tunables", return_value=False),
+            patch(
+                "helion.language.loops._supports_warp_specialize",
+                return_value=False,
+            ),
+            patch("helion._compat._supports_tensor_descriptor", return_value=True),
         ):
             sm90_bound = cute_matmul_bias_residual_gelu.bind(args)
         self.assertIsNot(sm90_bound, bound)
@@ -9491,7 +9503,17 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         )
         with (
             patch_cute_mma_support(),
-            patch("torch.cuda.get_device_capability", return_value=(10, 0)),
+            patch(
+                "helion.runtime.kernel.target_device_capability",
+                return_value=(10, 0),
+            ),
+            patch(
+                "helion._compiler.compile_environment.target_device_capability",
+                return_value=(10, 0),
+            ),
+            patch("helion.language.loops.use_tileir_tunables", return_value=False),
+            patch("helion.language.loops._supports_warp_specialize", return_value=True),
+            patch("helion._compat._supports_tensor_descriptor", return_value=True),
         ):
             bound = cute_matmul_bias_residual_gelu.bind(args)
 
@@ -9573,7 +9595,17 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         )
         with (
             patch_cute_mma_support(),
-            patch("torch.cuda.get_device_capability", return_value=(10, 0)),
+            patch(
+                "helion.runtime.kernel.target_device_capability",
+                return_value=(10, 0),
+            ),
+            patch(
+                "helion._compiler.compile_environment.target_device_capability",
+                return_value=(10, 0),
+            ),
+            patch("helion.language.loops.use_tileir_tunables", return_value=False),
+            patch("helion.language.loops._supports_warp_specialize", return_value=True),
+            patch("helion._compat._supports_tensor_descriptor", return_value=True),
         ):
             bound = cute_matmul_bias_residual_gelu.bind(args)
 

--- a/test/test_benchmark_provider_clone_args.py
+++ b/test/test_benchmark_provider_clone_args.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import cast
+
+import torch
+
+from helion.autotuner.benchmark_provider import _clone_args
+
+
+def _storage_id(tensor: torch.Tensor) -> int:
+    return tensor.untyped_storage()._cdata
+
+
+def test_clone_args_preserves_shared_storage_views_and_duplicate_refs() -> None:
+    storage = torch.arange(128, dtype=torch.uint8)
+    int16_view = storage.view(torch.int16).as_strided((3, 4), (6, 1), 2)
+    float32_view = storage[8:72].view(torch.float32)[::2]
+    broadcast_view = storage[20:21].expand(3, 4)
+    unrelated = torch.ones(4)
+    args = ([int16_view, float32_view, int16_view, broadcast_view], unrelated)
+
+    cloned = cast(
+        "tuple[list[torch.Tensor], torch.Tensor]",
+        _clone_args(args, process_group_name=None, idx_to_clone=(0,)),
+    )
+    cloned_views, cloned_unrelated = cloned
+
+    assert cloned_views[0] is cloned_views[2]
+    assert len({_storage_id(tensor) for tensor in cloned_views}) == 1
+    assert _storage_id(cloned_views[0]) != _storage_id(int16_view)
+    assert cloned_unrelated is unrelated
+    for original, copy_ in zip(
+        (int16_view, float32_view, int16_view, broadcast_view),
+        cloned_views,
+        strict=True,
+    ):
+        assert copy_.dtype is original.dtype
+        assert copy_.shape == original.shape
+        assert copy_.stride() == original.stride()
+        assert copy_.storage_offset() == original.storage_offset()
+        assert copy_.untyped_storage().nbytes() == original.untyped_storage().nbytes()
+
+    original_bytes = storage.clone()
+    cloned_views[0].fill_(0)
+    assert torch.equal(storage, original_bytes)
+
+
+def test_clone_args_creates_candidate_private_alias_groups() -> None:
+    storage = torch.arange(64, dtype=torch.float32)
+    even = storage[3:35:2]
+    overlapping = storage[7:23]
+    args = (even, overlapping)
+
+    first = cast(
+        "tuple[torch.Tensor, torch.Tensor]",
+        _clone_args(args, process_group_name=None, idx_to_clone=(0,)),
+    )
+    second = cast(
+        "tuple[torch.Tensor, torch.Tensor]",
+        _clone_args(args, process_group_name=None, idx_to_clone=(0,)),
+    )
+
+    assert _storage_id(first[0]) == _storage_id(first[1])
+    assert _storage_id(second[0]) == _storage_id(second[1])
+    assert _storage_id(first[0]) != _storage_id(second[0])
+    assert _storage_id(first[0]) != _storage_id(storage)
+    first[1].zero_()
+    assert not torch.equal(first[0], second[0])
+    assert torch.equal(storage, torch.arange(64, dtype=torch.float32))

--- a/test/test_benchmark_worker.py
+++ b/test/test_benchmark_worker.py
@@ -42,6 +42,7 @@ from helion.autotuner.base_search import PopulationMember
 from helion.autotuner.benchmark_job import AccuracyCheckJob
 from helion.autotuner.benchmark_job import AccuracyCheckResult
 from helion.autotuner.benchmark_job import BenchmarkJob
+from helion.autotuner.benchmark_job import CompiledFunctionLoadError
 from helion.autotuner.benchmark_provider import BenchmarkResult
 from helion.autotuner.benchmark_provider import IsolatedBenchmarkFailure
 from helion.autotuner.benchmark_provider import LocalBenchmarkProvider
@@ -309,6 +310,86 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
 
         modules_after = {name for name in sys.modules if name.startswith(module_prefix)}
         self.assertEqual(modules_after, modules_before)
+
+    def test_benchmark_job_classifies_wrapper_load_failure(self) -> None:
+        fn_spec = SerializedCompiledFunction(
+            function_name="call",
+            source_code="import helion_test_missing_worker_module_xyz\n",
+            filename=None,
+            module_name=None,
+        )
+
+        worker = BenchmarkWorker()
+        try:
+            with self.assertRaisesRegex(
+                CompiledFunctionLoadError,
+                "ModuleNotFoundError.*helion_test_missing_worker_module_xyz",
+            ):
+                worker.run(BenchmarkJob(fn_spec, "unused-args.pt"), timeout=30)
+        finally:
+            worker.shutdown()
+
+    def test_benchmark_job_classifies_non_import_load_failures(self) -> None:
+        fn_spec = SerializedCompiledFunction(
+            function_name="call",
+            source_code="raise RuntimeError('generated wrapper failed')\n",
+            filename=None,
+            module_name=None,
+        )
+
+        with self.assertRaisesRegex(
+            CompiledFunctionLoadError,
+            "RuntimeError.*generated wrapper failed",
+        ):
+            BenchmarkJob(fn_spec, "unused-args.pt")()
+
+    def test_source_module_exec_failure_is_classified_and_cleaned_up(self) -> None:
+        origin_name = "helion_test_failing_synthetic_origin_xyz"
+        sys.modules.pop(origin_name, None)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            origin_file = Path(tmpdir) / "origin.py"
+            origin_file.write_text(
+                "PARTIAL = True\nraise RuntimeError('origin exec failed')\n",
+                encoding="utf-8",
+            )
+            fn_spec = SerializedCompiledFunction(
+                function_name="call",
+                source_code=f"import {origin_name}\ndef call():\n    return None\n",
+                filename=None,
+                module_name=None,
+                source_modules=[(origin_name, str(origin_file))],
+            )
+
+            with self.assertRaisesRegex(
+                CompiledFunctionLoadError,
+                "RuntimeError.*origin exec failed",
+            ):
+                BenchmarkJob(fn_spec, "unused-args.pt")()
+
+        self.assertNotIn(origin_name, sys.modules)
+
+    def test_benchmark_job_does_not_reclassify_post_load_failure(self) -> None:
+        fn_spec = SerializedCompiledFunction(
+            function_name="call",
+            source_code="def call():\n    raise RuntimeError('kernel execution failed')\n",
+            filename=None,
+            module_name=None,
+        )
+
+        with (
+            patch(
+                "helion.autotuner.benchmark_job.load_trusted_kernel_args",
+                return_value=(),
+            ),
+            patch(
+                "helion.autotuner.benchmark_job.do_bench",
+                side_effect=lambda fn, **_kwargs: fn(),
+            ),
+            self.assertRaisesRegex(RuntimeError, "kernel execution failed") as raised,
+        ):
+            BenchmarkJob(fn_spec, "unused-args.pt")()
+
+        self.assertNotIsInstance(raised.exception, CompiledFunctionLoadError)
 
     def test_benchmark_job_can_use_wall_clock_bench(self) -> None:
         fn = _ReturnValue(torch.empty(()))
@@ -769,6 +850,36 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
         _, kwargs = provider._benchmark_worker.run.call_args
         self.assertEqual(kwargs["timeout"], 17.0)
 
+    def test_accuracy_wrapper_load_failure_falls_back_and_disables_worker(
+        self,
+    ) -> None:
+        provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
+        provider.settings = Settings(autotune_benchmark_timeout=17)
+        provider._precompile_args_path = "/tmp/args.pt"
+        provider._precompile_baseline_path = "/tmp/baseline.pt"
+        provider._effective_atol = 0.0
+        provider._effective_rtol = 0.0
+        provider._scale_atol = False
+        provider.log = Mock()
+        worker = Mock()
+        provider._benchmark_worker = worker
+        provider._subprocess_wrapper_unloadable = False
+        provider._subprocess_accuracy_check_enabled = lambda: True
+        worker.run.side_effect = CompiledFunctionLoadError("origin exec failed")
+
+        with patch(
+            "helion.autotuner.benchmark_provider._serialize_compiled_fn",
+            return_value=cast("SerializedCompiledFunction", object()),
+        ):
+            result = provider._run_subprocess_accuracy_check_job(
+                cast("CompiledConfig", object())
+            )
+
+        self.assertIsNone(result)
+        self.assertTrue(provider._subprocess_wrapper_unloadable)
+        worker.shutdown.assert_called_once()
+        self.assertIsNone(provider._benchmark_worker)
+
     def test_benchmark_timeout_has_worker_metric_and_status(self) -> None:
         provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
         provider.config_spec = SimpleNamespace(
@@ -1064,6 +1175,46 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
         self.assertEqual(provider._autotune_metrics.num_worker_failures, 1)
         self.assertEqual(provider._autotune_metrics.num_compile_failures, 0)
         run_job.assert_called_once()
+
+    def test_wrapper_load_failure_falls_back_and_disables_worker(self) -> None:
+        provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
+        provider.config_spec = SimpleNamespace(
+            compiler_seed_timeout_retry_repetitions=None,
+            backend=SimpleNamespace(name="cute", get_do_bench=lambda: None),
+            cute_flash_search_enabled=False,
+        )
+        provider.settings = Settings(autotune_benchmark_subprocess=True)
+        provider.log = Mock()
+        provider.kernel = SimpleNamespace(supports_subprocess_benchmark=lambda: True)
+        provider.mutated_arg_indices = []
+        provider._args_unpicklable = False
+        provider._precompile_args_path = "args.pt"
+        worker = Mock()
+        provider._benchmark_worker = worker
+        provider._compiler_seed_configs = set()
+        provider._compiler_seed_source_hashes = set()
+        provider._subprocess_wrapper_unloadable = False
+        worker.run.side_effect = CompiledFunctionLoadError("missing source module")
+
+        with patch(
+            "helion.autotuner.benchmark_provider._serialize_compiled_fn",
+            return_value=cast("SerializedCompiledFunction", object()),
+        ):
+            first = provider._run_subprocess_benchmark_job(
+                cast("CompiledConfig", object()), warmup=1, rep=50
+            )
+            second = provider._run_subprocess_benchmark_job(
+                cast("CompiledConfig", object()), warmup=1, rep=50
+            )
+
+        self.assertIsNone(first)
+        self.assertIsNone(second)
+        self.assertTrue(provider._subprocess_wrapper_unloadable)
+        self.assertFalse(provider._subprocess_benchmark_enabled())
+        provider.log.debug.assert_called_once()
+        worker.run.assert_called_once()
+        worker.shutdown.assert_called_once()
+        self.assertIsNone(provider._benchmark_worker)
 
     def test_fixed_repetition_job_uses_existing_benchmark_timeout(self) -> None:
         provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)

--- a/test/test_benchmarking.py
+++ b/test/test_benchmarking.py
@@ -4281,7 +4281,6 @@ def test_attention_bound_varied_b200_compiler_seed_order_and_population(
     expected_raw_count,
     expected_effective_count,
 ):
-    from torch._inductor.runtime.hints import DeviceProperties
     from torch._subclasses.fake_tensor import FakeTensorMode
 
     import helion
@@ -4289,51 +4288,29 @@ def test_attention_bound_varied_b200_compiler_seed_order_and_population(
     from helion._compiler.cute.cute_flash import FLASH_PIPELINE_FAMILY_KEY
     from helion._compiler.cute.cute_flash import FLASH_SOFTMAX_DISC_KEY
     from helion._compiler.cute.cute_flash import flash_structural_leaf_from_config
+    from helion._hardware import HardwareInfo
+    from helion._testing import patch_cute_mma_support
 
     attention_example = importlib.import_module("examples.attention")
+    compat_module = importlib.import_module("helion._compat")
     compile_environment = importlib.import_module(
         "helion._compiler.compile_environment"
     )
+    hardware_module = importlib.import_module("helion._hardware")
     kernel_module = importlib.import_module("helion.runtime.kernel")
+    loops_module = importlib.import_module("helion.language.loops")
     runtime_module = importlib.import_module("helion.runtime")
     source_kernel = getattr(attention_example, kernel_name)
     kernel = helion.kernel(source_kernel.fn, static_shapes=True, backend="cute")
-    fake_device_properties = DeviceProperties(
-        type="cuda",
-        index=0,
-        multi_processor_count=148,
-        cc=100,
-        major=10,
-        regs_per_multiprocessor=65536,
-        max_threads_per_multi_processor=2048,
-        max_threads_per_block=1024,
-        warp_size=32,
+    cached_hardware_decisions = (
+        compat_module._target_device_capability,
+        compat_module._supports_tensor_descriptor,
+        compat_module._min_dot_size,
+        compat_module._is_hip,
+        loops_module.use_tileir_tunables,
+        hardware_module.get_hardware_info,
     )
-    fake_cuda_properties = SimpleNamespace(
-        name="NVIDIA B200",
-        major=10,
-        minor=0,
-        multi_processor_count=148,
-        regs_per_multiprocessor=65536,
-        max_threads_per_multi_processor=2048,
-        max_threads_per_block=1024,
-        warp_size=32,
-        total_memory=192 * 1024**3,
-    )
-    monkeypatch.setattr(
-        DeviceProperties,
-        "create",
-        classmethod(lambda _cls, _device: fake_device_properties),
-    )
-    monkeypatch.setattr(
-        torch.cuda, "get_device_capability", lambda _device=None: (10, 0)
-    )
-    monkeypatch.setattr(
-        torch.cuda, "get_device_properties", lambda _device=None: fake_cuda_properties
-    )
-    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
-    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
-    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+    cache_info = tuple(fn.cache_info() for fn in cached_hardware_decisions)
     monkeypatch.setattr(
         kernel_module, "target_device_capability", lambda _device: (10, 0)
     )
@@ -4345,8 +4322,27 @@ def test_attention_bound_varied_b200_compiler_seed_order_and_population(
     monkeypatch.setattr(
         runtime_module, "get_num_sm", lambda _device, reserved_sms=0: 148
     )
+    monkeypatch.setattr(loops_module, "use_tileir_tunables", lambda: False)
+    monkeypatch.setattr(loops_module, "_supports_warp_specialize", lambda: True)
+    monkeypatch.setattr(compat_module, "_supports_tensor_descriptor", lambda: True)
+    monkeypatch.setattr(
+        compat_module,
+        "_min_dot_size",
+        lambda _device, _lhs, _rhs: (16, 16, 16),
+    )
+    monkeypatch.setattr(compat_module, "_is_hip", lambda: False)
+    monkeypatch.setattr(
+        hardware_module,
+        "get_hardware_info",
+        lambda _device=None: HardwareInfo(
+            device_kind="cuda",
+            hardware_name="NVIDIA B200",
+            runtime_version="13.0",
+            compute_capability="sm100",
+        ),
+    )
 
-    with FakeTensorMode():
+    with patch_cute_mma_support(), FakeTensorMode():
         q = torch.empty(
             shape,
             device="cuda",  # @ignore-device-lint
@@ -4400,11 +4396,13 @@ def test_attention_bound_varied_b200_compiler_seed_order_and_population(
     if kernel_name == "causal_attention_output" and shape == (2, 32, 65536, 64):
         assert any(
             raw.config is not None
-            and raw.config.config.get("cute_vector_widths") == [1, 1, 1]
+            and raw.config.config.get("cute_vector_widths")
+            == [1] * len(spec.cute_vector_widths)
             and normalized.config is not None
             and "cute_vector_widths" not in normalized.config.config
             for raw, normalized in zip(raw_projections, projections, strict=True)
         )
+    assert tuple(fn.cache_info() for fn in cached_hardware_decisions) == cache_info
 
 
 def test_attention_compiler_seed_generation_zero_requires_terminal_evidence():

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -9495,6 +9495,9 @@ class TestCuteBackend(TestCase):
             patch(
                 "helion.runtime.cute.launcher._record_cute_owned_launch_tensors"
             ) as record_owned,
+            patch(
+                "helion.runtime.cute.launcher._retain_cute_capture_owned_launch_tensors"
+            ) as retain_owned,
         ):
             first = default_cute_launcher(cute_kernel, (1,), 7, block=(32, 1, 1))
             second = default_cute_launcher(cute_kernel, (1,), 7, block=(32, 1, 1))
@@ -9503,6 +9506,7 @@ class TestCuteBackend(TestCase):
         # Build (and thus the cached args) happens once; the stream is appended
         # fresh on each of the three launches.
         self.assertEqual(build_calls, [(7,)])
+        self.assertEqual(retain_owned.call_count, 3)
         self.assertEqual(record_owned.call_count, 3)
         record_owned.assert_called_with(owned_tensors)
         self.assertEqual(

--- a/test/test_cute_grouped_gemm_split_sizes.py
+++ b/test/test_cute_grouped_gemm_split_sizes.py
@@ -790,7 +790,6 @@ def test_grouped_device_offsets_root_axis_order_is_semantic(
     _device_offsets_axis_order_kernel.reset()
     with (
         patch_cute_mma_support(),
-        patch("torch.cuda.get_device_capability", return_value=(10, 0)),
         patch(
             "helion.runtime.kernel.target_device_capability",
             return_value=(10, 0),
@@ -799,6 +798,9 @@ def test_grouped_device_offsets_root_axis_order_is_semantic(
             "helion._compiler.compile_environment.target_device_capability",
             return_value=(10, 0),
         ),
+        patch("helion.language.loops.use_tileir_tunables", return_value=False),
+        patch("helion.language.loops._supports_warp_specialize", return_value=True),
+        patch("helion._compat._supports_tensor_descriptor", return_value=True),
         patch(
             "helion._hardware.get_hardware_info",
             return_value=HardwareInfo(

--- a/test/test_cute_launcher_capture_ownership.py
+++ b/test/test_cute_launcher_capture_ownership.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import gc
+from types import SimpleNamespace
+from unittest.mock import patch
+import weakref
+
+import torch
+
+from helion._testing import skipIfNotCUDA
+from helion.runtime.cute import launcher
+
+
+def _launch_entry(storage: torch.Tensor) -> launcher._CuteLaunchArgCacheEntry:
+    return launcher._CuteLaunchArgCacheEntry(
+        schema=(),
+        launch_args=(),
+        grouped_static_metadata=(),
+        owned_tensors=(storage,),
+    )
+
+
+def test_managed_capture_retains_ungrouped_descriptor_through_lru_eviction() -> None:
+    cute_kernel = SimpleNamespace()
+    resources = launcher._CuteCudaGraphResources({}, {}, set(), set())
+    graph = SimpleNamespace(_helion_resources=resources)
+    first_ref: weakref.ReferenceType[torch.Tensor] | None = None
+    build_count = 0
+
+    def build(
+        _kernel: object,
+        _args: tuple[object, ...],
+        _grid: tuple[int, int, int],
+    ) -> launcher._CuteLaunchArgCacheEntry:
+        nonlocal build_count, first_ref
+        build_count += 1
+        storage = torch.empty(128, dtype=torch.uint8)
+        if build_count == 1:
+            first_ref = weakref.ref(storage)
+        return _launch_entry(storage)
+
+    token = launcher._CUTE_ACTIVE_CUDA_GRAPH.set(graph)  # pyrefly: ignore
+    try:
+        with (
+            patch.object(
+                launcher,
+                "_cuda_stream_capture_context",
+                return_value=(101, 202),
+            ),
+            patch.object(launcher, "_cute_kernel_param_is_constexpr", return_value=()),
+            patch.object(launcher, "_build_cute_schema_and_args", side_effect=build),
+            patch.object(torch.cuda, "current_stream", return_value="capture-stream"),
+            patch.object(torch.Tensor, "record_stream", autospec=True),
+        ):
+            first = launcher._build_cached_cute_schema_and_args(
+                cute_kernel, (), (1, 1, 1)
+            )
+    finally:
+        launcher._CUTE_ACTIVE_CUDA_GRAPH.reset(token)
+
+    capture_cache = cute_kernel._helion_cute_capture_owned_launch_tensors
+    assert len(capture_cache) == 1
+    assert first_ref is not None
+    assert first_ref() is first.owned_tensors[0]
+    del first
+
+    with (
+        patch.object(
+            launcher,
+            "_cuda_stream_capture_context",
+            return_value=(101, None),
+        ),
+        patch.object(launcher, "_cute_kernel_param_is_constexpr", return_value=()),
+        patch.object(launcher, "_build_cute_schema_and_args", side_effect=build),
+    ):
+        for grid_x in range(2, 10):
+            launcher._build_cached_cute_schema_and_args(cute_kernel, (), (grid_x, 1, 1))
+
+    assert len(cute_kernel._helion_cute_launch_arg_cache) == 8
+    gc.collect()
+    assert first_ref() is not None
+
+    resources.release()
+    gc.collect()
+    assert capture_cache == {}
+    assert first_ref() is None
+
+
+def test_raw_capture_conservatively_retains_ungrouped_descriptor() -> None:
+    cute_kernel = SimpleNamespace()
+    storage = torch.empty(128, dtype=torch.uint8)
+    storage_ref = weakref.ref(storage)
+
+    with patch.object(
+        launcher,
+        "_cuda_stream_capture_context",
+        return_value=(303, 404),
+    ):
+        launcher._retain_cute_capture_owned_launch_tensors(
+            cute_kernel,
+            grouped_launch_contexts=(),
+            owned_tensors=(storage,),
+        )
+
+    capture_cache = cute_kernel._helion_cute_capture_owned_launch_tensors
+    del storage
+    gc.collect()
+    assert storage_ref() is not None
+    capture_cache.clear()
+    gc.collect()
+    assert storage_ref() is None
+
+
+def test_last_launch_fast_hit_promotes_owned_tensors_to_capture() -> None:
+    cute_kernel = SimpleNamespace()
+    storage = torch.empty(128, dtype=torch.uint8)
+    launch = _launch_entry(storage)
+    last_launch = SimpleNamespace(
+        arg_guard=SimpleNamespace(grouped_launch_contexts=()),
+        launch=launch,
+        compiled=lambda *args: args,
+    )
+
+    with (
+        patch.object(
+            launcher, "_cute_last_launch_cache_entry", return_value=last_launch
+        ),
+        patch.object(launcher, "_retain_cute_capture_owned_launch_tensors") as retain,
+        patch.object(launcher, "_record_cute_owned_launch_tensors") as record,
+        patch.object(launcher, "_cute_current_stream", return_value="stream"),
+    ):
+        result = launcher.default_cute_launcher(cute_kernel, (1,), 7)
+
+    assert result == ("stream",)
+    retain.assert_called_once_with(
+        cute_kernel,
+        grouped_launch_contexts=(),
+        owned_tensors=(storage,),
+    )
+    record.assert_called_once_with((storage,))
+
+
+@skipIfNotCUDA()
+def test_managed_graph_reset_releases_resources_before_recapture() -> None:
+    graph = launcher._CuteCUDAGraph.__new__(launcher._CuteCUDAGraph)
+    resources = launcher._CuteCudaGraphResources({}, {}, set(), set())
+    graph._helion_resources = resources
+    owner = SimpleNamespace(cache={})
+
+    def retain(key: str) -> weakref.ReferenceType[torch.Tensor]:
+        value = object()
+        owner.cache[key] = value
+        resources.cache_entries[(id(owner), "cache", key)] = (
+            owner,
+            "cache",
+            key,
+            value,
+        )
+        tensor = torch.empty(1)
+        resources.tensors[id(tensor)] = tensor
+        return weakref.ref(tensor)
+
+    def parent_reset(_graph: object) -> None:
+        assert resources.cache_entries
+        assert resources.tensors
+
+    with patch.object(
+        torch.cuda.CUDAGraph,
+        "reset",
+        autospec=True,
+        side_effect=parent_reset,
+    ) as reset:
+        first_ref = retain("first")
+        graph.reset()
+        assert first_ref() is None
+        assert owner.cache == {}
+        assert resources == launcher._CuteCudaGraphResources({}, {}, set(), set())
+
+        second_ref = retain("second")
+        graph.reset()
+        assert second_ref() is None
+        assert owner.cache == {}
+        assert resources == launcher._CuteCudaGraphResources({}, {}, set(), set())
+
+    assert reset.call_count == 2

--- a/test/test_llm_autotuner.py
+++ b/test/test_llm_autotuner.py
@@ -413,6 +413,7 @@ class TestLLMGuidedSearch(TestCase):
             use_isolated=True,
             confirm_suspicious=True,
             use_interleaved=True,
+            candidate_private_args=False,
         ):
             rebenchmark_descs.append(desc)
             for member in members:

--- a/test/test_runtime_input_specialization.py
+++ b/test/test_runtime_input_specialization.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import contextvars
 import dataclasses
 import inspect
+import operator
+import threading
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from typing import Any
@@ -9,6 +12,7 @@ from typing import Hashable
 from typing import cast
 import unittest
 from unittest.mock import patch
+import weakref
 
 import sympy
 import torch
@@ -22,13 +26,27 @@ from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from helion._compiler.compile_environment import CompileEnvironment
 from helion._compiler.compile_environment import RuntimeInputSpecialization
 from helion._compiler.compile_environment import _symint_free_symbols
+from helion._compiler.cute.memory_ops import (
+    _PERSISTENT_VEC_ALIGNMENT_SPECIALIZATION_KEY,
+)
+from helion._compiler.cute.memory_ops import _TENSOR_DISJOINT_MATRIX_SPECIALIZATION_KEY
+from helion._compiler.cute.memory_ops import _persistent_vec_alignment_matrix_signature
+from helion._compiler.cute.memory_ops import _tensor_storage_disjoint_matrix_signature
+from helion._compiler.cute.memory_ops import runtime_tensor_has_specialized_alignment
+from helion._compiler.cute.memory_ops import runtime_tensors_are_proven_disjoint
 from helion._compiler.device_ir import _finalize_cute_tcgen05_search_planning
 from helion._testing import DEVICE
 from helion._testing import onlyBackends
+from helion.autotuner.base_cache import BoundKernelInMemoryCacheKey
 from helion.language.matmul_ops import _plan_cute_tcgen05_search_candidate
 from helion.runtime.cute.launcher import _Tcgen05GroupedWorklistCompatibilityClassifier
 from helion.runtime.kernel import BoundKernel
+from helion.runtime.kernel import Kernel
 from helion.runtime.kernel import _input_tensor_aliases
+from helion.runtime.kernel import _partition_prepared_extra_guards
+from helion.runtime.kernel import _PreparedCall
+from helion.runtime.kernel import _PreparedMetadataSpecializationExtractor
+from helion.runtime.kernel import _RuntimeInputSpecializationExtractor
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -261,6 +279,490 @@ class TestCuteRuntimeInputSpecialization(unittest.TestCase):
 
 
 class TestRuntimeInputSpecialization(unittest.TestCase):
+    def test_set_config_rejects_post_bind_realignment(self) -> None:
+        source = LocalSource("value", is_input=True)
+        specialization = RuntimeInputSpecialization(
+            sources=(source,),
+            classifier_identity="alignment_test",
+            classifier=_persistent_vec_alignment_matrix_signature,
+            reusable_tensor_properties=frozenset(("data_ptr",)),
+        )
+        env = cast("CompileEnvironment", object.__new__(CompileEnvironment))
+        env.runtime_input_specializations = {
+            _PERSISTENT_VEC_ALIGNMENT_SPECIALIZATION_KEY: specialization
+        }
+        env.bound_runtime_input_specialization_results = {}
+        env._runtime_arg_values_by_name = contextvars.ContextVar(
+            "test_runtime_arg_values", default=None
+        )
+        env.tensor_input_source = lambda _tensor: source  # type: ignore[method-assign]
+
+        backing = torch.empty(17, dtype=torch.bfloat16)
+        value = backing[1:17]
+        aligned = backing[:16]
+        self.assertEqual(value.data_ptr() % 4, 2)
+        env.snapshot_runtime_input_specialization_results({"value": value})
+        value.data = aligned.data
+        self.assertEqual(value.data_ptr() % 4, 0)
+
+        bound = cast("Any", object.__new__(BoundKernel))
+        bound._env = env
+        bound._runtime_tensor_refs_by_name = {"value": weakref.ref(value)}
+        bound._normalize_config = lambda config: config
+        bound.format_kernel_decorator = lambda _config, _settings: "test"
+        bound.kernel = SimpleNamespace(settings=SimpleNamespace())
+        observed: list[bool] = []
+
+        def compile_config(_config: object) -> object:
+            with bound._runtime_arg_values_for_codegen():
+                observed.append(
+                    runtime_tensor_has_specialized_alignment(
+                        env, cast("Any", object()), 4
+                    )
+                )
+            return lambda: None
+
+        bound.compile_config = compile_config
+        BoundKernel.set_config(bound, cast("Any", object()))
+
+        self.assertEqual(observed, [False])
+
+    def test_bound_runtime_specialization_snapshot_is_immutable(self) -> None:
+        source = LocalSource("value", is_input=True)
+        content_calls = 0
+
+        def content_classifier(values: Sequence[object]) -> int:
+            nonlocal content_calls
+            content_calls += 1
+            return int(cast("torch.Tensor", values[0])[0])
+
+        specialization = RuntimeInputSpecialization(
+            sources=(source,),
+            classifier_identity="pointer_test",
+            classifier=lambda values: cast("torch.Tensor", values[0]).data_ptr(),
+            reusable_tensor_properties=frozenset(("data_ptr",)),
+        )
+        env = cast("CompileEnvironment", object.__new__(CompileEnvironment))
+        env.runtime_input_specializations = {
+            "content": RuntimeInputSpecialization(
+                sources=(source,),
+                classifier_identity="content_test",
+                classifier=content_classifier,
+            ),
+            "pointer": specialization,
+        }
+        env.bound_runtime_input_specialization_results = {}
+        original = torch.empty(8)
+        original_pointer = original.data_ptr()
+
+        env.snapshot_runtime_input_specialization_results({"value": original})
+        self.assertEqual(content_calls, 0)
+        self.assertNotIn("content", env.bound_runtime_input_specialization_results)
+        self.assertFalse(env.runtime_input_specialization_matches_bound("late", None))
+        original.data = torch.empty_like(original).data
+        self.assertNotEqual(original.data_ptr(), original_pointer)
+
+        self.assertTrue(
+            env.runtime_input_specialization_matches_bound("pointer", original_pointer)
+        )
+        self.assertFalse(
+            env.runtime_input_specialization_matches_bound(
+                "pointer", original.data_ptr()
+            )
+        )
+
+    def test_late_rekey_retires_bound_when_runtime_snapshot_changes(self) -> None:
+        source = LocalSource("value", is_input=True)
+        key = _PERSISTENT_VEC_ALIGNMENT_SPECIALIZATION_KEY
+        specialization = RuntimeInputSpecialization(
+            sources=(source,),
+            classifier_identity="alignment_test",
+            classifier=_persistent_vec_alignment_matrix_signature,
+            reusable_tensor_properties=frozenset(("data_ptr",)),
+        )
+        env = cast("CompileEnvironment", object.__new__(CompileEnvironment))
+        env.runtime_input_specializations = {key: specialization}
+        env.bound_runtime_input_specialization_results = {}
+        env._runtime_arg_values_by_name = contextvars.ContextVar(
+            "test_late_rekey_runtime_args", default=None
+        )
+        env.tensor_input_source = lambda _tensor: source  # type: ignore[method-assign]
+
+        backing = torch.empty(17, dtype=torch.bfloat16)
+        aligned = backing[:16]
+        unaligned = backing[1:17]
+        value = backing[:16]
+        self.assertEqual(aligned.data_ptr() % 4, 0)
+
+        extractor = _RuntimeInputSpecializationExtractor(
+            (operator.itemgetter(0),),
+            specialization.classifier,
+            frozenset(("data_ptr",)),
+            key,
+        )
+        facts_a = extractor((value,))
+        env.bound_runtime_input_specialization_results = {key: facts_a}
+
+        signature = ("signature",)
+        bound = cast("Any", object.__new__(BoundKernel))
+        bound._reset_generation = 0
+        bound._base_spec_key = signature
+        bound._env = env
+        bound._cache_managed = True
+        stale_calls = 0
+
+        def compiled_a(_value: torch.Tensor) -> str:
+            nonlocal stale_calls
+            stale_calls += 1
+            return "stale-a"
+
+        # Model a config compiled and selected while the bound still had facts A.
+        config_a = object()
+        bound._run = compiled_a
+        bound._config = config_a
+        bound._compile_cache = {config_a: compiled_a}
+        bound._cache_path_map = {config_a: "compiled-a.py"}
+        bound._direct_prepared_call = object()
+        kernel = cast("Any", object.__new__(Kernel))
+        kernel._bind_lock = threading.RLock()
+        kernel._specialize_extra_lock = threading.Lock()
+        kernel._reset_generation = 0
+        kernel._specialization_generation = 0
+        kernel._specialization_aliases = {}
+        kernel._dispatch_cache = {}
+        kernel._prepared_call = None
+        kernel._specialize_extra = {signature: [extractor]}
+        kernel._compiler_seed_specialize_extra = {signature: ()}
+        kernel._has_specialization_extras = True
+        kernel._bound_kernels = {
+            BoundKernelInMemoryCacheKey(signature, (facts_a,)): bound
+        }
+        bound.kernel = kernel
+
+        self.assertTrue(
+            Kernel._extend_bound_kernel_specializations(
+                kernel,
+                bound,
+                signature,
+                [lambda _args: "tail-a"],
+                (value,),
+            )
+        )
+        (matching_cache_key,) = kernel._bound_kernels
+        self.assertEqual(matching_cache_key.extra_results, (facts_a, "tail-a"))
+        self.assertEqual(env.bound_runtime_input_specialization_results[key], facts_a)
+        self.assertIs(bound._run, compiled_a)
+        self.assertEqual(bound._compile_cache, {config_a: compiled_a})
+
+        value.data = unaligned.data
+        facts_b = extractor((value,))
+        self.assertNotEqual(facts_a, facts_b)
+        self.assertTrue(
+            Kernel._extend_bound_kernel_specializations(
+                kernel,
+                bound,
+                signature,
+                [lambda _args: "tail-b"],
+                (value,),
+            )
+        )
+        self.assertFalse(kernel._bound_kernels)
+        self.assertEqual(env.bound_runtime_input_specialization_results[key], facts_a)
+        self.assertNotEqual(bound._reset_generation, kernel._reset_generation)
+        self.assertIsNone(bound._run)
+        self.assertIsNone(bound._config)
+        self.assertFalse(bound._compile_cache)
+        self.assertFalse(bound._cache_path_map)
+        self.assertIsNone(bound._direct_prepared_call)
+
+        value.data = aligned.data
+        with env.use_runtime_arg_values({"value": value}):
+            self.assertTrue(
+                runtime_tensor_has_specialized_alignment(
+                    env,
+                    cast("Any", object()),
+                    4,
+                )
+            )
+
+        # Even if stale compiled state is assigned again, the retired bound
+        # redirects before it can execute that program.
+        bound._run = compiled_a
+        replacement_calls = 0
+
+        def replacement(_value: torch.Tensor) -> str:
+            nonlocal replacement_calls
+            replacement_calls += 1
+            return "replacement-b"
+
+        kernel.bind = lambda _args: replacement
+        value.data = unaligned.data
+        self.assertEqual(bound(value), "replacement-b")
+        self.assertEqual(replacement_calls, 1)
+        self.assertEqual(stale_calls, 0)
+
+    def test_disjoint_fact_rejects_post_bind_alias_change(self) -> None:
+        state_source = LocalSource("state", is_input=True)
+        other_source = LocalSource("other", is_input=True)
+        sources = (state_source, other_source)
+        specialization = RuntimeInputSpecialization(
+            sources=sources,
+            classifier_identity="state_ring_alias_test",
+            classifier=_tensor_storage_disjoint_matrix_signature,
+            reusable_tensor_properties=frozenset(("storage_span",)),
+        )
+        backing = torch.empty(64)
+        bound_values = (backing[:32], backing[16:48])
+        current_values = (torch.empty(32), torch.empty(32))
+        bound_result = specialization.classifier(bound_values)
+        fake_state = object()
+        fake_other = object()
+        env = SimpleNamespace(
+            input_sources={},
+            runtime_arg_values_by_name={
+                "state": current_values[0],
+                "other": current_values[1],
+            },
+            runtime_input_specializations={
+                _TENSOR_DISJOINT_MATRIX_SPECIALIZATION_KEY: specialization
+            },
+            tensor_input_source=lambda tensor: (
+                state_source if tensor is fake_state else other_source
+            ),
+            runtime_input_specialization_matches_bound=(
+                lambda key, result: (
+                    key == _TENSOR_DISJOINT_MATRIX_SPECIALIZATION_KEY
+                    and result == bound_result
+                )
+            ),
+        )
+
+        with patch(
+            "helion._compiler.cute.memory_ops._tensor_alias_sources",
+            return_value=sources,
+        ):
+            self.assertFalse(
+                runtime_tensors_are_proven_disjoint(
+                    cast("Any", env), cast("Any", fake_state), cast("Any", fake_other)
+                )
+            )
+            current_result = specialization.classifier(current_values)
+            env.runtime_input_specialization_matches_bound = lambda key, result: (
+                key == _TENSOR_DISJOINT_MATRIX_SPECIALIZATION_KEY
+                and result == current_result
+            )
+            self.assertTrue(
+                runtime_tensors_are_proven_disjoint(
+                    cast("Any", env), cast("Any", fake_state), cast("Any", fake_other)
+                )
+            )
+
+    def test_state_ring_alias_specialization_distinguishes_storage_views(self) -> None:
+        state_source = LocalSource("state", is_input=True)
+        other_source = LocalSource("other", is_input=True)
+        specialization = RuntimeInputSpecialization(
+            sources=(state_source, other_source),
+            classifier_identity="state_ring_alias_test",
+            classifier=_tensor_storage_disjoint_matrix_signature,
+            reusable_tensor_properties=frozenset(("storage_span",)),
+        )
+        env = SimpleNamespace(
+            specialized_vars=set(),
+            specialized_strides=set(),
+            tensor_descriptor_layout_guards={},
+            runtime_input_specializations={"state_ring_alias": specialization},
+        )
+        kernel = SimpleNamespace(signature=inspect.signature(lambda state, other: None))
+        bound = SimpleNamespace(
+            _env=env,
+            env=env,
+            kernel=kernel,
+            _fixed_config_for_td_layout_guards=lambda: None,
+        )
+        extractor = BoundKernel._specialize_extra(cast("BoundKernel[object]", bound))[0]
+
+        state = torch.empty((4, 8))
+        other = torch.empty((4, 8))
+        backing = torch.empty(64)
+        state_view = backing[:32].view(4, 8)
+        other_view = backing[16:48].view(4, 8)
+
+        self.assertEqual(state.shape, state_view.shape)
+        self.assertEqual(state.stride(), state_view.stride())
+        self.assertEqual(extractor((state, other)), (True,))
+        self.assertEqual(extractor((state_view, other_view)), (False,))
+
+    def test_direct_stale_bound_rebinds_after_kernel_reset(self) -> None:
+        calls = 0
+
+        def replacement(value: object) -> object:
+            nonlocal calls
+            calls += 1
+            return value
+
+        kernel = SimpleNamespace(
+            _reset_generation=2,
+            bind=lambda _args: replacement,
+        )
+        bound = cast("Any", object.__new__(BoundKernel))
+        bound.kernel = kernel
+        bound._cache_managed = True
+        bound._reset_generation = 1
+
+        value = object()
+        self.assertIs(bound(value), value)
+        self.assertEqual(calls, 1)
+
+    def test_direct_bound_call_uses_prepared_fast_path(self) -> None:
+        tensor = torch.empty(8)
+        kernel = SimpleNamespace(
+            _annotations=[torch.Tensor],
+            _compute_is_distributed=lambda _args, **_kwargs: False,
+            _reset_generation=0,
+            _specialization_generation=0,
+        )
+        bound = cast("Any", object.__new__(BoundKernel))
+        bound.kernel = kernel
+        bound._cache_managed = True
+        bound._reset_generation = 0
+        bound._run = lambda value: value
+        bound._direct_prepared_call = _PreparedCall(
+            cast("Any", bound),
+            (tensor,),
+            dist_initialized=torch.distributed.is_initialized(),
+            extra_guards=(),
+            is_distributed=False,
+        )
+
+        self.assertIs(bound(tensor), tensor)
+
+    def test_prepared_call_skips_reusable_classifier_until_storage_changes(
+        self,
+    ) -> None:
+        tensor = torch.empty(8)
+        calls = 0
+
+        def classifier(values: Sequence[object]) -> Hashable:
+            nonlocal calls
+            calls += 1
+            return cast("torch.Tensor", values[0]).data_ptr()
+
+        extractor = _RuntimeInputSpecializationExtractor(
+            (lambda args: cast("Hashable", args[0]),),
+            classifier,
+            frozenset(("data_ptr",)),
+        )
+        expected = extractor((tensor,))
+        kernel = SimpleNamespace(
+            _annotations=[torch.Tensor],
+            _compute_is_distributed=lambda _args, **_kwargs: False,
+            _reset_generation=0,
+            _specialization_generation=0,
+        )
+        bound = SimpleNamespace(kernel=kernel)
+        prepared = _PreparedCall(
+            cast("Any", bound),
+            (tensor,),
+            dist_initialized=torch.distributed.is_initialized(),
+            extra_guards=((extractor, expected),),
+            is_distributed=False,
+        )
+
+        calls = 0
+        self.assertTrue(prepared.matches(cast("Any", kernel), (tensor,)))
+        self.assertEqual(calls, 0)
+
+        replacement = torch.empty_like(tensor)
+        tensor.data = replacement.data
+        self.assertFalse(prepared.matches(cast("Any", kernel), (tensor,)))
+        self.assertEqual(calls, 1)
+
+        kernel._specialization_generation += 1
+        calls = 0
+        self.assertFalse(prepared.matches(cast("Any", kernel), (tensor,)))
+        self.assertEqual(calls, 0)
+
+    def test_prepared_storage_guard_reuses_only_unchanged_exact_tensors(self) -> None:
+        first = torch.empty(8)
+        second = torch.empty(8)
+        calls = 0
+
+        def classifier(values: Sequence[object]) -> Hashable:
+            nonlocal calls
+            calls += 1
+            return tuple(cast("torch.Tensor", value).data_ptr() for value in values)
+
+        extractor = _RuntimeInputSpecializationExtractor(
+            (
+                lambda args: cast("Hashable", args[0]),
+                lambda args: cast("Hashable", args[1]),
+            ),
+            classifier,
+            frozenset(("data_ptr", "storage_span")),
+        )
+        expected = extractor((first, second))
+        storage_guard, always_check, reusable = _partition_prepared_extra_guards(
+            (first, second),
+            ((extractor, expected),),
+        )
+        self.assertIsNotNone(storage_guard)
+        assert storage_guard is not None
+        self.assertFalse(always_check)
+        self.assertEqual(reusable, ((extractor, expected),))
+        self.assertTrue(storage_guard((first, second)))
+
+        replacement = torch.empty_like(first)
+        original_version = first._version
+        first.data = replacement.data
+        self.assertEqual(first._version, original_version)
+        self.assertFalse(storage_guard((first, second)))
+        self.assertEqual(calls, 1)
+
+    def test_prepared_guard_keeps_content_classifiers_and_skips_metadata(self) -> None:
+        tensor = torch.arange(4)
+        content_calls = 0
+
+        def content_classifier(values: Sequence[object]) -> int:
+            nonlocal content_calls
+            content_calls += 1
+            return int(cast("torch.Tensor", values[0])[0])
+
+        def content_extractor(args: Sequence[object]) -> int:
+            return content_classifier((args[0],))
+
+        metadata_extractor = _PreparedMetadataSpecializationExtractor(
+            lambda args: cast("torch.Tensor", args[0]).size(0)
+        )
+        unknown_property_extractor = _RuntimeInputSpecializationExtractor(
+            (lambda args: cast("Hashable", args[0]),),
+            lambda values: cast("torch.Tensor", values[0]).data_ptr(),
+            frozenset(("unknown",)),
+        )
+        storage_guard, always_check, reusable = _partition_prepared_extra_guards(
+            (tensor,),
+            (
+                (content_extractor, content_extractor((tensor,))),
+                (metadata_extractor, metadata_extractor((tensor,))),
+                (
+                    unknown_property_extractor,
+                    unknown_property_extractor((tensor,)),
+                ),
+            ),
+        )
+        self.assertIsNone(storage_guard)
+        self.assertEqual(
+            always_check,
+            (
+                (content_extractor, 0),
+                (unknown_property_extractor, tensor.data_ptr()),
+            ),
+        )
+        self.assertFalse(reusable)
+
+        tensor[0] = 3
+        self.assertEqual(always_check[0][0]((tensor,)), 3)
+        self.assertEqual(content_calls, 2)
+
     def test_tensor_alias_key_is_dynamo_safe_for_temporary_views(self) -> None:
         def fn(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
             assert _input_tensor_aliases((x.T, y.T)) is None


### PR DESCRIPTION
Stacked PRs:
 * #3591
 * #3590
 * #3589
 * __->__#3588
 * #3587


--- --- ---

### [cutedsl] Make tuning and runtime specialization reproducible

Very short kernels exposed several sources of benchmark noise and graph
lifetime bugs. This PR makes candidate cloning preserve alias relationships
while still isolating mutable buffers, uses balanced paired timing with bounded
work, and makes specialization and precompile/cache behavior deterministic.

It also keeps CuTe launch resources and descriptors alive across graph capture,
cache hits, reset, and recapture, and adds the CuTe memory operations used by
the later lowering changes. These are general runtime and autotuner changes;
there is no KDA-specific dispatch in this PR.

Using the latest available measurements, the six selected workloads have a
fastest-baseline mean of 41.976 µs, a Helion mean of 37.424 µs, and a
case-ratio geometric mean of **1.1310×**. The per-workload results and
measurement protocol are in #3587; this is stack-level context rather than
performance attributed to this PR alone.

The main review surface is shared autotuner and cache behavior: alias topology,
worker precompile behavior, cache invalidation, and captured-resource lifetime.