### PR TITLE
[cutedsl] Add optimized persistent reduction lowering

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from .common import dedupe_configs
 from .cute import CuteFlashAttentionHeuristic
 from .cute import CuteFp8GemmSkinnyMHeuristic
+from .cute import CutePersistentSubwarpRowsHeuristic
 from .cute import CutePointwiseVecHeuristic
 from .cute import CuteReductionTileHeuristic
 from .cute import CuteReductionWideChunkHeuristic
@@ -58,6 +59,7 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
         CuteTcgen05ThreadLocalEpilogueHeuristic,
         CuteReductionTileHeuristic,
         CuteReductionWideChunkHeuristic,
+        CutePersistentSubwarpRowsHeuristic,
         CuteRolledRowLadderHeuristic,
         CuteRolledClusterLadderHeuristic,
         CuteTileVecHeuristic,

--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -74,7 +74,10 @@ def _seq_config_list(
     slot order varies (e.g. ``num_threads`` registers tile slots first
     while ``cute_vector_widths`` keeps the rdim slot at index 0), so build
     by block id instead of by position."""
-    return [overrides.get(item.block_id, item._fill_missing()) for item in seq]
+    return [
+        overrides[item.block_id] if item.block_id in overrides else item._fill_missing()
+        for item in seq
+    ]
 
 
 def _cute_seed_vec_width(
@@ -208,6 +211,266 @@ def _cute_tile_inner_block_dtype(
                 if isinstance(last, int) and last == block_numel_int:
                     return val.dtype
     return None
+
+
+class CutePersistentSubwarpRowsHeuristic(AutotunerHeuristic):
+    """Seed a row-tiled, one-vector persistent reduction.
+
+    This targets the general shape of a small row tile sharing a short static
+    reduction: eight row threads, one 16-byte reduction fragment per thread,
+    and register reloads across repeated reduction sweeps.  It is deliberately
+    an autotuning seed only; no architecture has promoted it to the default.
+    """
+
+    name = "cute_persistent_subwarp_rows"
+    backend = "cute"
+    CACHE_SPECIALIZATION_FACTS = frozenset({"input_tensor_metadata"})
+    FULL_ROW_BLOCK_SIZE = 128
+    RECURRENT_STYLE_REDUCTION_SIZE = 128
+    RECURRENT_STYLE_REDUCTION_THREADS = 32
+    RECURRENT_STYLE_ROW_THREADS = 1
+    RECURRENT_STYLE_VECTOR_WIDTH = 4
+
+    @classmethod
+    def register_facts(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> frozenset[CompilerHeuristicSpecializationFact]:
+        # The lane-splitting legality proof consumes exact runtime strides.
+        # Register this independently of seed generation so explicitly pinned
+        # configs and autotuner-disabled compilation remain cache-safe.
+        return (
+            cls.CACHE_SPECIALIZATION_FACTS if cls._plan(env, device_ir) else frozenset()
+        )
+
+    @staticmethod
+    def _reduction_dtype(
+        device_ir: DeviceIR, reduction_size: int
+    ) -> torch.dtype | None:
+        # Ignore the integer FakeTensor produced by ``hl.arange`` itself and
+        # find a vector-loadable tensor value using that trailing dimension.
+        best_dtype: torch.dtype | None = None
+        best_width = 1
+        for graph_info in device_ir.graphs:
+            for node in graph_info.graph.nodes:
+                value = node.meta.get("val")
+                target_name = getattr(node.target, "__name__", "")
+                if (
+                    isinstance(value, torch.Tensor)
+                    and value.ndim >= 1
+                    and isinstance(value.shape[-1], int)
+                    and value.shape[-1] == reduction_size
+                    and target_name in ("_host_tensor", "load")
+                ):
+                    width = _cute_tile_seed_vec_width_for_dtype(value.dtype)
+                    if width > best_width:
+                        best_dtype = value.dtype
+                        best_width = width
+        return best_dtype
+
+    @classmethod
+    def _plan(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> tuple[int, int, int] | None:
+        spec = env.config_spec
+        if spec.matmul_facts or spec.reduction_loops or len(spec.block_sizes) != 1:
+            return None
+        reduction_blocks = [block for block in env.block_sizes if block.reduction]
+        if len(reduction_blocks) != 1:
+            return None
+        reduction_block = reduction_blocks[0]
+        try:
+            reduction_size = int(reduction_block.numel)
+        except (TypeError, ValueError):
+            return None
+        vec = _cute_tile_seed_vec_width_for_dtype(
+            cls._reduction_dtype(device_ir, reduction_size)
+        )
+        if vec <= 1 or not 128 <= reduction_size <= 256:
+            return None
+        if reduction_size % vec:
+            return None
+        reduction_threads = reduction_size // vec
+        if reduction_threads not in (16, 32):
+            return None
+
+        row_spec = cast("Any", spec.block_sizes[0])
+        if len(row_spec.block_ids) != 1:
+            return None
+        if not row_spec.min_size <= 16 <= row_spec.max_size:
+            return None
+        row_block_id = row_spec.block_id
+        required = (
+            (spec.num_threads, row_block_id),
+            (spec.num_threads, reduction_block.block_id),
+            (spec.cute_vector_widths, reduction_block.block_id),
+            (spec.cute_lane_layouts, reduction_block.block_id),
+            (spec.cute_reduction_reloads, reduction_block.block_id),
+        )
+        if any(
+            block_id not in sequence.valid_block_ids()
+            for sequence, block_id in required
+        ):
+            return None
+        return row_block_id, reduction_block.block_id, reduction_threads
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        return cls._plan(env, device_ir) is not None
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        plan = cls._plan(env, device_ir)
+        if plan is None:
+            return None
+        row_block_id, reduction_block_id, reduction_threads = plan
+        return cls._seed_config(
+            env,
+            row_block_id,
+            reduction_block_id,
+            reduction_threads,
+            row_block_size=16,
+        )
+
+    @classmethod
+    def _seed_config(
+        cls,
+        env: CompileEnvironment,
+        row_block_id: int,
+        reduction_block_id: int,
+        reduction_threads: int,
+        *,
+        row_block_size: int,
+        row_threads: int = 8,
+    ) -> Config:
+        reduction_size = int(env.block_sizes[reduction_block_id].numel)
+        vec = reduction_size // reduction_threads
+        seed: dict[str, Any] = {
+            "block_sizes": _seq_config_list(
+                env.config_spec.block_sizes, {row_block_id: row_block_size}
+            ),
+            "num_threads": _seq_config_list(
+                env.config_spec.num_threads,
+                {row_block_id: row_threads, reduction_block_id: reduction_threads},
+            ),
+            "cute_vector_widths": _seq_config_list(
+                env.config_spec.cute_vector_widths, {reduction_block_id: vec}
+            ),
+            "cute_lane_layouts": _seq_config_list(
+                env.config_spec.cute_lane_layouts, {reduction_block_id: "blocked"}
+            ),
+            "cute_reduction_reloads": _seq_config_list(
+                env.config_spec.cute_reduction_reloads,
+                {reduction_block_id: "register"},
+            ),
+            "num_warps": max(1, row_threads * reduction_threads // 32),
+            "num_stages": 1,
+            "pid_type": "flat",
+        }
+        return Config(**seed)
+
+    @classmethod
+    def _recurrent_style_seed_config(
+        cls,
+        env: CompileEnvironment,
+        device_ir: DeviceIR,
+        row_block_id: int,
+        reduction_block_id: int,
+    ) -> Config | None:
+        reduction_size = int(env.block_sizes[reduction_block_id].numel)
+        if reduction_size != cls.RECURRENT_STYLE_REDUCTION_SIZE:
+            return None
+        dtype_vec = _cute_tile_seed_vec_width_for_dtype(
+            cls._reduction_dtype(device_ir, reduction_size)
+        )
+        if dtype_vec < cls.RECURRENT_STYLE_VECTOR_WIDTH:
+            return None
+        if reduction_size % cls.RECURRENT_STYLE_VECTOR_WIDTH:
+            return None
+        reduction_threads = reduction_size // cls.RECURRENT_STYLE_VECTOR_WIDTH
+        if reduction_threads != cls.RECURRENT_STYLE_REDUCTION_THREADS:
+            return None
+        return cls._seed_config(
+            env,
+            row_block_id,
+            reduction_block_id,
+            reduction_threads,
+            row_block_size=16,
+            row_threads=cls.RECURRENT_STYLE_ROW_THREADS,
+        )
+
+    @classmethod
+    def get_seed_configs(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> list[Config] | None:
+        """Add recurrent-style, row-one, one-warp, and full-row schedules.
+
+        The recurrent-style sibling maps one row thread and 32 reduction
+        threads into a single-warp CTA with V=4 for K=128 updates.  The row-one
+        sibling maps all 16 rows onto independent 16-thread groups in an
+        eight-warp CTA.  This exposes enough resident warps to hide the
+        state-load latency of short recurrent updates.  A 128-row tile instead
+        maps eight groups across a short row loop, which amortizes invariant
+        setup, while a 32-row one-warp sibling targets latency-sensitive
+        workloads.  The existing 16-row seed stays rank zero and therefore
+        preserves the no-autotune/default behavior.
+        """
+        plan = cls._plan(env, device_ir)
+        if plan is None:
+            return None
+        row_block_id, reduction_block_id, reduction_threads = plan
+        primary = cls._seed_config(
+            env,
+            row_block_id,
+            reduction_block_id,
+            reduction_threads,
+            row_block_size=16,
+        )
+        row_spec = cast("Any", env.config_spec.block_sizes[0])
+        seeds = [primary]
+        recurrent_style = cls._recurrent_style_seed_config(
+            env,
+            device_ir,
+            row_block_id,
+            reduction_block_id,
+        )
+        if recurrent_style is not None:
+            seeds.append(recurrent_style)
+        if reduction_threads == 16:
+            seeds.append(
+                cls._seed_config(
+                    env,
+                    row_block_id,
+                    reduction_block_id,
+                    reduction_threads,
+                    row_block_size=16,
+                    row_threads=16,
+                )
+            )
+        one_warp_row_threads = max(1, 32 // reduction_threads)
+        if row_spec.max_size >= 32:
+            seeds.append(
+                cls._seed_config(
+                    env,
+                    row_block_id,
+                    reduction_block_id,
+                    reduction_threads,
+                    row_block_size=32,
+                    row_threads=one_warp_row_threads,
+                )
+            )
+        if row_spec.max_size >= cls.FULL_ROW_BLOCK_SIZE:
+            seeds.append(
+                cls._seed_config(
+                    env,
+                    row_block_id,
+                    reduction_block_id,
+                    reduction_threads,
+                    row_block_size=cls.FULL_ROW_BLOCK_SIZE,
+                )
+            )
+        return seeds
 
 
 class CuteTileVecHeuristic(AutotunerHeuristic):

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1053,11 +1053,19 @@ class Backend(abc.ABC):
         contraction = cute_matmul_contraction_block_ids()
         if not contraction:
             return set()
-        return {
-            info.block_id
-            for info in env.block_sizes
-            if info.reduction and canonical_block_id(info.block_id) in contraction
-        }
+        result: set[int] = set()
+        for info in env.block_sizes:
+            if not info.reduction:
+                continue
+            block_id = canonical_block_id(info.block_id)
+            # Reduction lowering may materialize an output-range block whose
+            # extent aliases an already-active *tile* block.  Such an alias
+            # reuses the tile strategy and must not reserve a second copy of
+            # the contraction threads.  Canonical reduction aliases, on the
+            # other hand, still need one (deduplicated) reserve.
+            if block_id in contraction and env.block_sizes[block_id].reduction:
+                result.add(block_id)
+        return result
 
     def _cute_matmul_contraction_thread_reserve(
         self, fn: DeviceFunction, tile_block_ids: list[int]

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -1638,19 +1638,46 @@ class CompileEnvironment:
         return None
 
     def canonical_block_id(self, block_id: int) -> int:
-        """Follow fixed block-size aliases back to their canonical symbolic owner."""
+        """Follow block-size aliases back to their canonical symbolic owner.
+
+        Reduction lowering creates a separate output-range block even when
+        that range is exactly an already-active tile block.  In that case
+        ``allocate_reduction_dimension`` deliberately reuses the tile's
+        symbolic variable, so preserve that identity here as well as for the
+        explicit ``FixedBlockSizeSource`` aliases.
+        """
 
         seen: set[int] = set()
         current = block_id
         while current not in seen:
             seen.add(current)
-            source = self.block_sizes[current].block_size_source
-            if not isinstance(source, FixedBlockSizeSource):
+            info = self.block_sizes[current]
+            source = info.block_size_source
+            if isinstance(source, FixedBlockSizeSource):
+                value = source.value
+            elif self.backend_name == "cute" and isinstance(
+                source, ReductionLoopBlockSizeSource
+            ):
+                value = info.size
+            else:
                 break
-            value = source.value
             if not isinstance(value, torch.SymInt):
                 break
-            next_block_id = self.get_block_id(value)
+            value_expr = value._sympy_()
+            # ``get_block_id`` intentionally prefers the newest matching
+            # reduction block.  Canonicalization needs the opposite: locate
+            # the earlier owner whose symbol was reused when this alias was
+            # allocated.  This is also usable after HostFunction teardown.
+            next_block_id = next(
+                (
+                    candidate.block_id
+                    for candidate in self.block_sizes[:current]
+                    if candidate.symbol() == value_expr
+                ),
+                None,
+            )
+            if next_block_id is None:
+                next_block_id = self.get_block_id(value)
             if next_block_id is None or next_block_id == current:
                 break
             current = next_block_id

--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -1200,7 +1200,10 @@ class CuteBackend(Backend):
                 # unaffected by flushing denormal exp outputs; skip the
                 # default lowering's denormal fixup (FSETP + 2 predicated
                 # FMULs per element) — see exp2_fastmath.py.
-                if HelionCuteDSLOpOverrides._ftz_safe_current_node():
+                if (
+                    HelionCuteDSLOpOverrides._ftz_safe_current_node()
+                    or HelionCuteDSLOpOverrides._fastmath_on()
+                ):
                     if CuteDSLOpOverrides._get_cse_var(x) is None:
                         x = CuteDSLOpOverrides._cast_expr(str(x), torch.float32)
                     return CuteDSLOpOverrides._apply_unary_op(
@@ -1211,7 +1214,10 @@ class CuteBackend(Backend):
 
             @staticmethod
             def exp2(x: CuteDSLArg) -> CuteDSLArg:
-                if HelionCuteDSLOpOverrides._ftz_safe_current_node():
+                if (
+                    HelionCuteDSLOpOverrides._ftz_safe_current_node()
+                    or HelionCuteDSLOpOverrides._fastmath_on()
+                ):
                     return CuteDSLOpOverrides._apply_unary_op(
                         x, "cute.math.exp2({x}, fastmath=True)"
                     )
@@ -1219,11 +1225,79 @@ class CuteBackend(Backend):
 
             @staticmethod
             def _fastmath_on() -> bool:
-                from torch._inductor.codegen.cutedsl.cutedsl_op_overrides import (
-                    _CUTEDSL_FAST_MATH,
+                from ..compile_environment import CompileEnvironment
+
+                return CompileEnvironment.current().settings.fast_math
+
+            @staticmethod
+            def _unary_math(x: CuteDSLArg, name: str) -> CuteDSLArg:
+                suffix = (
+                    ", fastmath=True" if HelionCuteDSLOpOverrides._fastmath_on() else ""
+                )
+                return CuteDSLOpOverrides._apply_unary_op(
+                    x, f"cute.math.{name}({{x}}{suffix})"
                 )
 
-                return _CUTEDSL_FAST_MATH.get()
+            @staticmethod
+            def sqrt(x: CuteDSLArg) -> CuteDSLArg:
+                return HelionCuteDSLOpOverrides._unary_math(x, "sqrt")
+
+            @staticmethod
+            def rsqrt(x: CuteDSLArg) -> CuteDSLArg:
+                return HelionCuteDSLOpOverrides._unary_math(x, "rsqrt")
+
+            @staticmethod
+            def log(x: CuteDSLArg) -> CuteDSLArg:
+                return HelionCuteDSLOpOverrides._unary_math(x, "log")
+
+            @staticmethod
+            def log2(x: CuteDSLArg) -> CuteDSLArg:
+                return HelionCuteDSLOpOverrides._unary_math(x, "log2")
+
+            @staticmethod
+            def log10(x: CuteDSLArg) -> CuteDSLArg:
+                return HelionCuteDSLOpOverrides._unary_math(x, "log10")
+
+            @staticmethod
+            def cos(x: CuteDSLArg) -> CuteDSLArg:
+                return HelionCuteDSLOpOverrides._unary_math(x, "cos")
+
+            @staticmethod
+            def sin(x: CuteDSLArg) -> CuteDSLArg:
+                return HelionCuteDSLOpOverrides._unary_math(x, "sin")
+
+            @staticmethod
+            def tan(x: CuteDSLArg) -> CuteDSLArg:
+                return HelionCuteDSLOpOverrides._unary_math(x, "tan")
+
+            @staticmethod
+            def acos(x: CuteDSLArg) -> CuteDSLArg:
+                return HelionCuteDSLOpOverrides._unary_math(x, "acos")
+
+            @staticmethod
+            def asin(x: CuteDSLArg) -> CuteDSLArg:
+                return HelionCuteDSLOpOverrides._unary_math(x, "asin")
+
+            @staticmethod
+            def atan(x: CuteDSLArg) -> CuteDSLArg:
+                return HelionCuteDSLOpOverrides._unary_math(x, "atan")
+
+            @staticmethod
+            def atan2(a: CuteDSLArg, b: CuteDSLArg) -> CuteDSLArg:
+                suffix = (
+                    ", fastmath=True" if HelionCuteDSLOpOverrides._fastmath_on() else ""
+                )
+                return CuteDSLOpOverrides._apply_binary_op(
+                    a, b, f"cute.math.atan2({{a}}, {{b}}{suffix})"
+                )
+
+            @staticmethod
+            def erf(x: CuteDSLArg) -> CuteDSLArg:
+                return HelionCuteDSLOpOverrides._unary_math(x, "erf")
+
+            @staticmethod
+            def tanh(x0: CuteDSLArg) -> CuteDSLArg:
+                return HelionCuteDSLOpOverrides._unary_math(x0, "tanh")
 
             @staticmethod
             # pyrefly: ignore [bad-override]

--- a/helion/_compiler/cute/factor_affine_reductions.py
+++ b/helion/_compiler/cute/factor_affine_reductions.py
@@ -1,0 +1,3327 @@
+"""Factor affine terms out of floating-point sum reductions under fast math.
+
+For a reduction over ``reduction_dims``, this pass rewrites::
+
+    sum((base + scalar[..., None] * direction[None, ...]) * weight[None, ...])
+
+to::
+
+    sum(base * weight[None, ...])
+      + scalar * sum(direction[None, ...] * weight[None, ...])
+
+when ``scalar`` varies only over the retained dimensions and ``direction`` and
+``weight`` vary only over the reduced dimensions.  The latter reduction is
+therefore invariant across the retained tile lanes and can be hoisted by the
+CuTe lane-invariant reduction pass.
+
+The identity distributes and reassociates floating-point arithmetic.  Callers
+must only run this pass when the user opted into ``Settings.fast_math``.
+Matching is deliberately narrow and fails closed: only explicit broadcast
+views, ``aten.sum.dim_IntList`` reductions, and fp32 tensors are accepted.  It
+runs before lowering metadata is prepared; the ordinary reduction lowering
+therefore adds the standard zero masks to both replacement sums.
+
+On Blackwell, the late AST phase can also pair independent lanes of eligible
+even-width fp32 reduction and list-building update loops into packed f32x2
+instructions.  That transform is separately guarded by fast math and target
+capability, and rejects unknown effects, ambiguous fragment aliases, and
+cross-lane or escaping dependencies.
+"""
+
+from __future__ import annotations
+
+import ast
+from itertools import starmap
+from typing import TYPE_CHECKING
+from typing import cast
+
+import torch
+
+from ...language import view_ops
+from ..ast_extension import ExtendedAST
+from ..ast_extension import create
+from ..ast_extension import expr_from_string
+from ..ast_read_writes import HELION_LANE_LOOP_VAR_ATTR
+from .licm_profitability import repeated_work_is_profitable
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+_ADD = torch.ops.aten.add.Tensor
+_MUL = torch.ops.aten.mul.Tensor
+_SUM = torch.ops.aten.sum.dim_IntList
+
+
+def _call_node(node: object, target: object) -> torch.fx.Node | None:
+    if (
+        isinstance(node, torch.fx.Node)
+        and node.op == "call_function"
+        and node.target is target
+    ):
+        return node
+    return None
+
+
+def _binary_args(
+    node: torch.fx.Node, target: object
+) -> tuple[torch.fx.Node, torch.fx.Node] | None:
+    if _call_node(node, target) is None or len(node.args) != 2 or node.kwargs:
+        return None
+    lhs, rhs = node.args
+    if not isinstance(lhs, torch.fx.Node) or not isinstance(rhs, torch.fx.Node):
+        return None
+    return lhs, rhs
+
+
+def _is_full_slice(value: object) -> bool:
+    return (
+        isinstance(value, slice)
+        and value.start is None
+        and value.stop is None
+        and value.step is None
+    )
+
+
+def _shape(node: torch.fx.Node) -> tuple[object, ...] | None:
+    value = node.meta.get("val")
+    if not isinstance(value, torch.Tensor):
+        return None
+    return tuple(value.shape)
+
+
+def _same_size(left: object, right: object) -> bool:
+    if isinstance(left, int) and isinstance(right, int):
+        return left == right
+    if isinstance(left, torch.SymInt) and isinstance(right, torch.SymInt):
+        return left.node is right.node
+    return False
+
+
+def _is_fp32_tensor(node: torch.fx.Node) -> bool:
+    value = node.meta.get("val")
+    return isinstance(value, torch.Tensor) and value.dtype is torch.float32
+
+
+def _normalized_dims(node: torch.fx.Node) -> tuple[int, ...] | None:
+    if len(node.args) < 2 or len(node.args) > 3:
+        return None
+    if set(node.kwargs) - {"keepdim", "dtype"}:
+        return None
+    if len(node.args) == 3 and "keepdim" in node.kwargs:
+        return None
+    if node.kwargs.get("dtype") is not None:
+        return None
+    source = node.args[0]
+    dims = node.args[1]
+    keepdim = node.args[2] if len(node.args) == 3 else node.kwargs.get("keepdim", False)
+    if keepdim is not False or not isinstance(source, torch.fx.Node):
+        return None
+    shape = _shape(source)
+    if shape is None or not shape or not isinstance(dims, (list, tuple)):
+        return None
+    if not dims or not all(isinstance(dim, int) for dim in dims):
+        return None
+    normalized = tuple(sorted({cast("int", dim) % len(shape) for dim in dims}))
+    if len(normalized) != len(dims):
+        return None
+    return normalized
+
+
+def _broadcast_source(
+    node: torch.fx.Node,
+    *,
+    rank: int,
+    reduced_dims: frozenset[int],
+    source_spans_reduced_dims: bool,
+) -> torch.fx.Node | None:
+    """Unwrap a pure ``None``/full-slice broadcast with an exact axis role.
+
+    ``source_spans_reduced_dims=False`` recognizes ``scalar[..., None]``;
+    ``True`` recognizes ``vector[None, ...]``.  Requiring an explicit view
+    avoids guessing whether a size-one symbolic dimension is semantically
+    invariant.
+    """
+    view = _call_node(node, view_ops.subscript)
+    if view is None or len(view.args) != 2 or view.kwargs:
+        return None
+    source, indices = view.args
+    if not isinstance(source, torch.fx.Node) or not isinstance(indices, (list, tuple)):
+        return None
+    if len(indices) != rank:
+        return None
+    output_shape = _shape(node)
+    source_shape = _shape(source)
+    if output_shape is None or source_shape is None:
+        return None
+    source_dim = 0
+    for dim, index in enumerate(indices):
+        should_span = (dim in reduced_dims) == source_spans_reduced_dims
+        if should_span:
+            if (
+                not _is_full_slice(index)
+                or source_dim >= len(source_shape)
+                or not _same_size(output_shape[dim], source_shape[source_dim])
+            ):
+                return None
+            source_dim += 1
+        elif index is not None or not _same_size(output_shape[dim], 1):
+            return None
+    expected_rank = (
+        len(reduced_dims) if source_spans_reduced_dims else rank - len(reduced_dims)
+    )
+    if len(source_shape) != expected_rank:
+        return None
+    return source
+
+
+def _copy_meta(
+    node: torch.fx.Node, template: torch.fx.Node, value: torch.Tensor
+) -> None:
+    node.meta = {**template.meta, "val": value}
+
+
+def _new_call(
+    graph: torch.fx.Graph,
+    target: object,
+    args: tuple[object, ...],
+    *,
+    template: torch.fx.Node,
+    value: torch.Tensor,
+    name: str | None = None,
+) -> torch.fx.Node:
+    # pyrefly: ignore [bad-argument-type]
+    node = graph.call_function(cast("object", target), args, {}, name=name)
+    _copy_meta(node, template, value)
+    return node
+
+
+def _materialized_shape(
+    graph: torch.fx.Graph, shape: tuple[object, ...]
+) -> list[int | torch.fx.Node] | None:
+    result: list[int | torch.fx.Node] = []
+    for size in shape:
+        if isinstance(size, int):
+            result.append(size)
+            continue
+        if not isinstance(size, torch.SymInt):
+            return None
+        source = next(
+            (
+                node
+                for node in graph.nodes
+                if isinstance(node.meta.get("val"), torch.SymInt)
+                and cast("torch.SymInt", node.meta["val"]).node is size.node
+            ),
+            None,
+        )
+        if source is None:
+            return None
+        result.append(source)
+    return result
+
+
+def _match_sum(node: torch.fx.Node) -> tuple[torch.fx.Node, tuple[int, ...]] | None:
+    if _call_node(node, _SUM) is None:
+        return None
+    dims = _normalized_dims(node)
+    if dims is None:
+        return None
+    product = node.args[0]
+    if not isinstance(product, torch.fx.Node):
+        return None
+    return product, dims
+
+
+def _match_affine_product(
+    product: torch.fx.Node,
+    dims: tuple[int, ...],
+) -> (
+    tuple[
+        torch.fx.Node,
+        torch.fx.Node,
+        torch.fx.Node,
+        torch.fx.Node,
+        torch.fx.Node,
+        torch.fx.Node,
+        torch.fx.Node,
+    ]
+    | None
+):
+    """Return sources and broadcasts for the matched affine expression."""
+    product_args = _binary_args(product, _MUL)
+    if product_args is None:
+        return None
+    product_shape = _shape(product)
+    if product_shape is None:
+        return None
+    rank = len(product_shape)
+    reduced = frozenset(dims)
+
+    for update, weight in (product_args, product_args[::-1]):
+        weight_source = _broadcast_source(
+            weight,
+            rank=rank,
+            reduced_dims=reduced,
+            source_spans_reduced_dims=True,
+        )
+        if weight_source is None:
+            continue
+        add_args = _binary_args(update, _ADD)
+        if add_args is None:
+            continue
+        for base, affine in (add_args, add_args[::-1]):
+            affine_args = _binary_args(affine, _MUL)
+            if affine_args is None:
+                continue
+            for scalar_view, direction in (affine_args, affine_args[::-1]):
+                scalar = _broadcast_source(
+                    scalar_view,
+                    rank=rank,
+                    reduced_dims=reduced,
+                    source_spans_reduced_dims=False,
+                )
+                if scalar is None:
+                    continue
+                direction_source = _broadcast_source(
+                    direction,
+                    rank=rank,
+                    reduced_dims=reduced,
+                    source_spans_reduced_dims=True,
+                )
+                if direction_source is None:
+                    continue
+                nodes = (base, scalar, direction_source, weight_source)
+                if all(_is_fp32_tensor(candidate) for candidate in nodes):
+                    return (
+                        base,
+                        scalar,
+                        scalar_view,
+                        direction_source,
+                        weight_source,
+                        direction,
+                        weight,
+                    )
+    return None
+
+
+def _rewrite_sum(graph: torch.fx.Graph, reduction: torch.fx.Node) -> bool:
+    if not _is_fp32_tensor(reduction):
+        return False
+    matched_sum = _match_sum(reduction)
+    if matched_sum is None:
+        return False
+    product, dims = matched_sum
+    matched_product = _match_affine_product(product, dims)
+    if matched_product is None:
+        return False
+    (
+        base,
+        scalar,
+        scalar_view,
+        direction,
+        weight,
+        direction_broadcast,
+        weight_broadcast,
+    ) = matched_product
+
+    reduction_value = reduction.meta.get("val")
+    product_value = product.meta.get("val")
+    direction_value = direction.meta.get("val")
+    weight_value = weight.meta.get("val")
+    direction_broadcast_value = direction_broadcast.meta.get("val")
+    if not all(
+        isinstance(value, torch.Tensor)
+        for value in (
+            reduction_value,
+            product_value,
+            direction_value,
+            weight_value,
+            direction_broadcast_value,
+        )
+    ):
+        return False
+    reduction_value = cast("torch.Tensor", reduction_value)
+    product_value = cast("torch.Tensor", product_value)
+    direction_value = cast("torch.Tensor", direction_value)
+    weight_value = cast("torch.Tensor", weight_value)
+    direction_broadcast_value = cast("torch.Tensor", direction_broadcast_value)
+
+    try:
+        dot_product_shape = tuple(
+            torch.broadcast_shapes(direction_value.shape, weight_value.shape)
+        )
+    except RuntimeError:
+        return False
+    reduced_input_shape = tuple(product_value.shape[dim] for dim in dims)
+    if len(dot_product_shape) != len(dims) or not all(
+        starmap(_same_size, zip(dot_product_shape, reduced_input_shape, strict=True))
+    ):
+        return False
+    broadcast_dot_shape = _shape(direction_broadcast)
+    scalar_shape = _shape(scalar)
+    if broadcast_dot_shape is None or scalar_shape is None:
+        return False
+    weight_broadcast_shape = _shape(weight_broadcast)
+    if (
+        weight_broadcast_shape is None
+        or len(broadcast_dot_shape) != len(weight_broadcast_shape)
+        or not all(
+            starmap(
+                _same_size,
+                zip(broadcast_dot_shape, weight_broadcast_shape, strict=True),
+            )
+        )
+    ):
+        return False
+    reduced_output_shape = tuple(
+        size for dim, size in enumerate(product_value.shape) if dim not in dims
+    )
+    if len(scalar_shape) != len(reduced_output_shape) or not all(
+        starmap(_same_size, zip(scalar_shape, reduced_output_shape, strict=True))
+    ):
+        return False
+    expanded_shape = _materialized_shape(graph, tuple(product_value.shape))
+    if expanded_shape is None:
+        return False
+
+    with graph.inserting_before(reduction):
+        base_product = _new_call(
+            graph,
+            _MUL,
+            (base, weight_broadcast),
+            template=product,
+            value=product_value.new_empty(product_value.shape),
+        )
+        base_sum = _new_call(
+            graph,
+            _SUM,
+            (base_product, list(dims)),
+            template=reduction,
+            value=reduction_value.new_empty(reduction_value.shape),
+            name="_helion_factored_base_sum",
+        )
+        dot_product = _new_call(
+            graph,
+            _MUL,
+            (direction_broadcast, weight_broadcast),
+            template=product,
+            value=direction_broadcast_value.new_empty(
+                cast("tuple[int | torch.SymInt, ...]", broadcast_dot_shape)
+            ),
+        )
+        expanded_dot_product = _new_call(
+            graph,
+            torch.ops.aten.expand.default,
+            (dot_product, expanded_shape),
+            template=product,
+            value=product_value.new_empty(product_value.shape),
+        )
+        dot_sum = _new_call(
+            graph,
+            _SUM,
+            (expanded_dot_product, list(dims)),
+            template=reduction,
+            value=reduction_value.new_empty(reduction_value.shape),
+            name="_helion_factored_dot_sum",
+        )
+        scalar_output_view = _new_call(
+            graph,
+            view_ops.subscript,
+            (scalar, scalar_view.args[1]),
+            template=scalar_view,
+            value=cast("torch.Tensor", scalar_view.meta["val"]).new_empty(
+                cast("torch.Tensor", scalar_view.meta["val"]).shape
+            ),
+        )
+        dot_output_view = _new_call(
+            graph,
+            view_ops.subscript,
+            (dot_sum, scalar_view.args[1]),
+            template=scalar_view,
+            value=cast("torch.Tensor", scalar_view.meta["val"]).new_empty(
+                cast("torch.Tensor", scalar_view.meta["val"]).shape
+            ),
+        )
+        scaled_dot_view = _new_call(
+            graph,
+            _MUL,
+            (scalar_output_view, dot_output_view),
+            template=scalar_view,
+            value=cast("torch.Tensor", scalar_view.meta["val"]).new_empty(
+                cast("torch.Tensor", scalar_view.meta["val"]).shape
+            ),
+        )
+        scaled_dot = _new_call(
+            graph,
+            _SUM,
+            (scaled_dot_view, list(dims)),
+            template=reduction,
+            value=reduction_value.new_empty(reduction_value.shape),
+            name="_helion_factored_scaled_dot",
+        )
+        factored = _new_call(
+            graph,
+            _ADD,
+            (base_sum, scaled_dot),
+            template=reduction,
+            value=reduction_value.new_empty(reduction_value.shape),
+            name="_helion_factored_result",
+        )
+
+    reduction.replace_all_uses_with(factored)
+    return True
+
+
+def factor_affine_reductions(graph: torch.fx.Graph, *, fast_math: bool) -> int:
+    """Factor eligible affine reductions in ``graph`` and return the count.
+
+    ``fast_math`` is an explicit argument so the numeric-policy gate remains
+    visible and directly testable at the only public entry point.
+    """
+    if not fast_math:
+        return 0
+    changed = 0
+    for node in list(graph.nodes):
+        if _rewrite_sum(graph, node):
+            changed += 1
+    if changed:
+        graph.eliminate_dead_code()
+        graph.lint()
+    return changed
+
+
+def _ast_call_path(node: ast.expr) -> str | None:
+    parts: list[str] = []
+    current = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if not isinstance(current, ast.Name):
+        return None
+    parts.append(current.id)
+    return ".".join(reversed(parts))
+
+
+def _assigned_name(stmt: ast.stmt) -> str | None:
+    if (
+        isinstance(stmt, ast.Assign)
+        and len(stmt.targets) == 1
+        and isinstance(stmt.targets[0], ast.Name)
+    ):
+        return stmt.targets[0].id
+    return None
+
+
+def _names_read(node: ast.AST) -> set[str]:
+    return {
+        child.id
+        for child in ast.walk(node)
+        if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Load)
+    }
+
+
+def _names_written(node: ast.AST) -> set[str]:
+    return {
+        child.id
+        for child in ast.walk(node)
+        if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store)
+    }
+
+
+def _mutation_roots(node: ast.AST) -> set[str]:
+    result: set[str] = set()
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Subscript) or not isinstance(child.ctx, ast.Store):
+            continue
+        root = child.value
+        while isinstance(root, (ast.Attribute, ast.Subscript)):
+            root = root.value
+        if isinstance(root, ast.Name):
+            result.add(root.id)
+    return result
+
+
+def _statement_effects(stmt: ast.stmt) -> tuple[set[str], set[str]]:
+    if isinstance(stmt, ast.Assign):
+        reads = _names_read(stmt.value)
+        writes = {target.id for target in stmt.targets if isinstance(target, ast.Name)}
+        for target in stmt.targets:
+            if not isinstance(target, ast.Name):
+                reads.update(_names_read(target))
+        return reads, writes
+    if isinstance(stmt, ast.For):
+        bound = {stmt.target.id} if isinstance(stmt.target, ast.Name) else set()
+        live, writes = _block_effects(stmt.body, bound)
+        return _names_read(stmt.iter) | live, bound | writes
+    if isinstance(stmt, ast.If):
+        body_live, body_writes = _block_effects(stmt.body, set())
+        else_live, else_writes = _block_effects(stmt.orelse, set())
+        return (
+            _names_read(stmt.test) | body_live | else_live,
+            body_writes | else_writes,
+        )
+    return _names_read(stmt), _names_written(stmt)
+
+
+def _block_effects(
+    body: list[ast.stmt], initially_written: set[str]
+) -> tuple[set[str], set[str]]:
+    live: set[str] = set()
+    written = set(initially_written)
+    all_writes: set[str] = set()
+    for statement in body:
+        reads, writes = _statement_effects(statement)
+        live.update(reads - written)
+        written.update(writes)
+        all_writes.update(writes)
+    return live, all_writes
+
+
+def _definitely_written_block(body: list[ast.stmt]) -> set[str]:
+    result: set[str] = set()
+    for statement in body:
+        if isinstance(statement, ast.Assign):
+            result.update(
+                target.id
+                for target in statement.targets
+                if isinstance(target, ast.Name)
+            )
+        elif isinstance(statement, ast.If) and statement.orelse:
+            result.update(
+                _definitely_written_block(statement.body)
+                & _definitely_written_block(statement.orelse)
+            )
+    return result
+
+
+def _reads_before_def_statement(statement: ast.stmt) -> set[str]:
+    if isinstance(statement, ast.Assign):
+        reads = _names_read(statement.value)
+        for target in statement.targets:
+            if not isinstance(target, ast.Name):
+                reads.update(_names_read(target))
+        return reads
+    if isinstance(statement, ast.If):
+        return (
+            _names_read(statement.test)
+            | _live_before_block(statement.body)
+            | _live_before_block(statement.orelse)
+        )
+    if isinstance(statement, ast.For):
+        bound = (
+            {statement.target.id} if isinstance(statement.target, ast.Name) else set()
+        )
+        return (
+            _names_read(statement.iter)
+            | _live_before_block(statement.body, initially_defined=bound)
+            | _live_before_block(statement.orelse)
+        )
+    return _names_read(statement)
+
+
+def _live_before_block(
+    body: list[ast.stmt],
+    initially_defined: set[str] | None = None,
+    live_out: set[str] | None = None,
+) -> set[str]:
+    """Names that a block may read before a guaranteed local definition."""
+    defined = set() if initially_defined is None else set(initially_defined)
+    live: set[str] = set()
+    for statement in body:
+        reads = _reads_before_def_statement(statement)
+        live.update(reads - defined)
+        if isinstance(statement, ast.Assign):
+            defined.update(
+                target.id
+                for target in statement.targets
+                if isinstance(target, ast.Name)
+            )
+        elif isinstance(statement, ast.If) and statement.orelse:
+            defined.update(
+                _definitely_written_block(statement.body)
+                & _definitely_written_block(statement.orelse)
+            )
+    if live_out is not None:
+        live.update(live_out - defined)
+    return live
+
+
+def _nested_live_out(
+    statement: ast.stmt,
+    field: str,
+    child: list[ast.stmt],
+    statement_live_out: set[str],
+) -> set[str]:
+    result = set(statement_live_out)
+    if field == "body" and isinstance(statement, ast.For):
+        bound = (
+            {statement.target.id} if isinstance(statement.target, ast.Name) else set()
+        )
+        result.update(_live_before_block(child, initially_defined=bound))
+    elif field == "body" and isinstance(statement, ast.While):
+        result.update(_names_read(statement.test))
+        result.update(_live_before_block(child))
+    return result
+
+
+def _zero_fp32_assignment(stmt: ast.stmt) -> str | None:
+    name = _assigned_name(stmt)
+    if name is None or not isinstance(cast("ast.Assign", stmt).value, ast.Call):
+        return None
+    call = cast("ast.Call", cast("ast.Assign", stmt).value)
+    if (
+        _ast_call_path(call.func) != "cutlass.Float32"
+        or len(call.args) != 1
+        or call.keywords
+        or not isinstance(call.args[0], ast.Constant)
+        or call.args[0].value != 0
+    ):
+        return None
+    return name
+
+
+def _constexpr_loop(node: ast.stmt) -> tuple[ast.For, str, int] | None:
+    if (
+        not isinstance(node, ast.For)
+        or not isinstance(node.target, ast.Name)
+        or not isinstance(node.iter, ast.Call)
+        or _ast_call_path(node.iter.func) != "cutlass.range_constexpr"
+        or len(node.iter.args) != 1
+        or node.iter.keywords
+        or not isinstance(node.iter.args[0], ast.Constant)
+        or not isinstance(node.iter.args[0].value, int)
+        or node.iter.args[0].value <= 0
+        or node.orelse
+    ):
+        return None
+    return node, node.target.id, node.iter.args[0].value
+
+
+def _static_repeated_loop(node: ast.stmt) -> tuple[ast.For, str, int] | None:
+    """Match either generated spelling of a compile-time lane loop."""
+    constexpr = _constexpr_loop(node)
+    if constexpr is not None:
+        return constexpr
+    if (
+        not isinstance(node, ast.For)
+        or not isinstance(node.target, ast.Name)
+        or not isinstance(node.iter, ast.Call)
+        or _ast_call_path(node.iter.func) != "range"
+        or len(node.iter.args) != 1
+        or node.iter.keywords
+        or not isinstance(node.iter.args[0], ast.Constant)
+        or not isinstance(node.iter.args[0].value, int)
+        or isinstance(node.iter.args[0].value, bool)
+        or node.iter.args[0].value <= 0
+        or node.orelse
+    ):
+        return None
+    return node, node.target.id, node.iter.args[0].value
+
+
+def _reduction_result(stmt: ast.stmt, accumulator: str) -> tuple[str, ast.Call] | None:
+    result = _assigned_name(stmt)
+    if result is None:
+        return None
+    value = cast("ast.Assign", stmt).value
+    if (
+        not isinstance(value, ast.Call)
+        or _ast_call_path(value.func) != "cutlass.Float32"
+        or len(value.args) != 1
+        or value.keywords
+        or not isinstance(value.args[0], ast.Call)
+    ):
+        return None
+    reduction = value.args[0]
+    if (
+        _ast_call_path(reduction.func) != "cute.arch.warp_reduction_sum"
+        or len(reduction.args) != 1
+        or any(
+            keyword.arg != "threads_in_group"
+            or not isinstance(keyword.value, ast.Constant)
+            or not isinstance(keyword.value.value, int)
+            or keyword.value.value <= 0
+            for keyword in reduction.keywords
+        )
+    ):
+        return None
+    argument = reduction.args[0]
+    if not isinstance(argument, ast.Name) or argument.id != accumulator:
+        return None
+    return result, reduction
+
+
+def _warp_reduction_assignment(
+    stmt: ast.stmt,
+) -> tuple[str, str, ast.Call] | None:
+    result = _assigned_name(stmt)
+    if result is None:
+        return None
+    value = cast("ast.Assign", stmt).value
+    if (
+        not isinstance(value, ast.Call)
+        or _ast_call_path(value.func) != "cutlass.Float32"
+        or len(value.args) != 1
+        or value.keywords
+        or not isinstance(value.args[0], ast.Call)
+    ):
+        return None
+    reduction = value.args[0]
+    if (
+        _ast_call_path(reduction.func) != "cute.arch.warp_reduction_sum"
+        or len(reduction.args) != 1
+        or any(
+            keyword.arg != "threads_in_group"
+            or not isinstance(keyword.value, ast.Constant)
+            or not isinstance(keyword.value.value, int)
+            or keyword.value.value <= 0
+            for keyword in reduction.keywords
+        )
+    ):
+        return None
+    argument = reduction.args[0]
+    if not isinstance(argument, ast.Name):
+        return None
+    return result, argument.id, reduction
+
+
+def _accumulated_term(stmt: ast.stmt, accumulator: str) -> ast.expr | None:
+    if _assigned_name(stmt) != accumulator:
+        return None
+    value = cast("ast.Assign", stmt).value
+    if not isinstance(value, ast.BinOp) or not isinstance(value.op, ast.Add):
+        return None
+    if isinstance(value.left, ast.Name) and value.left.id == accumulator:
+        return value.right
+    if isinstance(value.right, ast.Name) and value.right.id == accumulator:
+        return value.left
+    return None
+
+
+class _InlineInnerExpression(ast.NodeTransformer):
+    def __init__(
+        self,
+        definitions: dict[str, ast.expr],
+        lane_var: str,
+        replacement_lane: str,
+    ) -> None:
+        self.definitions = definitions
+        self.lane_var = lane_var
+        self.replacement_lane = replacement_lane
+        self.resolving: set[str] = set()
+
+    def visit_Name(self, node: ast.Name) -> ast.AST:
+        if not isinstance(node.ctx, ast.Load):
+            return node
+        if node.id == self.lane_var:
+            return ast.copy_location(
+                ast.Name(id=self.replacement_lane, ctx=ast.Load()), node
+            )
+        expression = self.definitions.get(node.id)
+        if expression is None:
+            return node
+        if node.id in self.resolving:
+            raise ValueError("cyclic generated definition")
+        self.resolving.add(node.id)
+        try:
+            return self.visit(expr_from_string(ast.unparse(expression)))
+        finally:
+            self.resolving.remove(node.id)
+
+
+_AST_PURE_CALLS = {
+    "cutlass.BFloat16",
+    "cutlass.Float16",
+    "cutlass.Float32",
+    "cutlass.Int32",
+    "cutlass.Int64",
+    "cutlass.Uint16",
+    "cutlass.Uint32",
+    "cute.arch.load",
+}
+_AST_PURE_OPERATOR_CALLS = {
+    "operator.add",
+    "operator.and_",
+    "operator.eq",
+    "operator.floordiv",
+    "operator.ge",
+    "operator.gt",
+    "operator.index",
+    "operator.invert",
+    "operator.le",
+    "operator.lshift",
+    "operator.lt",
+    "operator.mod",
+    "operator.mul",
+    "operator.ne",
+    "operator.neg",
+    "operator.or_",
+    "operator.pos",
+    "operator.pow",
+    "operator.rshift",
+    "operator.sub",
+    "operator.truediv",
+    "operator.xor",
+}
+_AST_GLOBAL_NAMES = {"cutlass", "cute", "operator"}
+
+
+def _clone_extended_ast(value: object) -> object:
+    """Clone Python/ExtendedAST nodes without losing Helion metadata."""
+    if isinstance(value, list):
+        return [_clone_extended_ast(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_clone_extended_ast(item) for item in value)
+    if isinstance(value, ast.AST):
+        fields = {
+            field: _clone_extended_ast(getattr(value, field)) for field in value._fields
+        }
+        if isinstance(value, ExtendedAST):
+            return value.copy(**fields)
+        return ast.copy_location(type(value)(**fields), value)
+    return value
+
+
+def _safe_invariant_expression(
+    expression: ast.expr,
+    *,
+    outer_lane: str,
+    outer_writes: set[str],
+    outer_mutations: set[str],
+    rmem_names: set[str],
+) -> bool:
+    if outer_lane in _names_read(expression):
+        return False
+    free_names = _names_read(expression) - _AST_GLOBAL_NAMES
+    if free_names & (outer_writes | outer_mutations):
+        return False
+    for child in ast.walk(expression):
+        if isinstance(
+            child,
+            (
+                ast.Await,
+                ast.DictComp,
+                ast.GeneratorExp,
+                ast.Lambda,
+                ast.ListComp,
+                ast.NamedExpr,
+                ast.SetComp,
+                ast.Yield,
+                ast.YieldFrom,
+            ),
+        ):
+            return False
+        if isinstance(child, ast.Call):
+            path = _ast_call_path(child.func)
+            if path == "cute.arch.load" or path not in _AST_PURE_CALLS:
+                return False
+        if isinstance(child, ast.Subscript):
+            if isinstance(child.ctx, ast.Store):
+                return False
+            if (
+                not isinstance(child.value, ast.Name)
+                or child.value.id not in rmem_names
+            ):
+                return False
+    return True
+
+
+def _fresh_ast_name(occupied: set[str], prefix: str) -> str:
+    index = 0
+    while f"{prefix}_{index}" in occupied:
+        index += 1
+    result = f"{prefix}_{index}"
+    occupied.add(result)
+    return result
+
+
+class _RenameAstName(ast.NodeTransformer):
+    def __init__(self, old: str, new: str) -> None:
+        self.old = old
+        self.new = new
+
+    def visit_Name(self, node: ast.Name) -> ast.Name:
+        if node.id != self.old:
+            return node
+        return ast.copy_location(ast.Name(id=self.new, ctx=node.ctx), node)
+
+
+def _unwrap_fp32(expression: ast.expr) -> ast.expr:
+    if (
+        isinstance(expression, ast.Call)
+        and _ast_call_path(expression.func) == "cutlass.Float32"
+        and len(expression.args) == 1
+        and not expression.keywords
+    ):
+        return expression.args[0]
+    return expression
+
+
+def _as_fp32(expression: ast.expr) -> ast.expr:
+    if (
+        isinstance(expression, ast.Call)
+        and _ast_call_path(expression.func) == "cutlass.Float32"
+        and len(expression.args) == 1
+        and not expression.keywords
+    ):
+        return expression
+    return create(
+        ast.Call,
+        func=expr_from_string("cutlass.Float32"),
+        args=[expression],
+        keywords=[],
+    )
+
+
+def _packed_pair_assignment(
+    lo_name: str,
+    hi_name: str,
+    function: str,
+    lo_lhs: ast.expr,
+    hi_lhs: ast.expr,
+    lo_rhs: ast.expr,
+    hi_rhs: ast.expr,
+    lo_acc: ast.expr | None = None,
+    hi_acc: ast.expr | None = None,
+) -> ast.Assign:
+    arguments = [
+        create(
+            ast.Tuple,
+            elts=[_as_fp32(lo_lhs), _as_fp32(hi_lhs)],
+            ctx=ast.Load(),
+        ),
+        create(
+            ast.Tuple,
+            elts=[_as_fp32(lo_rhs), _as_fp32(hi_rhs)],
+            ctx=ast.Load(),
+        ),
+    ]
+    if lo_acc is not None and hi_acc is not None:
+        arguments.append(
+            create(
+                ast.Tuple,
+                elts=[_as_fp32(lo_acc), _as_fp32(hi_acc)],
+                ctx=ast.Load(),
+            )
+        )
+    return create(
+        ast.Assign,
+        targets=[
+            create(
+                ast.Tuple,
+                elts=[
+                    create(ast.Name, id=lo_name, ctx=ast.Store()),
+                    create(ast.Name, id=hi_name, ctx=ast.Store()),
+                ],
+                ctx=ast.Store(),
+            )
+        ],
+        value=create(
+            ast.Call,
+            func=expr_from_string(function),
+            args=arguments,
+            keywords=[],
+        ),
+    )
+
+
+def _pair_lane_expression(pair_name: str, high: bool) -> ast.expr:
+    expression = create(
+        ast.BinOp,
+        left=create(ast.Name, id=pair_name, ctx=ast.Load()),
+        op=create(ast.Mult),
+        right=create(ast.Constant, value=2),
+    )
+    if high:
+        expression = create(
+            ast.BinOp,
+            left=expression,
+            op=create(ast.Add),
+            right=create(ast.Constant, value=1),
+        )
+    return expression
+
+
+def _subscript_accesses(
+    body: list[ast.stmt], context: type[ast.expr_context]
+) -> dict[str, set[str]]:
+    result: dict[str, set[str]] = {}
+    for statement in body:
+        for child in ast.walk(statement):
+            if not isinstance(child, ast.Subscript) or not isinstance(
+                child.ctx, context
+            ):
+                continue
+            if isinstance(child.value, ast.Name):
+                result.setdefault(child.value.id, set()).add(ast.unparse(child.slice))
+    return result
+
+
+def _has_effectful_call(
+    body: list[ast.stmt], *, ignored_calls: frozenset[int] = frozenset()
+) -> bool:
+    for statement in body:
+        for child in ast.walk(statement):
+            if not isinstance(child, ast.Call):
+                continue
+            if id(child) in ignored_calls:
+                continue
+            path = _ast_call_path(child.func)
+            if path is None:
+                if isinstance(child.func, ast.Attribute):
+                    receiver = child.func.value
+                    if (
+                        child.func.attr == "bitcast"
+                        and isinstance(receiver, ast.Call)
+                        and _ast_call_path(receiver.func) in _AST_PURE_CALLS
+                    ):
+                        continue
+                    if child.func.attr == "load" and any(
+                        isinstance(node, ast.Attribute) and node.attr == "iterator"
+                        for node in ast.walk(receiver)
+                    ):
+                        continue
+                return True
+            if path in _AST_PURE_CALLS or path.startswith("cute.math."):
+                continue
+            if path in _AST_PURE_OPERATOR_CALLS:
+                continue
+            return True
+    return False
+
+
+def _direct_subscript_key(node: ast.AST) -> tuple[str, str] | None:
+    if not isinstance(node, ast.Subscript) or not isinstance(node.value, ast.Name):
+        return None
+    return node.value.id, ast.dump(node.slice, include_attributes=False)
+
+
+def _deduplicate_fused_body(
+    context: list[ast.stmt],
+    first: list[ast.stmt],
+    second: list[ast.stmt],
+    rmem_names: set[str],
+) -> list[ast.stmt]:
+    """Remove second-sweep scalar recomputation made redundant by fusion."""
+    versions: dict[str, int] = {}
+    memory_versions: dict[str, int] = {}
+    definitions: dict[str, tuple[str, dict[str, int], dict[str, int]]] = {}
+    cache_values: dict[tuple[str, str], tuple[str, int, int]] = {}
+
+    def process(statement: ast.stmt, *, may_drop: bool) -> bool:
+        if not isinstance(statement, ast.Assign) or len(statement.targets) != 1:
+            return False
+        target = statement.targets[0]
+        if isinstance(target, ast.Subscript):
+            key = _direct_subscript_key(target)
+            if key is not None and key[0] in rmem_names:
+                root = key[0]
+                memory_versions[root] = memory_versions.get(root, 0) + 1
+                for stale_key in [
+                    cached_key for cached_key in cache_values if cached_key[0] == root
+                ]:
+                    del cache_values[stale_key]
+                if isinstance(statement.value, ast.Name):
+                    cache_values[key] = (
+                        statement.value.id,
+                        versions.get(statement.value.id, 0),
+                        memory_versions[root],
+                    )
+            return False
+        if not isinstance(target, ast.Name):
+            return False
+
+        name = target.id
+        rhs = statement.value
+        rhs_names = _names_read(rhs) - _AST_GLOBAL_NAMES
+        rhs_versions = {
+            dependency: versions.get(dependency, 0) for dependency in rhs_names
+        }
+        rhs_roots: set[str] = set()
+        for child in ast.walk(rhs):
+            key = _direct_subscript_key(child)
+            if key is not None and key[0] in rmem_names:
+                rhs_roots.add(key[0])
+        rhs_memory_versions = {root: memory_versions.get(root, 0) for root in rhs_roots}
+        redundant = False
+        previous = definitions.get(name)
+        if (
+            may_drop
+            and previous is not None
+            and not _has_effectful_call([statement])
+            and previous
+            == (
+                ast.dump(rhs, include_attributes=False),
+                rhs_versions,
+                rhs_memory_versions,
+            )
+        ):
+            redundant = True
+        cache_key = _direct_subscript_key(rhs)
+        cached = cache_values.get(cache_key) if cache_key is not None else None
+        if (
+            may_drop
+            and cache_key is not None
+            and cached is not None
+            and cached[0] == name
+            and cached[1] == versions.get(name, 0)
+            and cached[2] == memory_versions.get(cache_key[0], 0)
+        ):
+            redundant = True
+        if redundant:
+            return True
+
+        versions[name] = versions.get(name, 0) + 1
+        definitions[name] = (
+            ast.dump(rhs, include_attributes=False),
+            {dependency: versions.get(dependency, 0) for dependency in rhs_names},
+            rhs_memory_versions,
+        )
+        return False
+
+    for statement in (*context, *first):
+        process(statement, may_drop=False)
+    kept_second = [
+        statement for statement in second if not process(statement, may_drop=True)
+    ]
+    return [*first, *kept_second]
+
+
+class _ClonePairLane(ast.NodeTransformer):
+    def __init__(
+        self,
+        lane_name: str,
+        lane_expression: ast.expr,
+        renames: dict[str, str],
+    ) -> None:
+        self.lane_name = lane_name
+        self.lane_expression = lane_expression
+        self.renames = renames
+
+    def visit_Name(self, node: ast.Name) -> ast.AST:
+        if node.id == self.lane_name and isinstance(node.ctx, ast.Load):
+            return ast.copy_location(
+                cast("ast.expr", _clone_extended_ast(self.lane_expression)),
+                node,
+            )
+        replacement = self.renames.get(node.id)
+        if replacement is None:
+            return node
+        cloned = cast("ast.Name", _clone_extended_ast(node))
+        cloned.id = replacement
+        return cloned
+
+
+def _clone_pair_expression(
+    expression: ast.expr,
+    *,
+    lane_name: str,
+    lane_expression: ast.expr,
+    renames: dict[str, str],
+) -> ast.expr:
+    return cast(
+        "ast.expr",
+        _ClonePairLane(lane_name, lane_expression, renames).visit(
+            cast("ast.expr", _clone_extended_ast(expression))
+        ),
+    )
+
+
+def _definitions(body: list[ast.stmt]) -> dict[str, ast.expr] | None:
+    result: dict[str, ast.expr] = {}
+    for statement in body:
+        name = _assigned_name(statement)
+        if name is None:
+            continue
+        if name in result:
+            return None
+        result[name] = cast("ast.Assign", statement).value
+    return result
+
+
+def _read_counts(body: list[ast.stmt]) -> dict[str, int]:
+    result: dict[str, int] = {}
+    for statement in body:
+        for node in ast.walk(statement):
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+                result[node.id] = result.get(node.id, 0) + 1
+    return result
+
+
+def _dependency_closure(names: set[str], definitions: dict[str, ast.expr]) -> set[str]:
+    result = set(names)
+    worklist = list(names)
+    while worklist:
+        name = worklist.pop()
+        expression = definitions.get(name)
+        if expression is None:
+            continue
+        for dependency in _names_read(expression):
+            if dependency not in result:
+                result.add(dependency)
+                worklist.append(dependency)
+    return result
+
+
+def _index_dependencies(
+    body: list[ast.stmt], definitions: dict[str, ast.expr]
+) -> set[str]:
+    names = {
+        name
+        for statement in body
+        for node in ast.walk(statement)
+        if isinstance(node, ast.Subscript)
+        for name in _names_read(node.slice)
+    }
+    return _dependency_closure(names, definitions)
+
+
+def _strip_int_cast(expression: ast.expr) -> ast.expr:
+    while (
+        isinstance(expression, ast.Call)
+        and _ast_call_path(expression.func) in {"cutlass.Int32", "cutlass.Int64"}
+        and len(expression.args) == 1
+        and not expression.keywords
+    ):
+        expression = expression.args[0]
+    return expression
+
+
+def _lane_affine_coefficient(expression: ast.expr, lane_name: str) -> int | None:
+    """Return the integer lane coefficient for a simple affine expression."""
+    expression = _strip_int_cast(expression)
+    if isinstance(expression, ast.Name):
+        return 1 if expression.id == lane_name else 0
+    if isinstance(expression, ast.Constant):
+        return 0 if isinstance(expression.value, (int, bool)) else None
+    if isinstance(expression, ast.UnaryOp) and isinstance(
+        expression.op, (ast.UAdd, ast.USub)
+    ):
+        coefficient = _lane_affine_coefficient(expression.operand, lane_name)
+        if coefficient is None:
+            return None
+        return -coefficient if isinstance(expression.op, ast.USub) else coefficient
+    if not isinstance(expression, ast.BinOp):
+        return 0 if lane_name not in _names_read(expression) else None
+    if isinstance(expression.op, (ast.Add, ast.Sub)):
+        left = _lane_affine_coefficient(expression.left, lane_name)
+        right = _lane_affine_coefficient(expression.right, lane_name)
+        if left is None or right is None:
+            return None
+        return left - right if isinstance(expression.op, ast.Sub) else left + right
+    if isinstance(expression.op, ast.Mult):
+        left = _strip_int_cast(expression.left)
+        right = _strip_int_cast(expression.right)
+        if isinstance(left, ast.Constant) and isinstance(left.value, int):
+            coefficient = _lane_affine_coefficient(right, lane_name)
+            return None if coefficient is None else left.value * coefficient
+        if isinstance(right, ast.Constant) and isinstance(right.value, int):
+            coefficient = _lane_affine_coefficient(left, lane_name)
+            return None if coefficient is None else right.value * coefficient
+        return None if lane_name in _names_read(expression) else 0
+    if (
+        isinstance(expression.op, ast.FloorDiv)
+        and isinstance(_strip_int_cast(expression.right), ast.Constant)
+        and cast("ast.Constant", _strip_int_cast(expression.right)).value in {1, -1}
+    ):
+        coefficient = _lane_affine_coefficient(expression.left, lane_name)
+        if coefficient is None:
+            return None
+        divisor = cast(
+            "int", cast("ast.Constant", _strip_int_cast(expression.right)).value
+        )
+        return coefficient // divisor
+    return None if lane_name in _names_read(expression) else 0
+
+
+def _safe_lane_local_stores(
+    loop: ast.For, lane_name: str, rmem_names: set[str]
+) -> bool:
+    mutated = _mutation_roots(loop)
+    loop_locals = _names_written(loop) - {lane_name}
+    store_mappings: dict[str, set[str]] = {}
+    if not mutated <= rmem_names:
+        return False
+    for node in ast.walk(loop):
+        if not isinstance(node, ast.Subscript):
+            continue
+        if isinstance(node.ctx, ast.Store) and not isinstance(node.value, ast.Name):
+            return False
+        if not isinstance(node.value, ast.Name):
+            continue
+        root = node.value.id
+        if root not in mutated:
+            continue
+        if isinstance(node.ctx, ast.Load):
+            # A read from a fragment written by the loop can carry values
+            # between iterations.  Pairing changes that statement order.
+            return False
+        if not isinstance(node.ctx, ast.Store):
+            return False
+        if _names_read(node.slice) & loop_locals:
+            return False
+        coefficient = _lane_affine_coefficient(node.slice, lane_name)
+        if coefficient in {None, 0}:
+            return False
+        store_mappings.setdefault(root, set()).add(
+            ast.dump(node.slice, include_attributes=False)
+        )
+        if len(store_mappings[root]) > 1:
+            return False
+    return True
+
+
+_FP32_MATH_CALLS = {
+    "cute.math.absf",
+    "cute.math.atan2",
+    "cute.math.div",
+    "cute.math.erf",
+    "cute.math.exp",
+    "cute.math.exp2",
+    "cute.math.fma",
+    "cute.math.log",
+    "cute.math.log2",
+    "cute.math.maximum",
+    "cute.math.minimum",
+    "cute.math.rcp",
+    "cute.math.rsqrt",
+    "cute.math.sqrt",
+    "cute.math.tanh",
+}
+
+
+def _numeric_expression_kind(
+    expression: ast.expr,
+    definitions: dict[str, ast.expr],
+    fp32_rmem: set[str],
+    fp32_names: set[str],
+    resolving: set[str] | None = None,
+) -> str | None:
+    if (
+        isinstance(expression, ast.Call)
+        and _ast_call_path(expression.func) == "cutlass.Float32"
+        and len(expression.args) == 1
+        and not expression.keywords
+    ):
+        return "fp32"
+    if (
+        isinstance(expression, ast.Call)
+        and _ast_call_path(expression.func) == "cutlass.Int32"
+        and len(expression.args) == 1
+        and not expression.keywords
+    ):
+        return "int"
+    if isinstance(expression, ast.Constant):
+        if isinstance(expression.value, float):
+            return "fp32"
+        if isinstance(expression.value, (bool, int)):
+            return "int"
+        return None
+    if isinstance(expression, ast.Subscript) and isinstance(expression.value, ast.Name):
+        return "fp32" if expression.value.id in fp32_rmem else None
+    if isinstance(expression, ast.Name):
+        if expression.id in fp32_names:
+            return "fp32"
+        definition = definitions.get(expression.id)
+        if definition is None:
+            return None
+        resolving = set() if resolving is None else resolving
+        if expression.id in resolving:
+            return None
+        resolving.add(expression.id)
+        try:
+            return _numeric_expression_kind(
+                definition,
+                definitions,
+                fp32_rmem,
+                fp32_names,
+                resolving,
+            )
+        finally:
+            resolving.remove(expression.id)
+    if isinstance(expression, ast.UnaryOp) and isinstance(
+        expression.op, (ast.UAdd, ast.USub)
+    ):
+        return _numeric_expression_kind(
+            expression.operand, definitions, fp32_rmem, fp32_names, resolving
+        )
+    if isinstance(expression, ast.BinOp) and isinstance(
+        expression.op, (ast.Add, ast.Mult, ast.Sub)
+    ):
+        left = _numeric_expression_kind(
+            expression.left, definitions, fp32_rmem, fp32_names, resolving
+        )
+        right = _numeric_expression_kind(
+            expression.right, definitions, fp32_rmem, fp32_names, resolving
+        )
+        if left is None or right is None:
+            return None
+        return "fp32" if "fp32" in {left, right} else "int"
+    if isinstance(expression, ast.IfExp):
+        body_kind = _numeric_expression_kind(
+            expression.body, definitions, fp32_rmem, fp32_names, resolving
+        )
+        else_kind = _numeric_expression_kind(
+            expression.orelse, definitions, fp32_rmem, fp32_names, resolving
+        )
+        if body_kind is None or else_kind is None:
+            return None
+        return "fp32" if "fp32" in {body_kind, else_kind} else "int"
+    if isinstance(expression, ast.Call):
+        path = _ast_call_path(expression.func)
+        if path not in _FP32_MATH_CALLS or not expression.args:
+            return None
+        argument_kinds = [
+            _numeric_expression_kind(
+                argument, definitions, fp32_rmem, fp32_names, resolving
+            )
+            for argument in expression.args
+        ]
+        if any(kind is None for kind in argument_kinds):
+            return None
+        return "fp32" if "fp32" in argument_kinds else None
+    return None
+
+
+def _is_fp32_expression(
+    expression: ast.expr,
+    definitions: dict[str, ast.expr],
+    fp32_rmem: set[str],
+    fp32_names: set[str],
+) -> bool:
+    return (
+        _numeric_expression_kind(
+            expression,
+            definitions,
+            fp32_rmem,
+            fp32_names,
+        )
+        == "fp32"
+    )
+
+
+def _single_use_product(
+    expression: ast.expr,
+    definitions: dict[str, ast.expr],
+    reads: dict[str, int],
+) -> tuple[str | None, ast.BinOp] | None:
+    expression = _unwrap_fp32(expression)
+    if isinstance(expression, ast.BinOp) and isinstance(expression.op, ast.Mult):
+        return None, expression
+    if not isinstance(expression, ast.Name) or reads.get(expression.id) != 1:
+        return None
+    definition = _unwrap_fp32(definitions.get(expression.id, expression))
+    if not isinstance(definition, ast.BinOp) or not isinstance(definition.op, ast.Mult):
+        return None
+    return expression.id, definition
+
+
+class _InlineSingleUseProducts(ast.NodeTransformer):
+    def __init__(
+        self,
+        definitions: dict[str, ast.expr],
+        reads: dict[str, int],
+        blocked: set[str],
+        fp32_rmem: set[str],
+        fp32_names: set[str],
+    ) -> None:
+        self.definitions = definitions
+        self.reads = reads
+        self.blocked = blocked
+        self.fp32_rmem = fp32_rmem
+        self.fp32_names = fp32_names
+        self.inlined: set[str] = set()
+        self.resolving: set[str] = set()
+
+    def visit_Name(self, node: ast.Name) -> ast.AST:
+        if (
+            not isinstance(node.ctx, ast.Load)
+            or node.id in self.blocked
+            or node.id in self.resolving
+            or self.reads.get(node.id) != 1
+        ):
+            return node
+        definition = self.definitions.get(node.id)
+        if definition is None:
+            return node
+        product = _unwrap_fp32(definition)
+        if (
+            not isinstance(product, ast.BinOp)
+            or not isinstance(product.op, ast.Mult)
+            or not _is_fp32_expression(
+                product,
+                self.definitions,
+                self.fp32_rmem,
+                self.fp32_names,
+            )
+        ):
+            return node
+        self.inlined.add(node.id)
+        self.resolving.add(node.id)
+        try:
+            return self.visit(cast("ast.expr", _clone_extended_ast(product)))
+        finally:
+            self.resolving.remove(node.id)
+
+
+def _prepare_packed_product(
+    matched: tuple[str | None, ast.BinOp],
+    *,
+    definitions: dict[str, ast.expr],
+    reads: dict[str, int],
+    blocked: set[str],
+    fp32_rmem: set[str],
+    fp32_names: set[str],
+) -> tuple[ast.BinOp, set[str]]:
+    name, product = matched
+    inliner = _InlineSingleUseProducts(
+        definitions,
+        reads,
+        blocked,
+        fp32_rmem,
+        fp32_names,
+    )
+    prepared = cast(
+        "ast.BinOp",
+        inliner.visit(cast("ast.BinOp", _clone_extended_ast(product))),
+    )
+    skipped = set(inliner.inlined)
+    if name is not None:
+        skipped.add(name)
+    return prepared, skipped
+
+
+def _pair_assignment_names(
+    local_names: set[str], occupied: set[str]
+) -> tuple[dict[str, str], dict[str, str]]:
+    lo = {
+        name: _fresh_ast_name(occupied, f"_factored_{name}_lo")
+        for name in sorted(local_names)
+    }
+    hi = {
+        name: _fresh_ast_name(occupied, f"_factored_{name}_hi")
+        for name in sorted(local_names)
+    }
+    return lo, hi
+
+
+def _clone_statement_for_pair(
+    statement: ast.stmt,
+    *,
+    lane_name: str,
+    lane_expression: ast.expr,
+    renames: dict[str, str],
+) -> ast.stmt:
+    return cast(
+        "ast.stmt",
+        _ClonePairLane(lane_name, lane_expression, renames).visit(
+            cast("ast.stmt", _clone_extended_ast(statement))
+        ),
+    )
+
+
+def _pair_values(
+    expression: ast.expr,
+    *,
+    lane_name: str,
+    lane_lo: ast.expr,
+    lane_hi: ast.expr,
+    renames_lo: dict[str, str],
+    renames_hi: dict[str, str],
+) -> tuple[ast.expr, ast.expr]:
+    return (
+        _clone_pair_expression(
+            expression,
+            lane_name=lane_name,
+            lane_expression=lane_lo,
+            renames=renames_lo,
+        ),
+        _clone_pair_expression(
+            expression,
+            lane_name=lane_name,
+            lane_expression=lane_hi,
+            renames=renames_hi,
+        ),
+    )
+
+
+def _pair_arithmetic_assignment(
+    target: str,
+    expression: ast.BinOp,
+    *,
+    lane_name: str,
+    lane_lo: ast.expr,
+    lane_hi: ast.expr,
+    renames_lo: dict[str, str],
+    renames_hi: dict[str, str],
+    product: ast.BinOp | None = None,
+    addend: ast.expr | None = None,
+) -> ast.Assign:
+    lhs_expression = expression.left if product is None else product.left
+    rhs_expression = expression.right if product is None else product.right
+    lhs_lo, lhs_hi = _pair_values(
+        lhs_expression,
+        lane_name=lane_name,
+        lane_lo=lane_lo,
+        lane_hi=lane_hi,
+        renames_lo=renames_lo,
+        renames_hi=renames_hi,
+    )
+    rhs_lo, rhs_hi = _pair_values(
+        rhs_expression,
+        lane_name=lane_name,
+        lane_lo=lane_lo,
+        lane_hi=lane_hi,
+        renames_lo=renames_lo,
+        renames_hi=renames_hi,
+    )
+    if product is not None and addend is not None:
+        acc_lo, acc_hi = _pair_values(
+            addend,
+            lane_name=lane_name,
+            lane_lo=lane_lo,
+            lane_hi=lane_hi,
+            renames_lo=renames_lo,
+            renames_hi=renames_hi,
+        )
+        return _packed_pair_assignment(
+            renames_lo[target],
+            renames_hi[target],
+            "cute.arch.fma_packed_f32x2",
+            lhs_lo,
+            lhs_hi,
+            rhs_lo,
+            rhs_hi,
+            acc_lo,
+            acc_hi,
+        )
+    function = (
+        "cute.arch.mul_packed_f32x2"
+        if isinstance(expression.op, ast.Mult)
+        else "cute.arch.add_packed_f32x2"
+    )
+    return _packed_pair_assignment(
+        renames_lo[target],
+        renames_hi[target],
+        function,
+        lhs_lo,
+        lhs_hi,
+        rhs_lo,
+        rhs_hi,
+    )
+
+
+def _append_call(statement: ast.stmt) -> ast.Call | None:
+    if (
+        not isinstance(statement, ast.Expr)
+        or not isinstance(statement.value, ast.Call)
+        or not isinstance(statement.value.func, ast.Attribute)
+        or statement.value.func.attr != "append"
+        or len(statement.value.args) != 1
+        or statement.value.keywords
+    ):
+        return None
+    return statement.value
+
+
+def _pair_constexpr_loop(
+    loop: ast.For,
+    accumulators: tuple[str, ...],
+    accumulator_pairs: dict[str, tuple[str, str]],
+    *,
+    occupied: set[str],
+    rmem_names: set[str],
+    fp32_rmem: set[str],
+    fp32_names: set[str],
+    live_after: set[str],
+) -> ast.For | None:
+    matched = _constexpr_loop(loop)
+    if matched is None:
+        return None
+    _loop, lane_name, extent = matched
+    if extent % 2 != 0 or extent < 2:
+        return None
+    append_calls = [
+        call for statement in loop.body if (call := _append_call(statement)) is not None
+    ]
+    if not accumulators and len(append_calls) != 1:
+        return None
+    if len(append_calls) > 1:
+        return None
+    if append_calls and _append_call(loop.body[-1]) is None:
+        return None
+    if any(
+        isinstance(
+            node,
+            (
+                ast.Await,
+                ast.DictComp,
+                ast.GeneratorExp,
+                ast.Lambda,
+                ast.ListComp,
+                ast.NamedExpr,
+                ast.SetComp,
+                ast.Yield,
+                ast.YieldFrom,
+            ),
+        )
+        for node in ast.walk(loop)
+    ):
+        return None
+    for statement in loop.body:
+        if _append_call(statement) is not None:
+            continue
+        if not isinstance(statement, ast.Assign) or len(statement.targets) != 1:
+            return None
+        target = statement.targets[0]
+        if not isinstance(target, (ast.Name, ast.Subscript)):
+            return None
+        if isinstance(target, ast.Subscript) and not isinstance(target.value, ast.Name):
+            return None
+    if _has_effectful_call(
+        loop.body,
+        ignored_calls=frozenset(id(call) for call in append_calls),
+    ):
+        return None
+    if not _safe_lane_local_stores(loop, lane_name, rmem_names):
+        return None
+    if len(accumulators) == 1 and _mutation_roots(loop):
+        # Pairing one reduction while duplicating its cache-population path
+        # lengthens live ranges for little arithmetic savings.  Multiple
+        # reductions amortize those paired lane values; a pure reduction has
+        # no store path to duplicate.
+        return None
+    definitions = _definitions(loop.body)
+    if definitions is None:
+        return None
+    local_names = set(definitions) - set(accumulators)
+    if lane_name in local_names:
+        return None
+    if (local_names | {lane_name}) & live_after:
+        return None
+
+    seen: set[str] = set()
+    accumulator_set = set(accumulators)
+    for statement in loop.body:
+        assigned = _assigned_name(statement)
+        reads = _names_read(statement)
+        if assigned in accumulator_set:
+            assert assigned is not None
+            term = _accumulated_term(statement, assigned)
+            if term is None or _names_read(term) & accumulator_set:
+                return None
+            reads.discard(assigned)
+        elif reads & accumulator_set:
+            return None
+        if reads & (local_names - seen):
+            # Reject forward and loop-carried scalar dependencies.
+            return None
+        if assigned is not None:
+            seen.add(assigned)
+
+    reads = _read_counts(loop.body)
+    seeds: set[str] = set()
+    accumulator_terms: dict[str, ast.expr] = {}
+    for accumulator in accumulators:
+        matches = [
+            term
+            for statement in loop.body
+            if (term := _accumulated_term(statement, accumulator)) is not None
+        ]
+        if len(matches) != 1:
+            return None
+        accumulator_terms[accumulator] = matches[0]
+        seeds.update(_names_read(matches[0]))
+    append_statements = [
+        statement for statement in loop.body if _append_call(statement) is not None
+    ]
+    for statement in append_statements:
+        seeds.update(_names_read(statement))
+    value_dependencies = _dependency_closure(seeds, definitions)
+    index_dependencies = _index_dependencies(loop.body, definitions)
+    blocked_inline = index_dependencies | accumulator_set
+
+    skipped_products: set[str] = set()
+    accumulator_products: dict[str, ast.BinOp | None] = {}
+    for accumulator, term in accumulator_terms.items():
+        product = _single_use_product(term, definitions, reads)
+        if product is not None and _is_fp32_expression(
+            product[1], definitions, fp32_rmem, fp32_names
+        ):
+            prepared, skipped = _prepare_packed_product(
+                product,
+                definitions=definitions,
+                reads=reads,
+                blocked=blocked_inline,
+                fp32_rmem=fp32_rmem,
+                fp32_names=fp32_names,
+            )
+            accumulator_products[accumulator] = prepared
+            skipped_products.update(skipped)
+        elif _is_fp32_expression(term, definitions, fp32_rmem, fp32_names):
+            accumulator_products[accumulator] = None
+        else:
+            return None
+
+    fused_assignments: dict[str, tuple[ast.BinOp, ast.expr]] = {}
+    for name in value_dependencies - index_dependencies:
+        expression = _unwrap_fp32(definitions.get(name, ast.Name(id=name)))
+        if (
+            not isinstance(expression, ast.BinOp)
+            or not isinstance(expression.op, ast.Add)
+            or not _is_fp32_expression(expression, definitions, fp32_rmem, fp32_names)
+        ):
+            continue
+        candidates: list[tuple[int, ast.BinOp, ast.expr, set[str]]] = []
+        for operand, other in (
+            (expression.left, expression.right),
+            (expression.right, expression.left),
+        ):
+            product = _single_use_product(operand, definitions, reads)
+            if (
+                product is not None
+                and product[0] is not None
+                and _is_fp32_expression(product[1], definitions, fp32_rmem, fp32_names)
+            ):
+                prepared, skipped = _prepare_packed_product(
+                    product,
+                    definitions=definitions,
+                    reads=reads,
+                    blocked=blocked_inline,
+                    fp32_rmem=fp32_rmem,
+                    fp32_names=fp32_names,
+                )
+                candidates.append((len(skipped), prepared, other, skipped))
+        if candidates:
+            best = candidates[0]
+            for candidate in candidates[1:]:
+                if candidate[0] > best[0]:
+                    best = candidate
+            _score, prepared, other, skipped = best
+            skipped_products.update(skipped)
+            fused_assignments[name] = prepared, other
+
+    renames_lo, renames_hi = _pair_assignment_names(local_names, occupied)
+    for accumulator, (accumulator_lo, accumulator_hi) in accumulator_pairs.items():
+        renames_lo[accumulator] = accumulator_lo
+        renames_hi[accumulator] = accumulator_hi
+    pair_lane = _fresh_ast_name(occupied, "_factored_pair_lane")
+    lane_lo = _pair_lane_expression(pair_lane, False)
+    lane_hi = _pair_lane_expression(pair_lane, True)
+    result: list[ast.stmt] = []
+    packed_operations = 0
+
+    for statement in loop.body:
+        assigned = _assigned_name(statement)
+        if assigned in accumulators:
+            assert assigned is not None
+            term = accumulator_terms[assigned]
+            product = accumulator_products[assigned]
+            accumulator_lo, accumulator_hi = accumulator_pairs[assigned]
+            if product is not None:
+                lhs_lo, lhs_hi = _pair_values(
+                    product.left,
+                    lane_name=lane_name,
+                    lane_lo=lane_lo,
+                    lane_hi=lane_hi,
+                    renames_lo=renames_lo,
+                    renames_hi=renames_hi,
+                )
+                rhs_lo, rhs_hi = _pair_values(
+                    product.right,
+                    lane_name=lane_name,
+                    lane_lo=lane_lo,
+                    lane_hi=lane_hi,
+                    renames_lo=renames_lo,
+                    renames_hi=renames_hi,
+                )
+                result.append(
+                    _packed_pair_assignment(
+                        accumulator_lo,
+                        accumulator_hi,
+                        "cute.arch.fma_packed_f32x2",
+                        lhs_lo,
+                        lhs_hi,
+                        rhs_lo,
+                        rhs_hi,
+                        create(ast.Name, id=accumulator_lo, ctx=ast.Load()),
+                        create(ast.Name, id=accumulator_hi, ctx=ast.Load()),
+                    )
+                )
+                packed_operations += 1
+            else:
+                term_lo, term_hi = _pair_values(
+                    _unwrap_fp32(term),
+                    lane_name=lane_name,
+                    lane_lo=lane_lo,
+                    lane_hi=lane_hi,
+                    renames_lo=renames_lo,
+                    renames_hi=renames_hi,
+                )
+                result.append(
+                    _packed_pair_assignment(
+                        accumulator_lo,
+                        accumulator_hi,
+                        "cute.arch.add_packed_f32x2",
+                        create(ast.Name, id=accumulator_lo, ctx=ast.Load()),
+                        create(ast.Name, id=accumulator_hi, ctx=ast.Load()),
+                        term_lo,
+                        term_hi,
+                    )
+                )
+                packed_operations += 1
+            continue
+        if assigned is not None and assigned in skipped_products:
+            continue
+        if assigned is not None:
+            expression = _unwrap_fp32(cast("ast.Assign", statement).value)
+            fused = fused_assignments.get(assigned)
+            if fused is not None:
+                result.append(
+                    _pair_arithmetic_assignment(
+                        assigned,
+                        cast("ast.BinOp", expression),
+                        lane_name=lane_name,
+                        lane_lo=lane_lo,
+                        lane_hi=lane_hi,
+                        renames_lo=renames_lo,
+                        renames_hi=renames_hi,
+                        product=fused[0],
+                        addend=fused[1],
+                    )
+                )
+                packed_operations += 1
+                continue
+            if (
+                assigned in value_dependencies - index_dependencies
+                and isinstance(expression, ast.BinOp)
+                and isinstance(expression.op, (ast.Add, ast.Mult))
+                and _is_fp32_expression(expression, definitions, fp32_rmem, fp32_names)
+            ):
+                result.append(
+                    _pair_arithmetic_assignment(
+                        assigned,
+                        expression,
+                        lane_name=lane_name,
+                        lane_lo=lane_lo,
+                        lane_hi=lane_hi,
+                        renames_lo=renames_lo,
+                        renames_hi=renames_hi,
+                    )
+                )
+                packed_operations += 1
+                continue
+        result.extend(
+            (
+                _clone_statement_for_pair(
+                    statement,
+                    lane_name=lane_name,
+                    lane_expression=lane_lo,
+                    renames=renames_lo,
+                ),
+                _clone_statement_for_pair(
+                    statement,
+                    lane_name=lane_name,
+                    lane_expression=lane_hi,
+                    renames=renames_hi,
+                ),
+            )
+        )
+
+    if packed_operations == 0:
+        return None
+    return create(
+        ast.For,
+        target=create(ast.Name, id=pair_lane, ctx=ast.Store()),
+        iter=expr_from_string(f"cutlass.range_constexpr({extent // 2})"),
+        body=result,
+        orelse=[],
+        type_comment=None,
+    )
+
+
+def _rmem_storage_names(body: list[ast.stmt]) -> tuple[set[str], set[str]]:
+    module = ast.Module(body=body, type_ignores=[])
+    assignments: dict[str, list[ast.Assign]] = {}
+    for node in ast.walk(module):
+        name = _assigned_name(node) if isinstance(node, ast.stmt) else None
+        if name is not None:
+            assignments.setdefault(name, []).append(cast("ast.Assign", node))
+    write_counts: dict[str, int] = {}
+    for node in ast.walk(module):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+            write_counts[node.id] = write_counts.get(node.id, 0) + 1
+
+    rmem_names: set[str] = set()
+    fp32_rmem: set[str] = set()
+    for name, definitions in assignments.items():
+        if len(definitions) != 1 or write_counts.get(name) != 1:
+            continue
+        value = definitions[0].value
+        if (
+            not isinstance(value, ast.Call)
+            or _ast_call_path(value.func) != "cute.make_rmem_tensor"
+            or len(value.args) != 2
+            or value.keywords
+        ):
+            continue
+        rmem_names.add(name)
+        if _ast_call_path(cast("ast.expr", value.args[1])) == "cutlass.Float32":
+            fp32_rmem.add(name)
+
+    # A register fragment is considered non-aliasing only when every load of
+    # its Python name is the base of a direct subscript.  Passing the fragment
+    # to a helper or assigning it to another name could create an alias that a
+    # lane-local store analysis cannot see.
+    parents: dict[int, ast.AST] = {}
+    for parent in ast.walk(module):
+        for child in ast.iter_child_nodes(parent):
+            parents[id(child)] = parent
+    aliased: set[str] = set()
+    for node in ast.walk(module):
+        if (
+            not isinstance(node, ast.Name)
+            or not isinstance(node.ctx, ast.Load)
+            or node.id not in rmem_names
+        ):
+            continue
+        parent = parents.get(id(node))
+        if not (isinstance(parent, ast.Subscript) and parent.value is node):
+            aliased.add(node.id)
+    rmem_names -= aliased
+    return rmem_names, fp32_rmem
+
+
+def _collect_fp32_names(
+    body: list[ast.stmt],
+    fp32_rmem: set[str],
+    initial: set[str],
+) -> set[str]:
+    module = ast.Module(body=body, type_ignores=[])
+    assignments: dict[str, list[ast.expr]] = {}
+    write_counts: dict[str, int] = {}
+    for node in ast.walk(module):
+        name = _assigned_name(node) if isinstance(node, ast.stmt) else None
+        if name is not None:
+            assignments.setdefault(name, []).append(cast("ast.Assign", node).value)
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+            write_counts[node.id] = write_counts.get(node.id, 0) + 1
+    result = {name for name in initial if write_counts.get(name, 0) == 0}
+    changed = True
+    while changed:
+        changed = False
+        for name, expressions in assignments.items():
+            if name in result:
+                continue
+            if write_counts.get(name) == len(expressions) and all(
+                _is_fp32_expression(expression, {}, fp32_rmem, result)
+                for expression in expressions
+            ):
+                result.add(name)
+                changed = True
+    return result
+
+
+def _empty_list_assignment(statement: ast.stmt) -> str | None:
+    name = _assigned_name(statement)
+    if name is None:
+        return None
+    value = cast("ast.Assign", statement).value
+    if not isinstance(value, ast.List) or value.elts:
+        return None
+    return name
+
+
+def _append_target(call: ast.Call) -> str | None:
+    if not isinstance(call.func, ast.Attribute) or not isinstance(
+        call.func.value, ast.Name
+    ):
+        return None
+    return call.func.value.id
+
+
+def _valid_append_output(body: list[ast.stmt], loop_index: int, loop: ast.For) -> bool:
+    calls = [
+        call for statement in loop.body if (call := _append_call(statement)) is not None
+    ]
+    if not calls:
+        return True
+    if len(calls) != 1 or _append_call(loop.body[-1]) is None:
+        return False
+    target = _append_target(calls[0])
+    if target is None:
+        return False
+    initializer = next(
+        (
+            index
+            for index in range(loop_index - 1, -1, -1)
+            if target in _statement_effects(body[index])[1]
+        ),
+        None,
+    )
+    if initializer is None or _empty_list_assignment(body[initializer]) != target:
+        return False
+    if any(
+        target in (_statement_effects(statement)[0] | _statement_effects(statement)[1])
+        for statement in body[initializer + 1 : loop_index]
+    ):
+        return False
+    for node in ast.walk(loop):
+        if not isinstance(node, ast.Name) or node.id != target:
+            continue
+        if not isinstance(node.ctx, ast.Load):
+            return False
+        parent_calls = [
+            call for call in calls if cast("ast.Attribute", call.func).value is node
+        ]
+        if not parent_calls:
+            return False
+    return True
+
+
+def _loop_accumulator_initializers(
+    body: list[ast.stmt], loop_index: int, loop: ast.For
+) -> dict[str, int] | None:
+    accumulators = {
+        name
+        for statement in loop.body
+        if (name := _assigned_name(statement)) is not None
+        and _accumulated_term(statement, name) is not None
+    }
+    if not accumulators:
+        return {}
+    result: dict[str, int] = {}
+    for accumulator in accumulators:
+        initializer = next(
+            (
+                index
+                for index in range(loop_index - 1, -1, -1)
+                if accumulator in _statement_effects(body[index])[1]
+            ),
+            None,
+        )
+        if (
+            initializer is None
+            or _zero_fp32_assignment(body[initializer]) != accumulator
+        ):
+            return None
+        if any(
+            accumulator
+            in (_statement_effects(statement)[0] | _statement_effects(statement)[1])
+            for statement in body[initializer + 1 : loop_index]
+        ):
+            return None
+        result[accumulator] = initializer
+    return result
+
+
+def _pack_fp32_block(
+    body: list[ast.stmt],
+    *,
+    occupied: set[str],
+    rmem_names: set[str],
+    fp32_rmem: set[str],
+    fp32_names: set[str],
+    live_out: set[str],
+) -> list[ast.stmt]:
+    for statement_index, statement in enumerate(body):
+        statement_live_out = _live_before_block(
+            body[statement_index + 1 :], live_out=live_out
+        )
+        for field in ("body", "orelse", "finalbody"):
+            child = getattr(statement, field, None)
+            if isinstance(child, list) and all(
+                isinstance(item, ast.stmt) for item in child
+            ):
+                setattr(
+                    statement,
+                    field,
+                    _pack_fp32_block(
+                        child,
+                        occupied=occupied,
+                        rmem_names=rmem_names,
+                        fp32_rmem=fp32_rmem,
+                        fp32_names=fp32_names,
+                        live_out=_nested_live_out(
+                            statement,
+                            field,
+                            child,
+                            statement_live_out,
+                        ),
+                    ),
+                )
+
+    index = 0
+    while index < len(body):
+        statement = body[index]
+        if not isinstance(statement, ast.For) or _constexpr_loop(statement) is None:
+            index += 1
+            continue
+        initializer_indices = _loop_accumulator_initializers(body, index, statement)
+        if initializer_indices is None or not _valid_append_output(
+            body, index, statement
+        ):
+            index += 1
+            continue
+        accumulators = tuple(
+            name
+            for candidate in statement.body
+            if (name := _assigned_name(candidate)) in initializer_indices
+        )
+        if not accumulators and not any(
+            _append_call(candidate) is not None for candidate in statement.body
+        ):
+            index += 1
+            continue
+
+        trial_occupied = set(occupied)
+        accumulator_pairs = {
+            accumulator: (
+                _fresh_ast_name(trial_occupied, f"_{accumulator}_lo"),
+                _fresh_ast_name(trial_occupied, f"_{accumulator}_hi"),
+            )
+            for accumulator in accumulators
+        }
+        live_after = _live_before_block(body[index + 1 :], live_out=live_out)
+        paired = _pair_constexpr_loop(
+            statement,
+            accumulators,
+            accumulator_pairs,
+            occupied=trial_occupied,
+            rmem_names=rmem_names,
+            fp32_rmem=fp32_rmem,
+            fp32_names=fp32_names,
+            live_after=live_after,
+        )
+        if paired is None:
+            index += 1
+            continue
+
+        occupied.update(trial_occupied)
+        for initializer_index in sorted(
+            set(initializer_indices.values()), reverse=True
+        ):
+            accumulator = _zero_fp32_assignment(body[initializer_index])
+            assert accumulator is not None
+            lo_name, hi_name = accumulator_pairs[accumulator]
+            body[initializer_index : initializer_index + 1] = [
+                create(
+                    ast.Assign,
+                    targets=[create(ast.Name, id=lo_name, ctx=ast.Store())],
+                    value=expr_from_string("cutlass.Float32(0)"),
+                ),
+                create(
+                    ast.Assign,
+                    targets=[create(ast.Name, id=hi_name, ctx=ast.Store())],
+                    value=expr_from_string("cutlass.Float32(0)"),
+                ),
+            ]
+            if initializer_index < index:
+                index += 1
+
+        reductions = [
+            create(
+                ast.Assign,
+                targets=[create(ast.Name, id=accumulator, ctx=ast.Store())],
+                value=expr_from_string(
+                    f"cutlass.Float32({accumulator_pairs[accumulator][0]}) + "
+                    f"cutlass.Float32({accumulator_pairs[accumulator][1]})"
+                ),
+            )
+            for accumulator in accumulators
+        ]
+        body[index : index + 1] = [paired, *reductions]
+        index += 1 + len(reductions)
+    return body
+
+
+def pack_fp32_constexpr_loops(
+    body: list[ast.stmt],
+    *,
+    fast_math: bool,
+    target_device_capability: tuple[int, int] | None,
+    float_scalar_names: set[str] | frozenset[str] = frozenset(),
+) -> list[ast.stmt]:
+    """Pair independent fp32 loop lanes into Blackwell packed instructions.
+
+    Packed f32x2 arithmetic changes evaluation order and is therefore enabled
+    only for fast-math kernels.  The FFMA2 path is validated on Blackwell; all
+    older or unknown targets retain their scalar generated AST.
+    """
+    if (
+        not fast_math
+        or target_device_capability is None
+        or target_device_capability < (10, 0)
+    ):
+        return body
+    occupied = {
+        node.id
+        for statement in body
+        for node in ast.walk(statement)
+        if isinstance(node, ast.Name)
+    }
+    rmem_names, fp32_rmem = _rmem_storage_names(body)
+    fp32_names = _collect_fp32_names(body, fp32_rmem, set(float_scalar_names))
+    return [
+        ast.fix_missing_locations(statement)
+        for statement in _pack_fp32_block(
+            body,
+            occupied=occupied,
+            rmem_names=rmem_names,
+            fp32_rmem=fp32_rmem,
+            fp32_names=fp32_names,
+            live_out=set(),
+        )
+    ]
+
+
+_PACKED_LICM_CALLS = {
+    *_AST_PURE_CALLS,
+    "cutlass.range_constexpr",
+    "cute.arch.fma_packed_f32x2",
+    "cute.arch.warp_reduction_sum",
+}
+_PACKED_LICM_UNSUPPORTED_CONTROL = (
+    ast.AsyncFor,
+    ast.AsyncFunctionDef,
+    ast.AsyncWith,
+    ast.ClassDef,
+    ast.FunctionDef,
+    ast.Global,
+    ast.Match,
+    ast.Nonlocal,
+    ast.Try,
+    ast.With,
+)
+
+
+def _fp32_name(expression: ast.expr, name: str) -> bool:
+    return (
+        isinstance(expression, ast.Call)
+        and _ast_call_path(expression.func) == "cutlass.Float32"
+        and len(expression.args) == 1
+        and not expression.keywords
+        and isinstance(expression.args[0], ast.Name)
+        and expression.args[0].id == name
+    )
+
+
+def _packed_accumulator_update(
+    statement: ast.stmt, lo_accumulator: str, hi_accumulator: str
+) -> bool:
+    if (
+        not isinstance(statement, ast.Assign)
+        or len(statement.targets) != 1
+        or not isinstance(statement.targets[0], ast.Tuple)
+    ):
+        return False
+    target = statement.targets[0]
+    if (
+        len(target.elts) != 2
+        or not all(isinstance(elt, ast.Name) for elt in target.elts)
+        or cast("ast.Name", target.elts[0]).id != lo_accumulator
+        or cast("ast.Name", target.elts[1]).id != hi_accumulator
+        or not isinstance(statement.value, ast.Call)
+        or _ast_call_path(statement.value.func) != "cute.arch.fma_packed_f32x2"
+        or len(statement.value.args) != 3
+        or statement.value.keywords
+        or any(
+            not isinstance(argument, ast.Tuple) or len(argument.elts) != 2
+            for argument in statement.value.args
+        )
+    ):
+        return False
+    accumulator_pair = statement.value.args[2]
+    return (
+        isinstance(accumulator_pair, ast.Tuple)
+        and len(accumulator_pair.elts) == 2
+        and _fp32_name(accumulator_pair.elts[0], lo_accumulator)
+        and _fp32_name(accumulator_pair.elts[1], hi_accumulator)
+    )
+
+
+def _packed_pair_sum(
+    statement: ast.stmt, lo_accumulator: str, hi_accumulator: str
+) -> str | None:
+    result = _assigned_name(statement)
+    if result is None:
+        return None
+    value = cast("ast.Assign", statement).value
+    if not isinstance(value, ast.BinOp) or not isinstance(value.op, ast.Add):
+        return None
+    if not (
+        _fp32_name(value.left, lo_accumulator)
+        and _fp32_name(value.right, hi_accumulator)
+    ):
+        return None
+    return result
+
+
+def _packed_licm_call_is_pure(call: ast.Call) -> bool:
+    path = _ast_call_path(call.func)
+    if path == "cute.math.div":
+        return (
+            len(call.args) == 2
+            and not call.keywords
+            and isinstance(call.args[1], ast.Constant)
+            and isinstance(call.args[1].value, (int, float))
+            and not isinstance(call.args[1].value, bool)
+            and call.args[1].value != 0
+        )
+    if path == "cute.arch.load":
+        return False
+    if path in _PACKED_LICM_CALLS or path in _FP32_MATH_CALLS:
+        return True
+    if not (
+        isinstance(call.func, ast.Attribute)
+        and call.func.attr == "bitcast"
+        and isinstance(call.func.value, ast.Call)
+    ):
+        return False
+    return _ast_call_path(call.func.value.func) in _AST_PURE_CALLS
+
+
+def _packed_licm_statement_is_pure(statement: ast.stmt, rmem_names: set[str]) -> bool:
+    if isinstance(statement, ast.Assign):
+        if len(statement.targets) != 1 or not isinstance(
+            statement.targets[0], (ast.Name, ast.Tuple)
+        ):
+            return False
+        if isinstance(statement.targets[0], ast.Tuple) and not all(
+            isinstance(elt, ast.Name) for elt in statement.targets[0].elts
+        ):
+            return False
+    elif isinstance(statement, ast.For):
+        if _constexpr_loop(statement) is None:
+            return False
+        if not all(
+            _packed_licm_statement_is_pure(child, rmem_names)
+            for child in statement.body
+        ):
+            return False
+    else:
+        return False
+
+    parents = {
+        id(child): parent
+        for parent in ast.walk(statement)
+        for child in ast.iter_child_nodes(parent)
+    }
+    for node in ast.walk(statement):
+        if isinstance(
+            node,
+            (
+                ast.Await,
+                ast.DictComp,
+                ast.GeneratorExp,
+                ast.Lambda,
+                ast.ListComp,
+                ast.NamedExpr,
+                ast.SetComp,
+                ast.Yield,
+                ast.YieldFrom,
+            ),
+        ):
+            return False
+        if isinstance(node, ast.Call) and not _packed_licm_call_is_pure(node):
+            return False
+        if isinstance(node, ast.Attribute):
+            call_path_root: ast.AST = node
+            while (
+                isinstance(parent := parents.get(id(call_path_root)), ast.Attribute)
+                and parent.value is call_path_root
+            ):
+                call_path_root = parent
+            parent = parents.get(id(call_path_root))
+            if not (isinstance(parent, ast.Call) and parent.func is call_path_root):
+                return False
+        if isinstance(node, (ast.BoolOp, ast.Compare, ast.IfExp)):
+            return False
+        if isinstance(node, ast.UnaryOp) and not isinstance(
+            node.op, (ast.Invert, ast.UAdd, ast.USub)
+        ):
+            return False
+        if isinstance(node, ast.Subscript):
+            if (
+                not isinstance(node.ctx, ast.Load)
+                or not isinstance(node.value, ast.Name)
+                or node.value.id not in rmem_names
+            ):
+                return False
+        if isinstance(node, ast.BinOp):
+            if isinstance(node.op, (ast.Add, ast.Mult, ast.Sub)):
+                continue
+            if not (
+                isinstance(node.op, (ast.Div, ast.FloorDiv, ast.Mod))
+                and isinstance(node.right, ast.Constant)
+                and isinstance(node.right.value, (int, float))
+                and not isinstance(node.right.value, bool)
+                and node.right.value != 0
+            ):
+                return False
+    return True
+
+
+def _dead_packed_assignment_is_discardable(statement: ast.stmt) -> bool:
+    """Return whether deleting an unused generated scalar assignment is safe."""
+    if not (
+        isinstance(statement, ast.Assign)
+        and len(statement.targets) == 1
+        and isinstance(statement.targets[0], ast.Name)
+    ):
+        return False
+
+    def safe_expression(expression: ast.expr) -> bool:
+        if isinstance(expression, (ast.Constant, ast.Name)):
+            return True
+        if isinstance(expression, ast.UnaryOp) and isinstance(
+            expression.op, (ast.Invert, ast.UAdd, ast.USub)
+        ):
+            return safe_expression(expression.operand)
+        if isinstance(expression, ast.BinOp) and isinstance(
+            expression.op, (ast.Add, ast.Mult, ast.Sub)
+        ):
+            return safe_expression(expression.left) and safe_expression(
+                expression.right
+            )
+        if not isinstance(expression, ast.Call) or expression.keywords:
+            return False
+        path = _ast_call_path(expression.func)
+        return path in (_AST_PURE_CALLS - {"cute.arch.load"}) and all(
+            safe_expression(argument) for argument in expression.args
+        )
+
+    return safe_expression(statement.value)
+
+
+def _packed_block_effects(
+    body: list[ast.stmt], initially_defined: set[str] | None = None
+) -> tuple[set[str], set[str]]:
+    live: set[str] = set()
+    written = set() if initially_defined is None else set(initially_defined)
+    all_writes: set[str] = set()
+    for statement in body:
+        if isinstance(statement, ast.Assign):
+            reads = _names_read(statement.value)
+            for target in statement.targets:
+                if not isinstance(target, (ast.Name, ast.Tuple)):
+                    reads.update(_names_read(target))
+            writes = {
+                node.id
+                for target in statement.targets
+                for node in ast.walk(target)
+                if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store)
+            }
+        elif isinstance(statement, ast.For) and isinstance(statement.target, ast.Name):
+            nested_live, nested_writes = _packed_block_effects(
+                statement.body, {statement.target.id}
+            )
+            reads = _names_read(statement.iter) | nested_live
+            writes = {statement.target.id} | nested_writes
+        else:
+            reads = _names_read(statement)
+            writes = _names_written(statement)
+        live.update(reads - written)
+        written.update(writes)
+        all_writes.update(writes)
+    return live, all_writes
+
+
+def _store_name_counts(nodes: Iterable[ast.AST]) -> dict[str, int]:
+    result: dict[str, int] = {}
+    for root in nodes:
+        for node in ast.walk(root):
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+                result[node.id] = result.get(node.id, 0) + 1
+    return result
+
+
+def _load_name_counts(nodes: Iterable[ast.AST]) -> dict[str, int]:
+    result: dict[str, int] = {}
+    for root in nodes:
+        for node in ast.walk(root):
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+                result[node.id] = result.get(node.id, 0) + 1
+    return result
+
+
+def _canonical_ast_name(name: str, rename_groups: dict[str, str]) -> str:
+    seen: set[str] = set()
+    while name in rename_groups and name not in seen:
+        seen.add(name)
+        name = rename_groups[name]
+    return name
+
+
+def _canonical_counts(
+    counts: dict[str, int], rename_groups: dict[str, str]
+) -> dict[str, int]:
+    result: dict[str, int] = {}
+    for name, count in counts.items():
+        canonical = _canonical_ast_name(name, rename_groups)
+        result[canonical] = result.get(canonical, 0) + count
+    return result
+
+
+def _packed_inner_dependency_slice(
+    loop: ast.For,
+    lo_accumulator: str,
+    hi_accumulator: str,
+    rmem_names: set[str],
+) -> list[ast.stmt] | None:
+    if not loop.body or not _packed_accumulator_update(
+        loop.body[-1], lo_accumulator, hi_accumulator
+    ):
+        return None
+    definitions: dict[str, ast.expr] = {}
+    definition_indices: dict[str, int] = {}
+    for index, statement in enumerate(loop.body[:-1]):
+        name = _assigned_name(statement)
+        if (
+            name is None
+            or name in definitions
+            or name in {lo_accumulator, hi_accumulator}
+        ):
+            return None
+        assert isinstance(statement, ast.Assign)
+        definitions[name] = statement.value
+        definition_indices[name] = index
+
+    local_names = set(definitions)
+    seen = {cast("ast.Name", loop.target).id}
+    for statement in loop.body[:-1]:
+        name = _assigned_name(statement)
+        assert name is not None
+        if _names_read(statement) & (local_names - seen):
+            return None
+        seen.add(name)
+
+    needed = _dependency_closure(
+        _names_read(cast("ast.Assign", loop.body[-1]).value)
+        - {lo_accumulator, hi_accumulator},
+        definitions,
+    )
+    selected_indices = {
+        definition_indices[name] for name in needed if name in definition_indices
+    }
+    for index, statement in enumerate(loop.body[:-1]):
+        if index not in selected_indices and not _dead_packed_assignment_is_discardable(
+            statement
+        ):
+            return None
+    selected = [
+        statement
+        for index, statement in enumerate(loop.body[:-1])
+        if index in selected_indices
+    ]
+    selected.append(loop.body[-1])
+    if not all(
+        _packed_licm_statement_is_pure(statement, rmem_names) for statement in selected
+    ):
+        return None
+    return selected
+
+
+def _try_hoist_one_packed_reduction(
+    loop: ast.For,
+    *,
+    row_extent: int,
+    rmem_names: set[str],
+    rename_groups: dict[str, str],
+    scope_stores: dict[str, int],
+    scope_loads: dict[str, int],
+    live_after_scope: set[str],
+) -> tuple[list[ast.stmt], set[str], str] | None:
+    body = loop.body
+    if any(
+        isinstance(
+            node,
+            (
+                ast.Break,
+                ast.Continue,
+                ast.Delete,
+                ast.Raise,
+                ast.Return,
+                *_PACKED_LICM_UNSUPPORTED_CONTROL,
+            ),
+        )
+        or type(node).__name__ == "TryStar"
+        for node in ast.walk(loop)
+    ):
+        return None
+    for index in range(len(body) - 4):
+        lo_accumulator = _zero_fp32_assignment(body[index])
+        hi_accumulator = _zero_fp32_assignment(body[index + 1])
+        inner_match = _constexpr_loop(body[index + 2])
+        if (
+            lo_accumulator is None
+            or hi_accumulator is None
+            or lo_accumulator == hi_accumulator
+            or inner_match is None
+        ):
+            continue
+        inner_loop, _inner_lane, _inner_extent = inner_match
+        selected_inner = _packed_inner_dependency_slice(
+            inner_loop, lo_accumulator, hi_accumulator, rmem_names
+        )
+        if selected_inner is None:
+            continue
+        combined = _packed_pair_sum(body[index + 3], lo_accumulator, hi_accumulator)
+        reduction = _warp_reduction_assignment(body[index + 4])
+        if combined is None or reduction is None or reduction[1] != combined:
+            continue
+        result_name = reduction[0]
+        original_pattern = body[index : index + 5]
+        call_paths = [
+            _ast_call_path(node.func)
+            for statement in original_pattern
+            for node in ast.walk(statement)
+            if isinstance(node, ast.Call)
+        ]
+        if (
+            call_paths.count("cute.arch.fma_packed_f32x2") != 1
+            or call_paths.count("cute.arch.warp_reduction_sum") != 1
+        ):
+            continue
+        if not all(
+            _packed_licm_statement_is_pure(statement, rmem_names)
+            for statement in original_pattern
+        ):
+            continue
+
+        inner_copy = cast("ast.For", _clone_extended_ast(inner_loop))
+        inner_copy.body = [
+            cast("ast.stmt", _clone_extended_ast(statement))
+            for statement in selected_inner
+        ]
+        hoisted = [
+            body[index],
+            body[index + 1],
+            inner_copy,
+            body[index + 3],
+            body[index + 4],
+        ]
+        external_reads, _hoisted_writes = _packed_block_effects(hoisted)
+        external_reads -= _AST_GLOBAL_NAMES
+        lane_name = cast("ast.Name", loop.target).id
+        if lane_name in external_reads:
+            continue
+
+        original_stores = _store_name_counts(original_pattern)
+        canonical_original_stores = _canonical_counts(original_stores, rename_groups)
+        if len(canonical_original_stores) != len(original_stores):
+            continue
+        if any(
+            scope_stores.get(name) != count
+            for name, count in canonical_original_stores.items()
+        ):
+            continue
+
+        internal_names = set(original_stores) - {result_name}
+        original_loads = _canonical_counts(
+            _load_name_counts(original_pattern), rename_groups
+        )
+        if any(
+            scope_loads.get(_canonical_ast_name(name, rename_groups), 0)
+            != original_loads.get(_canonical_ast_name(name, rename_groups), 0)
+            for name in internal_names
+        ):
+            continue
+        canonical_live_after = {
+            _canonical_ast_name(name, rename_groups) for name in live_after_scope
+        }
+        if {
+            _canonical_ast_name(name, rename_groups) for name in internal_names
+        } & canonical_live_after:
+            continue
+
+        row_prefix = body[:index]
+        canonical_result = _canonical_ast_name(result_name, rename_groups)
+        if canonical_result in {
+            _canonical_ast_name(name, rename_groups)
+            for name in _names_read(ast.Module(body=row_prefix, type_ignores=[]))
+        }:
+            continue
+        row_suffix = body[index + 5 :]
+        if canonical_result not in {
+            _canonical_ast_name(name, rename_groups)
+            for name in _names_read(ast.Module(body=row_suffix, type_ignores=[]))
+        }:
+            continue
+
+        unselected = [*row_prefix, *row_suffix]
+        unselected_writes = {
+            _canonical_ast_name(name, rename_groups)
+            for name in _names_written(ast.Module(body=unselected, type_ignores=[]))
+        }
+        unselected_mutations = {
+            _canonical_ast_name(name, rename_groups)
+            for name in _mutation_roots(ast.Module(body=unselected, type_ignores=[]))
+        }
+        canonical_external_reads = {
+            _canonical_ast_name(name, rename_groups) for name in external_reads
+        }
+        if _canonical_ast_name(lane_name, rename_groups) in canonical_external_reads:
+            continue
+        if canonical_external_reads & (
+            set(canonical_original_stores) | unselected_writes | unselected_mutations
+        ):
+            continue
+        if not repeated_work_is_profitable(
+            hoisted,
+            repeat_extent=row_extent,
+            live_scalars=1,
+        ):
+            continue
+
+        loop.body = unselected
+        return hoisted, canonical_external_reads, canonical_result
+    return None
+
+
+def _earliest_packed_hoist_index(
+    prefix: list[ast.stmt],
+    *,
+    canonical_dependencies: set[str],
+    canonical_result: str,
+    rename_groups: dict[str, str],
+) -> int:
+    """Place a reduction after its last dependency or control-flow barrier."""
+    insertion_index = 0
+    for index, statement in enumerate(prefix):
+        written_or_mutated = {
+            _canonical_ast_name(name, rename_groups)
+            for name in _names_written(statement) | _mutation_roots(statement)
+        }
+        read = {
+            _canonical_ast_name(name, rename_groups) for name in _names_read(statement)
+        }
+        has_control_exit = any(
+            isinstance(
+                node,
+                (
+                    ast.Break,
+                    ast.Continue,
+                    ast.Delete,
+                    ast.Raise,
+                    ast.Return,
+                    *_PACKED_LICM_UNSUPPORTED_CONTROL,
+                ),
+            )
+            or type(node).__name__ == "TryStar"
+            for node in ast.walk(statement)
+        )
+        if (
+            canonical_dependencies & written_or_mutated
+            or canonical_result in read
+            or has_control_exit
+        ):
+            insertion_index = index + 1
+    return insertion_index
+
+
+def _hoist_packed_reduction_block(
+    body: list[ast.stmt],
+    *,
+    rmem_names: set[str],
+    rename_groups: dict[str, str],
+    live_after: set[str],
+) -> list[ast.stmt]:
+    result: list[ast.stmt] = []
+    scope_stores = _canonical_counts(_store_name_counts(body), rename_groups)
+    scope_loads = _canonical_counts(_load_name_counts(body), rename_groups)
+    for statement_index, statement in enumerate(body):
+        statement_live_after = live_after | _names_read(
+            ast.Module(body=body[statement_index + 1 :], type_ignores=[])
+        )
+        if isinstance(statement, (ast.For, ast.If, ast.While)):
+            child_fields = ("body", "orelse")
+        else:
+            child_fields = ()
+        for field in child_fields:
+            child = getattr(statement, field, None)
+            if isinstance(child, list) and all(
+                isinstance(item, ast.stmt) for item in child
+            ):
+                setattr(
+                    statement,
+                    field,
+                    _hoist_packed_reduction_block(
+                        child,
+                        rmem_names=rmem_names,
+                        rename_groups=rename_groups,
+                        live_after=_nested_live_out(
+                            statement,
+                            field,
+                            child,
+                            statement_live_after,
+                        ),
+                    ),
+                )
+        lane_name = getattr(statement, HELION_LANE_LOOP_VAR_ATTR, None)
+        outer_match = _static_repeated_loop(statement)
+        if (
+            not isinstance(statement, ast.For)
+            or not isinstance(lane_name, str)
+            or outer_match is None
+            or outer_match[1] != lane_name
+            or outer_match[2] <= 1
+        ):
+            result.append(statement)
+            continue
+        last_hoist_end = 0
+        while replacement := _try_hoist_one_packed_reduction(
+            statement,
+            row_extent=outer_match[2],
+            rmem_names=rmem_names,
+            rename_groups=rename_groups,
+            scope_stores=scope_stores,
+            scope_loads=scope_loads,
+            live_after_scope=live_after,
+        ):
+            hoisted, dependencies, reduction_result = replacement
+            insertion_index = max(
+                last_hoist_end,
+                _earliest_packed_hoist_index(
+                    result,
+                    canonical_dependencies=dependencies,
+                    canonical_result=reduction_result,
+                    rename_groups=rename_groups,
+                ),
+            )
+            result[insertion_index:insertion_index] = hoisted
+            last_hoist_end = insertion_index + len(hoisted)
+        result.append(statement)
+    return result
+
+
+def hoist_packed_factored_reductions(
+    body: list[ast.stmt],
+    *,
+    fast_math: bool,
+    rename_groups: dict[str, str] | None = None,
+) -> list[ast.stmt]:
+    """Hoist pure row-invariant reductions exposed by fp32 lane packing.
+
+    Packing replaces a scalar accumulator with a two-name tuple update, which
+    deliberately falls outside the earlier general LICM.  Recognize only the
+    generated zero/constexpr-loop/pair-sum/warp-reduction sequence and retain
+    the exact ordered dependency slice feeding its packed FMA.
+    """
+    if not fast_math:
+        return body
+    renames = rename_groups or {}
+    rmem_names, _fp32_rmem = _rmem_storage_names(body)
+    return [
+        ast.fix_missing_locations(statement)
+        for statement in _hoist_packed_reduction_block(
+            body,
+            rmem_names=rmem_names,
+            rename_groups=renames,
+            live_after=set(),
+        )
+    ]
+
+
+def _try_fuse_adjacent_reduction_loops(loop: ast.For, rmem_names: set[str]) -> bool:
+    """Fuse two independent neighboring constexpr reduction sweeps."""
+    body = loop.body
+    for first_index in range(len(body) - 4):
+        first_loop_match = _constexpr_loop(body[first_index])
+        if first_loop_match is None:
+            continue
+        first_loop, first_lane, first_extent = first_loop_match
+        first_reduction = _warp_reduction_assignment(body[first_index + 1])
+        if first_reduction is None:
+            continue
+        _first_result, first_acc, _first_call = first_reduction
+        init_candidates = [
+            index
+            for index in range(first_index)
+            if _zero_fp32_assignment(body[index]) == first_acc
+        ]
+        if not init_candidates:
+            continue
+        first_init_index = init_candidates[-1]
+        if any(
+            first_acc in _statement_effects(statement)[1]
+            for statement in body[first_init_index + 1 : first_index]
+        ):
+            continue
+        second_acc = _zero_fp32_assignment(body[first_index + 2])
+        second_loop_match = _constexpr_loop(body[first_index + 3])
+        if second_acc is None or second_loop_match is None:
+            continue
+        second_loop, second_lane, second_extent = second_loop_match
+        second_reduction = _reduction_result(body[first_index + 4], second_acc)
+        if (
+            first_extent != second_extent
+            or second_reduction is None
+            or not second_reduction[0].startswith("_helion_factored_base_sum")
+            or first_acc in _statement_effects(second_loop)[0]
+        ):
+            continue
+        if not all(
+            isinstance(statement, ast.Assign)
+            for statement in (*first_loop.body, *second_loop.body)
+        ):
+            continue
+        first_live = _live_before_block(first_loop.body, {first_lane, first_acc})
+        first_writes = _names_written(first_loop)
+        second_live = _live_before_block(second_loop.body, {second_lane, second_acc})
+        second_writes = _names_written(second_loop)
+        if (first_live & first_writes) - {first_acc} or (
+            second_live & second_writes
+        ) - {second_acc}:
+            continue
+        if first_writes & second_live or second_writes & first_live:
+            continue
+        first_reduction_reads, first_reduction_writes = _statement_effects(
+            body[first_index + 1]
+        )
+        if (
+            second_writes & first_reduction_reads
+            or first_reduction_writes & second_live
+            or first_reduction_writes & second_writes
+            or second_acc
+            in (
+                first_live
+                | first_writes
+                | first_reduction_reads
+                | first_reduction_writes
+            )
+        ):
+            continue
+        if (
+            not _safe_lane_local_stores(first_loop, first_lane, rmem_names)
+            or _mutation_roots(second_loop)
+            or _has_effectful_call(first_loop.body)
+            or _has_effectful_call(second_loop.body)
+        ):
+            continue
+
+        second_loop_copy = cast("ast.For", _clone_extended_ast(second_loop))
+        if second_lane != first_lane:
+            rename = _RenameAstName(second_lane, first_lane)
+            for statement in second_loop_copy.body:
+                rename.visit(statement)
+        stores = _subscript_accesses(first_loop.body, ast.Store)
+        loads = _subscript_accesses(second_loop_copy.body, ast.Load)
+        if any(
+            root in loads and not loads[root] <= slices
+            for root, slices in stores.items()
+        ):
+            continue
+
+        first_loop.body = _deduplicate_fused_body(
+            body[:first_index], first_loop.body, second_loop_copy.body, rmem_names
+        )
+        loop.body = [
+            *body[: first_init_index + 1],
+            *body[first_init_index + 1 : first_index],
+            body[first_index + 2],
+            first_loop,
+            body[first_index + 1],
+            body[first_index + 4],
+            *body[first_index + 5 :],
+        ]
+        return True
+    return False
+
+
+def _hoist_one_invariant_reduction(
+    loop: ast.For,
+    occupied: set[str],
+    rmem_names: set[str],
+    live_after: set[str],
+) -> list[ast.stmt] | None:
+    if not isinstance(loop.target, ast.Name):
+        return None
+    body = loop.body
+    outer_lane = loop.target.id
+    outer_writes = _names_written(loop)
+    outer_mutations = _mutation_roots(loop)
+    for index in range(len(body) - 2):
+        accumulator = _zero_fp32_assignment(body[index])
+        inner_match = _constexpr_loop(body[index + 1])
+        if accumulator is None or inner_match is None:
+            continue
+        inner_loop, inner_lane, extent = inner_match
+        reduced = _reduction_result(body[index + 2], accumulator)
+        if reduced is None or not inner_loop.body:
+            continue
+        result_name, _reduction_call = reduced
+        if not result_name.startswith("_helion_factored_dot_sum"):
+            continue
+        term = _accumulated_term(inner_loop.body[-1], accumulator)
+        if term is None:
+            continue
+        definitions: dict[str, ast.expr] = {}
+        valid = True
+        for statement in inner_loop.body[:-1]:
+            name = _assigned_name(statement)
+            if name is None:
+                valid = False
+                break
+            assert isinstance(statement, ast.Assign)
+            if name in definitions or name == accumulator:
+                valid = False
+                break
+            definitions[name] = statement.value
+        if not valid or _has_effectful_call(inner_loop.body[:-1]):
+            continue
+        seen: set[str] = set()
+        for statement in inner_loop.body[:-1]:
+            name = _assigned_name(statement)
+            assert name is not None
+            if _names_read(statement) & (set(definitions) - seen):
+                valid = False
+                break
+            seen.add(name)
+        if not valid:
+            continue
+        term_dependencies = _dependency_closure(_names_read(term), definitions)
+        if set(definitions) - term_dependencies:
+            continue
+        new_lane = _fresh_ast_name(occupied, "_factored_lane")
+        try:
+            normalized = cast(
+                "ast.expr",
+                _InlineInnerExpression(definitions, inner_lane, new_lane).visit(
+                    expr_from_string(ast.unparse(term))
+                ),
+            )
+        except ValueError:
+            continue
+        candidate_writes = (
+            _names_written(body[index])
+            | _names_written(body[index + 1])
+            | _names_written(body[index + 2])
+        )
+        if not _safe_invariant_expression(
+            normalized,
+            outer_lane=outer_lane,
+            outer_writes=outer_writes - candidate_writes,
+            outer_mutations=outer_mutations,
+            rmem_names=rmem_names,
+        ):
+            continue
+        deleted_names = _names_written(inner_loop) | {inner_lane, accumulator}
+        outside_slice = [*body[:index], *body[index + 3 :]]
+        if deleted_names & (
+            live_after
+            | {name for statement in outside_slice for name in _names_read(statement)}
+        ):
+            continue
+        new_accumulator = _fresh_ast_name(occupied, "_factored_acc")
+        init = create(
+            ast.Assign,
+            targets=[create(ast.Name, id=new_accumulator, ctx=ast.Store())],
+            value=expr_from_string("cutlass.Float32(0)"),
+        )
+        accumulation = create(
+            ast.Assign,
+            targets=[create(ast.Name, id=new_accumulator, ctx=ast.Store())],
+            value=create(
+                ast.BinOp,
+                left=create(ast.Name, id=new_accumulator, ctx=ast.Load()),
+                op=create(ast.Add),
+                right=normalized,
+            ),
+        )
+        precompute_loop = create(
+            ast.For,
+            target=create(ast.Name, id=new_lane, ctx=ast.Store()),
+            iter=expr_from_string(f"cutlass.range_constexpr({extent})"),
+            body=[accumulation],
+            orelse=[],
+            type_comment=None,
+        )
+        result_assignment = create(
+            ast.Assign,
+            targets=[create(ast.Name, id=result_name, ctx=ast.Store())],
+            value=expr_from_string(
+                ast.unparse(cast("ast.Assign", body[index + 2]).value)
+            ),
+        )
+        replacement_call = next(
+            child
+            for child in ast.walk(result_assignment.value)
+            if isinstance(child, ast.Call)
+            and _ast_call_path(child.func) == "cute.arch.warp_reduction_sum"
+        )
+        replacement_call.args[0] = create(ast.Name, id=new_accumulator, ctx=ast.Load())
+        del body[index : index + 3]
+        return [init, precompute_loop, result_assignment, loop]
+    return None
+
+
+def _hoist_factored_block(
+    body: list[ast.stmt],
+    occupied: set[str],
+    rmem_names: set[str],
+    live_out: set[str],
+) -> list[ast.stmt]:
+    result: list[ast.stmt] = []
+    for statement_index, statement in enumerate(body):
+        statement_live_out = _live_before_block(
+            body[statement_index + 1 :], live_out=live_out
+        )
+        for field in ("body", "orelse", "finalbody"):
+            child = getattr(statement, field, None)
+            if isinstance(child, list) and all(
+                isinstance(item, ast.stmt) for item in child
+            ):
+                setattr(
+                    statement,
+                    field,
+                    _hoist_factored_block(
+                        child,
+                        occupied,
+                        rmem_names,
+                        _nested_live_out(
+                            statement,
+                            field,
+                            child,
+                            statement_live_out,
+                        ),
+                    ),
+                )
+        if isinstance(statement, ast.For) and isinstance(
+            getattr(statement, HELION_LANE_LOOP_VAR_ATTR, None), str
+        ):
+            replacement = _hoist_one_invariant_reduction(
+                statement,
+                occupied,
+                rmem_names,
+                statement_live_out,
+            )
+            if replacement is not None:
+                remaining_loop = cast("ast.For", replacement[-1])
+                _try_fuse_adjacent_reduction_loops(remaining_loop, rmem_names)
+                result.extend(replacement)
+                continue
+            _try_fuse_adjacent_reduction_loops(statement, rmem_names)
+        result.append(statement)
+    return result
+
+
+def hoist_factored_reductions(
+    body: list[ast.stmt],
+    *,
+    fast_math: bool,
+) -> list[ast.stmt]:
+    """Hoist standalone reductions exposed by :func:`factor_affine_reductions`."""
+    if not fast_math:
+        return body
+    occupied = {
+        node.id
+        for stmt in body
+        for node in ast.walk(stmt)
+        if isinstance(node, ast.Name)
+    }
+    rmem_names, _fp32_rmem = _rmem_storage_names(body)
+    return [
+        ast.fix_missing_locations(stmt)
+        for stmt in _hoist_factored_block(body, occupied, rmem_names, set())
+    ]

--- a/helion/_compiler/cute/fuse_two_pass_loads.py
+++ b/helion/_compiler/cute/fuse_two_pass_loads.py
@@ -45,16 +45,39 @@ import ast
 import re
 
 from ..ast_extension import statement_from_string
+from ..ast_read_writes import ReadWrites
+
+_PERSISTENT_BRANCH_VEC_LOAD = "_helion_persistent_branch_vec_load"
+_PERSISTENT_BRANCH_VEC_STORE = "_helion_persistent_branch_vec_store"
+
+
+def _unwrap_persistent_branch_vec_load(node: ast.AST) -> ast.AST:
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == _PERSISTENT_BRANCH_VEC_LOAD
+        and len(node.args) == 6
+    ):
+        return node.args[5]
+    return node
 
 
 def _range_bounds(node: ast.AST) -> tuple[ast.expr, ast.expr, ast.expr] | None:
-    """Extract ``(start, end, step)`` from a Call to ``range(...)``.
+    """Extract ``(start, end, step)`` from a supported range call.
 
-    Returns None if the iter is not a 1-, 2-, or 3-arg ``range`` call.
+    Synthetic lanes can use either Python ``range`` or CuTe's compile-time
+    ``cutlass.range_constexpr``.
     """
     if not isinstance(node, ast.Call):
         return None
-    if not (isinstance(node.func, ast.Name) and node.func.id == "range"):
+    is_range = isinstance(node.func, ast.Name) and node.func.id == "range"
+    is_constexpr_range = (
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == "range_constexpr"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "cutlass"
+    )
+    if not (is_range or is_constexpr_range):
         return None
     args = node.args
     if not args:
@@ -149,6 +172,7 @@ def _load_kind(
 
     Returns None when ``node`` doesn't look like a gmem load we can fuse.
     """
+    node = _unwrap_persistent_branch_vec_load(node)
     if _looks_like_tracked_load(node) is not None:
         return "masked"
     # A cache-hinted SCALAR load also routes through ``cute.arch.load``
@@ -293,6 +317,7 @@ def _scalar_load_ptr_text(node: ast.AST) -> str | None:
 def _normalized_load_text(node: ast.AST) -> str:
     """Unparse with cache hints stripped and the two scalar load forms
     collapsed onto one spelling (see ``_scalar_load_ptr_text``)."""
+    node = _unwrap_persistent_branch_vec_load(node)
     ptr = _scalar_load_ptr_text(node)
     if ptr is not None:
         return f"__scalar_load__({ptr})"
@@ -338,6 +363,180 @@ def _unmasked_load_tensor_dtype(
     return None
 
 
+def _is_store_call(node: ast.Call) -> bool:
+    """Whether this is a generated memory write."""
+    func = node.func
+    is_store = (
+        isinstance(func, ast.Attribute) and func.attr in ("store", "__setitem__")
+    ) or (
+        isinstance(func, ast.Name)
+        and (
+            func.id.startswith("_cute_store_")
+            or func.id == _PERSISTENT_BRANCH_VEC_STORE
+        )
+    )
+    is_atomic = (
+        isinstance(func, ast.Attribute) and func.attr.startswith("atomic_")
+    ) or (isinstance(func, ast.Name) and func.id.startswith("_cute_atomic_"))
+    return is_store or is_atomic
+
+
+def _contains_arch_attribute(node: ast.AST) -> bool:
+    return any(
+        isinstance(child, ast.Attribute) and child.attr == "arch"
+        for child in ast.walk(node)
+    )
+
+
+def _tensor_arg_roots(
+    node: ast.AST,
+    tensor_names: set[str],
+) -> frozenset[str] | None:
+    """Return kernel tensor arguments whose storage an expression addresses.
+
+    ``None`` means the address cannot be resolved to named tensor arguments and
+    must conservatively alias every tracked load.
+    """
+    roots: set[str] = set()
+    unresolved_iterator = False
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Attribute) or child.attr != "iterator":
+            continue
+        if isinstance(child.value, ast.Name) and child.value.id in tensor_names:
+            roots.add(child.value.id)
+        else:
+            unresolved_iterator = True
+    if unresolved_iterator:
+        return None
+    if isinstance(node, ast.Name) and node.id in tensor_names:
+        roots.add(node.id)
+    return frozenset(roots) if roots else None
+
+
+def _store_tensor_roots(
+    node: ast.Call,
+    tensor_names: set[str],
+) -> frozenset[str] | None:
+    """Resolve the destination tensor arguments of a generated write."""
+    func = node.func
+    pointer: ast.AST | None = None
+    if (
+        isinstance(func, ast.Name)
+        and func.id == _PERSISTENT_BRANCH_VEC_STORE
+        and len(node.args) == 6
+    ):
+        pointer = node.args[3]
+    elif isinstance(func, ast.Name) and func.id.startswith(
+        ("_cute_store_", "_cute_atomic_")
+    ):
+        pointer = node.args[0] if node.args else None
+    elif isinstance(func, ast.Attribute):
+        if func.attr.startswith("atomic_"):
+            pointer = node.args[0] if node.args else None
+        elif func.attr == "store":
+            # ``cute.arch.store(ptr, value, ...)`` is a free function, while
+            # ``ptr.store(value)`` carries its destination on ``func.value``.
+            pointer = (
+                node.args[0]
+                if node.args and _contains_arch_attribute(func.value)
+                else func.value
+            )
+        elif func.attr == "__setitem__":
+            pointer = func.value
+    return _tensor_arg_roots(pointer, tensor_names) if pointer is not None else None
+
+
+def _tensor_roots_may_alias(
+    left: frozenset[str] | None,
+    right: frozenset[str] | None,
+    proven_disjoint_tensor_pairs: set[frozenset[str]],
+) -> bool:
+    if left is None or right is None:
+        return True
+    return any(
+        left_name == right_name
+        or frozenset((left_name, right_name)) not in proven_disjoint_tensor_pairs
+        for left_name in left
+        for right_name in right
+    )
+
+
+class _LexicalMemoryOrder(ast.NodeVisitor):
+    """Track assignments and stores in generated source execution order."""
+
+    def __init__(
+        self,
+        body: list[ast.stmt],
+        tensor_names: set[str],
+        proven_disjoint_tensor_pairs: set[frozenset[str]],
+    ) -> None:
+        super().__init__()
+        self._position = 0
+        self._tensor_names = tensor_names
+        self._proven_disjoint_tensor_pairs = proven_disjoint_tensor_pairs
+        self.assignment_positions: dict[int, int] = {}
+        self.stores: list[tuple[int, frozenset[str] | None]] = []
+        for stmt in body:
+            self.visit(stmt)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self.assignment_positions[id(node)] = self._position
+        self._position += 1
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if _is_store_call(node):
+            self.stores.append(
+                (
+                    self._position,
+                    _store_tensor_roots(node, self._tensor_names),
+                )
+            )
+            self._position += 1
+        self.generic_visit(node)
+
+    def _may_alias(
+        self,
+        store_roots: frozenset[str] | None,
+        load_roots: frozenset[str] | None,
+    ) -> bool:
+        return _tensor_roots_may_alias(
+            store_roots,
+            load_roots,
+            self._proven_disjoint_tensor_pairs,
+        )
+
+    def has_aliasing_store_between(
+        self,
+        producer: ast.Assign,
+        consumer: ast.Assign,
+        load_roots: frozenset[str] | None,
+    ) -> bool:
+        producer_pos = self.assignment_positions.get(id(producer))
+        consumer_pos = self.assignment_positions.get(id(consumer))
+        if producer_pos is None or consumer_pos is None or consumer_pos <= producer_pos:
+            return True
+        return any(
+            producer_pos < store_pos < consumer_pos
+            and self._may_alias(store_roots, load_roots)
+            for store_pos, store_roots in self.stores
+        )
+
+    def has_aliasing_store_in(
+        self,
+        node: ast.AST,
+        load_roots: frozenset[str] | None,
+    ) -> bool:
+        return any(
+            isinstance(child, ast.Call)
+            and _is_store_call(child)
+            and self._may_alias(
+                _store_tensor_roots(child, self._tensor_names), load_roots
+            )
+            for child in ast.walk(node)
+        )
+
+
 def _rewrite_vec_extract(
     node: ast.AST,
     hoist_var: str,
@@ -380,7 +579,11 @@ def _rewrite_vec_extract(
     ast.fix_missing_locations(node)
 
 
-def _canonical_load_text(node: ast.AST, lane_var_alias: dict[str, str]) -> str:
+def _canonical_load_text(
+    node: ast.AST,
+    lane_var_alias: dict[str, str],
+    definitions: dict[str, ast.expr] | None = None,
+) -> str:
     """Stringify a load node with lane-base / hoist variables canonicalised.
 
     The strategy creates fresh variable names for each sweep
@@ -390,6 +593,30 @@ def _canonical_load_text(node: ast.AST, lane_var_alias: dict[str, str]) -> str:
     textual form modulo the rename — otherwise identical loads compare
     unequal and fusion bails.
     """
+    if definitions:
+
+        class _InlineDefinitions(ast.NodeTransformer):
+            def __init__(self) -> None:
+                super().__init__()
+                self.expanding: set[str] = set()
+
+            def visit_Name(self, node: ast.Name) -> ast.AST:
+                if not isinstance(node.ctx, ast.Load):
+                    return node
+                value = definitions.get(node.id)
+                if value is None or node.id in self.expanding:
+                    return node
+                self.expanding.add(node.id)
+                replacement = self.visit(
+                    ast.parse(ast.unparse(value), mode="eval").body
+                )
+                self.expanding.remove(node.id)
+                return ast.copy_location(replacement, node)
+
+        node = _InlineDefinitions().visit(
+            ast.parse(ast.unparse(node), mode="eval").body
+        )
+
     # Per-load-site eviction hints differ between sweeps and must not
     # defeat matching (see _node_text).
     text = _normalized_load_text(node)
@@ -409,14 +636,21 @@ class _CuteFuseTwoPassLoads:
         thread_block_dims: tuple[int, int, int] = (1, 1, 1),
         tensor_dtypes: dict[str, str] | None = None,
         reload_modes: dict[int, str] | None = None,
+        proven_disjoint_tensor_pairs: set[frozenset[str]] | None = None,
+        proven_tensor_stride_values: dict[tuple[str, int], int] | None = None,
     ) -> None:
         super().__init__()
         self._counter = 0
         self._constexpr_values = constexpr_values or {}
-        # Autotuner-selected reload mode per rolled-reduction block id
-        # ("auto" / "register" / "gmem").  Sweep loops are matched back to
-        # their block id via the ``roffset_<id>`` loop offset variable.
+        # Autotuner-selected reload mode per rolled or persistent reduction
+        # block id ("auto" / "register" / "gmem").  Sweep loops are matched
+        # back to their block id through their generated lane/offset variable.
         self._reload_modes = reload_modes or {}
+        self._proven_disjoint_tensor_pairs = proven_disjoint_tensor_pairs or set()
+        self._proven_tensor_stride_values = proven_tensor_stride_values or {}
+        # Recursive matches append declarations here so allocations can be
+        # emitted once at kernel scope, never inside a dynamic branch.
+        self._root_declarations: list[ast.stmt] = []
         # Kernel tensor-arg name -> backend dtype string (e.g.
         # "cutlass.Float32"); resolves the cache dtype for unmasked
         # scalar loads.
@@ -433,10 +667,147 @@ class _CuteFuseTwoPassLoads:
         self._thread_block_dims = dims
         self._thread_count = dims[0] * dims[1] * dims[2]
 
+    def _canonical_aliases(self, local: dict[str, str]) -> dict[str, str]:
+        """Resolve aliases proved by explicit copy assignments."""
+        aliases = dict(local)
+
+        def resolve(name: str) -> str:
+            seen: set[str] = set()
+            while name in aliases and name not in seen:
+                seen.add(name)
+                replacement = aliases[name]
+                if replacement == name:
+                    break
+                name = replacement
+            return name
+
+        return {name: resolve(name) for name in aliases}
+
+    @staticmethod
+    def _pure_definitions_before(
+        statements: list[ast.stmt],
+        stop: int,
+        inherited: dict[str, ast.expr] | None = None,
+    ) -> dict[str, ast.expr]:
+        """Collect dominating, side-effect-free scalar definitions."""
+        definitions = dict(inherited or {})
+        for stmt in statements[:stop]:
+            for name in ReadWrites.from_ast(stmt).writes:
+                definitions.pop(name, None)
+            if (
+                isinstance(stmt, ast.Assign)
+                and len(stmt.targets) == 1
+                and isinstance(stmt.targets[0], ast.Name)
+            ):
+                target = stmt.targets[0].id
+                has_memory_access = any(
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr in ("load", "store")
+                    for node in ast.walk(stmt.value)
+                )
+                if not has_memory_access:
+                    definitions[target] = stmt.value
+        return definitions
+
+    @staticmethod
+    def _reduction_block_id(loop: ast.For) -> int | None:
+        if not isinstance(loop.target, ast.Name):
+            return None
+        match = re.match(
+            r"(?:roffset|synthetic_lane|reduction_lane)_(\d+)",
+            loop.target.id,
+        )
+        return int(match.group(1)) if match is not None else None
+
     def _new_cache_name(self) -> str:
         name = f"_fuse_cache_{self._counter}"
         self._counter += 1
         return name
+
+    def _consumer_store_preserves_snapshot(
+        self,
+        loop: ast.For,
+        container: list[ast.stmt],
+        load_index: int,
+        load_stmt: ast.Assign,
+        load_roots: frozenset[str] | None,
+    ) -> bool:
+        """Whether a consume sweep may read a pre-populated register cache.
+
+        An in-place consume loop is not automatically a cache barrier. Once
+        the producer sweep has populated every cache slot, a later exact
+        per-lane read/modify/write may safely read that snapshot when each
+        iteration's store is proved unable to affect another iteration's
+        logical load. This is the same injectivity proof used when splitting
+        persistent reductions in the first place.
+        """
+        from .persistent_branch_vec import _definition_snapshots
+        from .persistent_branch_vec import _lane_accesses_are_iteration_independent
+        from .persistent_branch_vec import _memory_load_calls
+
+        if (
+            load_roots is None
+            or not isinstance(loop.target, ast.Name)
+            or container is not loop.body
+        ):
+            return False
+        bounds = _range_bounds(loop.iter)
+        if bounds is None:
+            return False
+        lane_extent = _trip_count_for(*bounds, self._constexpr_values)
+        if lane_extent is None:
+            return False
+        load_calls = _memory_load_calls(load_stmt.value)
+        if len(load_calls) != 1:
+            return False
+        load_call = load_calls[0]
+
+        snapshots = _definition_snapshots(container)
+        definitely_written: set[str] = set()
+        live_in: set[str] = set()
+        may_writes: set[str] = set()
+        for statement in container:
+            effects = ReadWrites.from_ast(statement)
+            live_in.update(set(effects.reads) - definitely_written - {loop.target.id})
+            may_writes.update(effects.writes)
+            if isinstance(statement, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+                definitely_written.update(effects.writes)
+        loop_carried_names = live_in & may_writes
+
+        saw_aliasing_store = False
+        tensor_names = set(self._tensor_dtypes)
+        for statement_index, statement in enumerate(container):
+            for store_call in (
+                child
+                for child in ast.walk(statement)
+                if isinstance(child, ast.Call) and _is_store_call(child)
+            ):
+                store_roots = _store_tensor_roots(store_call, tensor_names)
+                if not _tensor_roots_may_alias(
+                    store_roots,
+                    load_roots,
+                    self._proven_disjoint_tensor_pairs,
+                ):
+                    continue
+                saw_aliasing_store = True
+                if statement_index <= load_index:
+                    return False
+                unstable_names = set(loop_carried_names)
+                for crossed in container[load_index + 1 : statement_index + 1]:
+                    unstable_names.update(ReadWrites.from_ast(crossed).writes)
+                if not _lane_accesses_are_iteration_independent(
+                    load_call,
+                    store_call,
+                    lane_var=loop.target.id,
+                    lane_extent=lane_extent,
+                    load_definitions=snapshots[load_index],
+                    store_definitions=snapshots[statement_index],
+                    proven_tensor_stride_values=self._proven_tensor_stride_values,
+                    loop_carried_names=unstable_names,
+                ):
+                    return False
+        return saw_aliasing_store
 
     def _resolve_load_container(
         self,
@@ -581,6 +952,7 @@ class _CuteFuseTwoPassLoads:
         CONST`` branch.  For unmasked / vec loads, derive from the pointer
         or vec-type expression.
         """
+        node = _unwrap_persistent_branch_vec_load(node)
         if kind == "masked":
             assert isinstance(node, ast.IfExp)
             return _dtype_from_default(node.orelse)
@@ -615,37 +987,39 @@ class _CuteFuseTwoPassLoads:
             return None
         return None
 
-    def _try_fuse(self, body: list[ast.stmt]) -> list[ast.stmt] | None:
+    def _try_fuse(
+        self, body: list[ast.stmt], *, allow_smem: bool = True
+    ) -> list[ast.stmt] | None:
         # Find top-level ``for offset in range(...)`` loops with matching
         # target and range signature -- they don't need to be adjacent in
         # the body. Two-pass reduction kernels typically have
         # post-reduction statements between the two loops.
-        loop_indices: list[int] = []
-        for i, stmt in enumerate(body):
-            if isinstance(stmt, ast.For) and not stmt.orelse:
-                loop_indices.append(i)
-        if len(loop_indices) < 2:
+        loops = [stmt for stmt in body if isinstance(stmt, ast.For) and not stmt.orelse]
+        if len(loops) < 2:
             return None
 
         # Group loops by (target, range) signature -- preserve order.
-        groups_by_key: dict[tuple[str, str], list[int]] = {}
-        for li in loop_indices:
-            stmt = body[li]
-            assert isinstance(stmt, ast.For)
-            if not isinstance(stmt.target, ast.Name):
+        groups_by_key: dict[tuple[str, str], list[ast.For]] = {}
+        for loop in loops:
+            if not isinstance(loop.target, ast.Name):
                 continue
-            key = (stmt.target.id, _node_text(stmt.iter))
-            groups_by_key.setdefault(key, []).append(li)
-        groups: list[list[int]] = [g for g in groups_by_key.values() if len(g) >= 2]
+            key = (loop.target.id, _node_text(loop.iter))
+            groups_by_key.setdefault(key, []).append(loop)
+        # Also process every later suffix.  A value may first be loaded in
+        # sweep two and reused in sweep three; after the full group caches
+        # sweep-one loads, its [1:] suffix handles that later-origin value.
+        groups = [
+            group[start:]
+            for group in groups_by_key.values()
+            for start in range(len(group) - 1)
+        ]
 
         any_fused = False
         new_body = list(body)
         for group in groups:
             if len(group) < 2:
                 continue
-            first_idx = group[0]
-            first_loop = new_body[first_idx]
-            assert isinstance(first_loop, ast.For)
+            first_loop = group[0]
             range_args = _range_bounds(first_loop.iter)
             if range_args is None:
                 continue
@@ -668,21 +1042,45 @@ class _CuteFuseTwoPassLoads:
                 continue
             first_container, first_cache_index, first_cache_size = first_ctx
             cache_size = first_cache_size
+            first_loop_index = new_body.index(first_loop)
+            first_scope_definitions = self._pure_definitions_before(
+                new_body, first_loop_index
+            )
 
             # Gather ALL subsequent sweeps in the group that share the
             # first sweep's container shape.  Multi-pass kernels (e.g.
             # 3-pass softmax: max sweep, sum sweep, normalize sweep)
             # re-load the same values in every later sweep, so each one
             # should read the cache instead.
-            sweeps: list[tuple[int, list[ast.stmt], str, dict[str, str]]] = []
-            for body_idx in group[1:]:
-                loop_k = new_body[body_idx]
-                assert isinstance(loop_k, ast.For)
+            sweeps: list[
+                tuple[
+                    int,
+                    ast.For,
+                    list[ast.stmt],
+                    str,
+                    dict[str, str],
+                    dict[str, ast.expr],
+                ]
+            ] = []
+            for loop_k in group[1:]:
                 ctx_k = self._resolve_load_container(loop_k, start, step, trip)
                 if ctx_k is None or ctx_k[2] != cache_size:
                     continue
-                alias_k = self._build_second_alias(first_loop, loop_k)
-                sweeps.append((body_idx, ctx_k[0], ctx_k[1], alias_k))
+                body_idx = new_body.index(loop_k)
+                alias_k = self._canonical_aliases(
+                    self._build_second_alias(first_loop, loop_k)
+                )
+                scope_definitions = self._pure_definitions_before(new_body, body_idx)
+                sweeps.append(
+                    (
+                        body_idx,
+                        loop_k,
+                        ctx_k[0],
+                        ctx_k[1],
+                        alias_k,
+                        scope_definitions,
+                    )
+                )
             if not sweeps:
                 continue
             # Default policy: register-backed cache only when
@@ -716,20 +1114,15 @@ class _CuteFuseTwoPassLoads:
             # raw slot count understates the register cost by V.
             _vec_m = re.search(r"VectorType\.get\(\[(\d+)\]", ast.unparse(first_loop))
             cache_elems = cache_size * (int(_vec_m.group(1)) if _vec_m else 1)
-            # Rolled-reduction sweeps use ``roffset_<block_id>`` offset
-            # vars; tile-loop sweeps use ``tile_offset_<n>``.  Only the
-            # former have a reload-mode knob.
-            _bid_m = (
-                re.match(r"roffset_(\d+)", first_loop.target.id)
-                if isinstance(first_loop.target, ast.Name)
-                else None
-            )
-            is_reduction_sweep = _bid_m is not None
+            # Both rolled and persistent reduction sweeps have a reload-mode
+            # knob; tile loops retain the automatic policy.
+            block_id = self._reduction_block_id(first_loop)
+            is_reduction_sweep = block_id is not None
             _fuser_mode = os.environ.get("HELION_FUSER_MODE")
             if _fuser_mode is None:
                 _fuser_mode = (
-                    self._reload_modes.get(int(_bid_m.group(1)), "auto")
-                    if _bid_m is not None
+                    self._reload_modes.get(block_id, "auto")
+                    if block_id is not None
                     else "auto"
                 )
                 # The config knob spells "never fuse" as ``"gmem"``
@@ -743,6 +1136,8 @@ class _CuteFuseTwoPassLoads:
                 if cache_elems > 1024:
                     continue
             elif _fuser_mode == "smem":
+                if not allow_smem:
+                    continue
                 use_smem = True
                 if cache_elems > 1024:
                     continue
@@ -764,6 +1159,9 @@ class _CuteFuseTwoPassLoads:
             # vec element type.  Scalar (masked / unmasked) loads cache as
             # the existing fast path.
             tracked: dict[str, tuple[int, str, str, str | None, int | None]] = {}
+            tracked_statements: dict[str, ast.Assign] = {}
+            tracked_tensor_roots: dict[str, frozenset[str] | None] = {}
+            first_keys: dict[int, str] = {}
             for j, s in enumerate(first_container):
                 if (
                     isinstance(s, ast.Assign)
@@ -787,20 +1185,59 @@ class _CuteFuseTwoPassLoads:
                     v_width = _vec_width(s.value) if kind == "vec" else 1
                     if kind == "vec" and v_width is None:
                         continue
-                    tracked[_node_text(s.value)] = (
+                    first_definitions = self._pure_definitions_before(
+                        first_container, j, first_scope_definitions
+                    )
+                    key = _canonical_load_text(s.value, {}, first_definitions)
+                    tracked[key] = (
                         j,
                         s.targets[0].id,
                         kind,
                         dtype,
                         v_width,
                     )
+                    tracked_statements[key] = s
+                    first_keys[id(s)] = key
+                    tracked_tensor_roots[key] = _tensor_arg_roots(
+                        s.value, set(self._tensor_dtypes)
+                    )
             if not tracked:
                 continue
 
             # Match loads in each subsequent sweep's container.
+            # ``auto`` is a profitability policy, not an instruction to keep
+            # reduction values live as far as correctness permits.  A disjoint
+            # write is still a useful phase boundary: crossing it can extend
+            # several per-lane fragments through unrelated reductions and put
+            # a high-thread-count CTA on a much longer dependency chain.  Let
+            # explicit register/smem choices opt into that tradeoff.  Preserve
+            # the historical tile-loop policy, whose much shorter live ranges
+            # are not selected through this reduction-reload knob.
+            disjoint_pairs = (
+                self._proven_disjoint_tensor_pairs
+                if not is_reduction_sweep or _fuser_mode in ("register", "smem")
+                else set()
+            )
+            memory_order = _LexicalMemoryOrder(
+                new_body,
+                set(self._tensor_dtypes),
+                disjoint_pairs,
+            )
+            proven_memory_order = _LexicalMemoryOrder(
+                new_body,
+                set(self._tensor_dtypes),
+                self._proven_disjoint_tensor_pairs,
+            )
             per_sweep_matches: list[list[tuple[int, str, str]]] = []
             matched_keys: set[str] = set()
-            for _body_idx, container_k, _cache_index_k, alias_k in sweeps:
+            for (
+                _body_idx,
+                loop_k,
+                container_k,
+                _cache_index_k,
+                alias_k,
+                scope_definitions,
+            ) in sweeps:
                 matches: list[tuple[int, str, str]] = []
                 for j, s in enumerate(container_k):
                     if (
@@ -813,8 +1250,59 @@ class _CuteFuseTwoPassLoads:
                             continue
                         # Canonicalise this sweep's load text against the
                         # first sweep's variable names before keying.
-                        key = _canonical_load_text(s.value, alias_k)
-                        if key in tracked:
+                        definitions_at_load = self._pure_definitions_before(
+                            container_k, j, scope_definitions
+                        )
+                        key = _canonical_load_text(
+                            s.value, alias_k, definitions_at_load
+                        )
+                        producer = tracked_statements.get(key)
+                        load_roots = tracked_tensor_roots.get(key)
+                        consumer_has_aliasing_store = (
+                            memory_order.has_aliasing_store_in(loop_k, load_roots)
+                        )
+                        snapshot_safe = (
+                            _fuser_mode == "register"
+                            and consumer_has_aliasing_store
+                            and self._consumer_store_preserves_snapshot(
+                                loop_k,
+                                container_k,
+                                j,
+                                s,
+                                load_roots,
+                            )
+                        )
+                        crosses_phase_boundary = (
+                            memory_order.has_aliasing_store_between(
+                                producer,
+                                s,
+                                load_roots,
+                            )
+                            if producer is not None
+                            else True
+                        )
+                        # An explicit register policy may retain an exact
+                        # in-place snapshot through the short writeback
+                        # epilogue. Keep ``auto`` conservative: this tradeoff
+                        # saves bandwidth but extends the fragment live range,
+                        # which can regress small launches through pressure.
+                        if snapshot_safe and crosses_phase_boundary:
+                            crosses_phase_boundary = (
+                                producer is None
+                                or proven_memory_order.has_aliasing_store_between(
+                                    producer,
+                                    s,
+                                    load_roots,
+                                )
+                            )
+                        if (
+                            producer is not None
+                            and not memory_order.has_aliasing_store_in(
+                                first_loop, load_roots
+                            )
+                            and (not consumer_has_aliasing_store or snapshot_safe)
+                            and not crosses_phase_boundary
+                        ):
                             matches.append((j, s.targets[0].id, key))
                             matched_keys.add(key)
                 per_sweep_matches.append(matches)
@@ -924,7 +1412,9 @@ class _CuteFuseTwoPassLoads:
                 ):
                     if _load_kind(s.value, self._tensor_dtypes) is None:
                         continue
-                    key = _node_text(s.value)
+                    key = first_keys.get(id(s))
+                    if key is None:
+                        continue
                     entry = cache_names.get(key)
                     if entry is None:
                         continue
@@ -950,16 +1440,22 @@ class _CuteFuseTwoPassLoads:
             # extracts inside the nested constexpr V-loop are rewritten
             # to read from the cache at the appropriate slot expression.
             smem_barrier_positions: list[int] = []
-            for (body_idx, container_k, cache_index_k, alias_k), matches in zip(
-                sweeps, per_sweep_matches, strict=True
-            ):
+            for (
+                body_idx,
+                _loop_k,
+                container_k,
+                cache_index_k,
+                _alias_k,
+                _scope_definitions,
+            ), matches in zip(sweeps, per_sweep_matches, strict=True):
                 if not matches:
                     continue
                 vec_extract_rewrites: list[
                     tuple[str, str, str, int, bool, int, str]
                 ] = []
                 new_sweep_body: list[ast.stmt] = []
-                for s in container_k:
+                matched_by_index = {j: key for j, _name, key in matches}
+                for statement_index, s in enumerate(container_k):
                     if (
                         isinstance(s, ast.Assign)
                         and len(s.targets) == 1
@@ -967,7 +1463,10 @@ class _CuteFuseTwoPassLoads:
                     ):
                         kind = _load_kind(s.value, self._tensor_dtypes)
                         if kind is not None:
-                            key = _canonical_load_text(s.value, alias_k)
+                            key = matched_by_index.get(statement_index)
+                            if key is None:
+                                new_sweep_body.append(s)
+                                continue
                             entry = cache_names.get(key)
                             if entry is not None:
                                 cache, vec_w = entry
@@ -1033,16 +1532,48 @@ class _CuteFuseTwoPassLoads:
                         statement_from_string("cute.arch.sync_threads()"),
                     )
 
-            # Insert cache declarations before the first loop, in
-            # original order (so ``alloc_smem`` precedes
-            # ``make_tensor``).
-            for offset, decl in enumerate(cache_decls):
-                new_body.insert(first_idx + offset, decl)
+            # Declarations are inserted by ``transform`` at kernel scope.
+            # This remains valid when the matching sweeps live below a
+            # dynamic branch, where CuTe forbids local-memory allocation.
+            self._root_declarations.extend(cache_decls)
             any_fused = True
 
         if not any_fused:
             return None
         return new_body
+
+    def _transform_body(
+        self,
+        body: list[ast.stmt],
+        *,
+        under_dynamic_branch: bool,
+    ) -> list[ast.stmt]:
+        """Recursively transform statement-list fields before siblings."""
+        transformed = list(body)
+        for stmt in transformed:
+            child_under_branch = under_dynamic_branch or isinstance(stmt, ast.If)
+            for field in ("body", "orelse", "finalbody"):
+                child = getattr(stmt, field, None)
+                if isinstance(child, list) and all(
+                    isinstance(child_stmt, ast.stmt) for child_stmt in child
+                ):
+                    setattr(
+                        stmt,
+                        field,
+                        self._transform_body(
+                            child,
+                            under_dynamic_branch=child_under_branch,
+                        ),
+                    )
+        fused = self._try_fuse(
+            transformed,
+            allow_smem=not under_dynamic_branch,
+        )
+        return transformed if fused is None else fused
+
+    def transform(self, body: list[ast.stmt]) -> list[ast.stmt]:
+        transformed = self._transform_body(body, under_dynamic_branch=False)
+        return [*self._root_declarations, *transformed]
 
 
 def fuse_two_pass_loads(
@@ -1052,6 +1583,8 @@ def fuse_two_pass_loads(
     thread_block_dims: tuple[int, int, int] = (1, 1, 1),
     tensor_dtypes: dict[str, str] | None = None,
     reload_modes: dict[int, str] | None = None,
+    proven_disjoint_tensor_pairs: set[frozenset[str]] | None = None,
+    proven_tensor_stride_values: dict[tuple[str, int], int] | None = None,
 ) -> list[ast.stmt]:
     """Apply two-pass load fusion to a list of statements (the device kernel
     body). Returns the (possibly modified) body.
@@ -1067,6 +1600,14 @@ def fuse_two_pass_loads(
     path so kernels with 2-D / 3-D thread blocks (layernorm,
     block-pointer softmax) don't have rows clobber each other's slots.
 
+    ``proven_disjoint_tensor_pairs`` contains only argument-name pairs whose
+    allocations cannot overlap.  Distinct argument names are otherwise
+    conservatively treated as aliases across every store or atomic write.
+
+    ``proven_tensor_stride_values`` supplies cache-keyed exact strides for the
+    injectivity proof used by an in-place consume sweep. Without that proof,
+    a store to the loaded tensor remains a hard cache barrier.
+
     Safe to call on any kernel body — only rewrites when a strict pattern
     match succeeds.
     """
@@ -1075,8 +1616,7 @@ def fuse_two_pass_loads(
         thread_block_dims=thread_block_dims,
         tensor_dtypes=tensor_dtypes,
         reload_modes=reload_modes,
+        proven_disjoint_tensor_pairs=proven_disjoint_tensor_pairs,
+        proven_tensor_stride_values=proven_tensor_stride_values,
     )
-    new_body = transformer._try_fuse(body)
-    if new_body is None:
-        return body
-    return new_body
+    return transformer.transform(body)

--- a/helion/_compiler/cute/hoist_lane_invariant_reductions.py
+++ b/helion/_compiler/cute/hoist_lane_invariant_reductions.py
@@ -1,0 +1,2690 @@
+"""Hoist repeated invariant reductions out of CuTe grid-lane loops.
+
+A row-tiled persistent kernel can assign several rows to each thread while a
+second thread axis performs the same reduction for every row.  Codegen then
+has this shape (``row_lane`` is a compile-time loop)::
+
+    for row_lane in range(16):
+        row = row_base + row_lane
+        if uniform_guard:
+            ...
+        else:
+            key_acc = ...                         # independent of row_lane
+            for k_lane in cutlass.range_constexpr(8):
+                key_acc = key_acc + key[k_lane] ** 2
+            key_norm = cute.arch.warp_reduction_sum(key_acc)
+            ... state[row, k_lane] ...            # depends on row_lane
+
+The invariant reduction is otherwise emitted sixteen times.  This pass first
+unswitches a final, thread-uniform guard and then moves complete backward
+slices for row-invariant warp reductions before the row loop.
+
+The transform is deliberately fail closed.  It only handles generated lane
+loops with statically profitable repeated work, simple assignments and
+positive ``range_constexpr`` loops.  Loads may cross loop writes only when
+runtime storage-specialization facts prove all source/destination tensor pairs
+disjoint.  Atomics, unknown calls, ambiguous pointers, loop-carried
+dependencies, and lane-dependent slices reject the rewrite.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+from typing import TYPE_CHECKING
+from typing import cast
+
+from ..ast_extension import ExtendedAST
+from ..ast_extension import create
+from ..ast_extension import expr_from_string
+from ..ast_extension import statement_from_string
+from ..ast_read_writes import HELION_LANE_LOOP_VAR_ATTR
+from .fuse_two_pass_loads import _is_store_call
+from .fuse_two_pass_loads import _store_tensor_roots
+from .fuse_two_pass_loads import _tensor_arg_roots
+from .licm_profitability import repeated_work_is_profitable
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+_INT32_MIN = -(1 << 31)
+_INT32_MAX = (1 << 31) - 1
+_PYTHON_FLOAT = "python.float"
+_PYTHON_INT32 = "python.int32"
+_PURE_OPERATOR_CALLS = {
+    "operator.add",
+    "operator.and_",
+    "operator.eq",
+    "operator.floordiv",
+    "operator.ge",
+    "operator.gt",
+    "operator.index",
+    "operator.invert",
+    "operator.le",
+    "operator.lshift",
+    "operator.lt",
+    "operator.mod",
+    "operator.mul",
+    "operator.ne",
+    "operator.neg",
+    "operator.or_",
+    "operator.pos",
+    "operator.pow",
+    "operator.rshift",
+    "operator.sub",
+    "operator.truediv",
+    "operator.xor",
+}
+_PURE_CUTLASS_CALLS = {
+    "cutlass.BFloat16",
+    "cutlass.Boolean",
+    "cutlass.Float16",
+    "cutlass.Float32",
+    "cutlass.Float8E4M3FN",
+    "cutlass.Int32",
+    "cutlass.Int64",
+    "cutlass.Uint16",
+    "cutlass.Uint32",
+    "cutlass.const_expr",
+    "cutlass.range",
+    "cutlass.range_constexpr",
+}
+_PURE_CUTE_MATH_CALLS = {
+    "cute.math.absf",
+    "cute.math.atan2",
+    "cute.math.div",
+    "cute.math.erf",
+    "cute.math.exp",
+    "cute.math.exp2",
+    "cute.math.fma",
+    "cute.math.log",
+    "cute.math.log2",
+    "cute.math.max",
+    "cute.math.min",
+    "cute.math.rcp",
+    "cute.math.rsqrt",
+    "cute.math.sqrt",
+    "cute.math.tanh",
+}
+_PURE_WARP_REDUCTION_CALLS = {
+    "cute.arch.warp_reduction_max",
+    "cute.arch.warp_reduction_sum",
+}
+_PURE_LOAD_HELPERS = {"_cute_load_l2_evict_last"}
+_CUTLASS_SCALAR_TYPES = {
+    "cutlass.BFloat16": 2,
+    "cutlass.Boolean": 1,
+    "cutlass.Float16": 2,
+    "cutlass.Float32": 4,
+    "cutlass.Float8E4M3FN": 1,
+    "cutlass.Int32": 4,
+    "cutlass.Int64": 8,
+    "cutlass.Uint16": 2,
+    "cutlass.Uint32": 4,
+}
+_UNIFORM_GLOBAL_NAMES = {
+    "abs",
+    "bool",
+    "cutlass",
+    "cute",
+    "float",
+    "int",
+    "ir",
+    "len",
+    "max",
+    "min",
+    "operator",
+    "range",
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class _Effects:
+    live_in: frozenset[str]
+    writes: frozenset[str]
+
+
+def _clone_ast(value: object) -> object:
+    """Clone ordinary and Helion ExtendedAST nodes without using deepcopy."""
+    if isinstance(value, list):
+        return [_clone_ast(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_clone_ast(item) for item in value)
+    if not isinstance(value, ast.AST):
+        return value
+    fields = {field: _clone_ast(getattr(value, field)) for field in value._fields}
+    if isinstance(value, ExtendedAST):
+        return value.copy(**fields)
+    return ast.copy_location(type(value)(**fields), value)
+
+
+class _LoadedNames(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.names: set[str] = set()
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if isinstance(node.ctx, ast.Load):
+            self.names.add(node.id)
+
+
+def _names_read(node: ast.AST) -> set[str]:
+    visitor = _LoadedNames()
+    visitor.visit(node)
+    return visitor.names
+
+
+def _bound_names(node: ast.AST) -> set[str]:
+    if isinstance(node, ast.Name):
+        return {node.id}
+    if isinstance(node, (ast.Tuple, ast.List)):
+        result: set[str] = set()
+        for elt in node.elts:
+            result.update(_bound_names(elt))
+        return result
+    if isinstance(node, ast.Starred):
+        return _bound_names(node.value)
+    return set()
+
+
+def _assignment_target_reads(node: ast.AST) -> set[str]:
+    """Names evaluated while assigning to a non-name target."""
+    if isinstance(node, ast.Name):
+        return set()
+    return _names_read(node)
+
+
+def _assignment_target_writes(node: ast.AST) -> set[str]:
+    return _bound_names(node)
+
+
+def _mutation_roots(node: ast.AST) -> set[str]:
+    result: set[str] = set()
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call) and _is_private_store_staging_append(child):
+            assert isinstance(child.func, ast.Attribute)
+            assert isinstance(child.func.value, ast.Name)
+            result.add(child.func.value.id)
+        if not isinstance(child, (ast.Attribute, ast.Subscript)) or not isinstance(
+            child.ctx, ast.Store
+        ):
+            continue
+        root: ast.AST = child.value
+        while isinstance(root, (ast.Attribute, ast.Subscript)):
+            root = root.value
+        if isinstance(root, ast.Name):
+            result.add(root.id)
+    return result
+
+
+def _block_effects(body: list[ast.stmt], initially_written: set[str]) -> _Effects:
+    live_in: set[str] = set()
+    written = set(initially_written)
+    all_writes: set[str] = set()
+    for stmt in body:
+        effects = _statement_effects(stmt)
+        live_in.update(set(effects.live_in) - written)
+        written.update(effects.writes)
+        all_writes.update(effects.writes)
+    return _Effects(frozenset(live_in), frozenset(all_writes))
+
+
+def _statement_effects(stmt: ast.stmt) -> _Effects:
+    """Return assignment-time live-ins and definite local-name writes.
+
+    ``ReadWrites`` intentionally flattens nested statements, which makes names
+    defined inside a synthetic K loop look like loop inputs.  This small
+    structured analysis preserves assignment order, including loop-carried
+    accumulator reads.
+    """
+    if isinstance(stmt, ast.Assign):
+        reads = _names_read(stmt.value)
+        writes: set[str] = set()
+        for target in stmt.targets:
+            reads.update(_assignment_target_reads(target))
+            writes.update(_assignment_target_writes(target))
+        return _Effects(frozenset(reads), frozenset(writes))
+    if isinstance(stmt, ast.AnnAssign):
+        reads = _assignment_target_reads(stmt.target)
+        if stmt.value is not None:
+            reads.update(_names_read(stmt.value))
+        return _Effects(frozenset(reads), frozenset(_bound_names(stmt.target)))
+    if isinstance(stmt, ast.AugAssign):
+        reads = _names_read(stmt.value) | _names_read(stmt.target)
+        if isinstance(stmt.target, ast.Name):
+            reads.add(stmt.target.id)
+        return _Effects(frozenset(reads), frozenset(_bound_names(stmt.target)))
+    if isinstance(stmt, ast.For):
+        bound = _bound_names(stmt.target)
+        effects = _block_effects(stmt.body, bound)
+        return _Effects(
+            frozenset(_names_read(stmt.iter) | set(effects.live_in)),
+            frozenset(bound | set(effects.writes)),
+        )
+    if isinstance(stmt, ast.If):
+        body_effects = _block_effects(stmt.body, set())
+        else_effects = _block_effects(stmt.orelse, set())
+        return _Effects(
+            frozenset(
+                _names_read(stmt.test)
+                | set(body_effects.live_in)
+                | set(else_effects.live_in)
+            ),
+            frozenset(set(body_effects.writes) | set(else_effects.writes)),
+        )
+
+    # Unsupported compound statements are never selected for hoisting.  Their
+    # conservative flattened effects still keep the surrounding dataflow safe.
+    reads = _names_read(stmt)
+    writes = {
+        child.id
+        for child in ast.walk(stmt)
+        if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store)
+    }
+    return _Effects(frozenset(reads), frozenset(writes))
+
+
+def _call_path(node: ast.expr) -> str | None:
+    parts: list[str] = []
+    current: ast.expr = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if not isinstance(current, ast.Name):
+        return None
+    parts.append(current.id)
+    return ".".join(reversed(parts))
+
+
+def _is_atomic_call(call: ast.Call) -> bool:
+    path = _call_path(call.func)
+    return path is not None and (
+        path.split(".")[-1].startswith("atomic_") or path.startswith("_cute_atomic_")
+    )
+
+
+def _is_proven_scalar_bitcast(call: ast.Call) -> bool:
+    """Recognize the generated scalar-constructor ``.bitcast`` form only."""
+    if (
+        not isinstance(call.func, ast.Attribute)
+        or call.func.attr != "bitcast"
+        or len(call.args) != 1
+        or call.keywords
+        or not isinstance(call.func.value, ast.Call)
+    ):
+        return False
+    receiver = call.func.value
+    receiver_type = _call_path(receiver.func)
+    target_type = _call_path(cast("ast.expr", call.args[0]))
+    return (
+        receiver_type in _CUTLASS_SCALAR_TYPES
+        and len(receiver.args) == 1
+        and not receiver.keywords
+        and isinstance(call.args[0], ast.Attribute)
+        and target_type in _CUTLASS_SCALAR_TYPES
+        and _CUTLASS_SCALAR_TYPES[receiver_type] == _CUTLASS_SCALAR_TYPES[target_type]
+    )
+
+
+def _load_pointer(call: ast.Call) -> ast.AST | None:
+    path = _call_path(call.func)
+    if path == "cute.arch.load":
+        return call.args[0] if call.args else None
+    if path is not None and path.startswith("_cute_load_"):
+        return call.args[0] if call.args else None
+    if isinstance(call.func, ast.Attribute) and call.func.attr == "load":
+        return call.func.value
+    return None
+
+
+def _is_generated_arch_load(call: ast.Call) -> bool:
+    return (
+        _call_path(call.func) == "cute.arch.load"
+        and len(call.args) == 2
+        and all(
+            keyword.arg in {"cop", "level1_eviction_priority"}
+            and isinstance(keyword.value, ast.Constant)
+            and isinstance(keyword.value.value, str)
+            for keyword in call.keywords
+        )
+    )
+
+
+def _is_allowed_pure_call(call: ast.Call) -> bool:
+    path = _call_path(call.func)
+    if path is None:
+        if _is_proven_scalar_bitcast(call):
+            return True
+        # Generated pointer loads carry the address expression as their
+        # receiver.  Alias checks below separately prove that receiver's tensor
+        # root before any such load may move.
+        return (
+            isinstance(call.func, ast.Attribute)
+            and call.func.attr == "load"
+            and not call.args
+            and not call.keywords
+        )
+    if path in {"abs", "max", "min", "range"}:
+        return True
+    if path in _PURE_OPERATOR_CALLS or path in _PURE_CUTLASS_CALLS:
+        return True
+    if path in _PURE_CUTE_MATH_CALLS:
+        return True
+    if path == "ir.VectorType.get":
+        return True
+    if path == "cute.arch.load":
+        return _is_generated_arch_load(call)
+    if path in {"cute.arch.block_idx", "cute.arch.lane_idx", "cute.arch.thread_idx"}:
+        return True
+    if path in _PURE_WARP_REDUCTION_CALLS:
+        return True
+    return path in _PURE_LOAD_HELPERS and len(call.args) == 2 and not call.keywords
+
+
+def _is_private_store_staging_append(call: ast.Call) -> bool:
+    return (
+        isinstance(call.func, ast.Attribute)
+        and call.func.attr == "append"
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id.startswith("_persistent_branch_store_values_")
+    )
+
+
+def _has_only_known_effects(node: ast.AST) -> bool:
+    return all(
+        _is_allowed_pure_call(child)
+        or _is_store_call(child)
+        or _is_private_store_staging_append(child)
+        for child in ast.walk(node)
+        if isinstance(child, ast.Call)
+    )
+
+
+def _is_positive_constexpr_loop(stmt: ast.For) -> bool:
+    if stmt.orelse or not isinstance(stmt.target, ast.Name):
+        return False
+    call = stmt.iter
+    if (
+        not isinstance(call, ast.Call)
+        or _call_path(call.func) != "cutlass.range_constexpr"
+    ):
+        return False
+    if len(call.args) != 1:
+        return False
+    extent = call.args[0]
+    return (
+        isinstance(extent, ast.Constant)
+        and isinstance(extent.value, int)
+        and extent.value > 0
+    )
+
+
+def _is_hoistable_statement(stmt: ast.stmt, tensor_names: set[str]) -> bool:
+    if isinstance(stmt, ast.Assign):
+        for target in stmt.targets:
+            if isinstance(target, ast.Name):
+                continue
+            if not (
+                isinstance(target, ast.Subscript)
+                and isinstance(target.value, ast.Name)
+                and target.value.id.startswith("_fuse_cache_")
+            ):
+                return False
+    elif isinstance(stmt, ast.For):
+        if not _is_positive_constexpr_loop(stmt):
+            return False
+        if not all(_is_hoistable_statement(child, tensor_names) for child in stmt.body):
+            return False
+    else:
+        return False
+
+    for child in ast.walk(stmt):
+        if not isinstance(child, ast.Call):
+            continue
+        if _is_store_call(child) or _is_atomic_call(child):
+            return False
+        if not _is_allowed_pure_call(child):
+            return False
+        pointer = _load_pointer(child)
+        if pointer is not None and _tensor_arg_roots(pointer, tensor_names) is None:
+            return False
+    return True
+
+
+def _static_lane_extent(loop: ast.For) -> int | None:
+    call = loop.iter
+    if not isinstance(call, ast.Call) or _call_path(call.func) not in {
+        "range",
+        "cutlass.range_constexpr",
+    }:
+        return None
+    if len(call.args) != 1:
+        return None
+    extent = call.args[0]
+    if not isinstance(extent, ast.Constant) or not isinstance(extent.value, int):
+        return None
+    return extent.value
+
+
+def _bounded_integer_interval(
+    node: ast.AST,
+    *,
+    lane_var: str,
+    lane_extent: int,
+    thread_block_dims: tuple[int, int, int],
+) -> tuple[int, int] | None:
+    """Bound the small integer grammar used by generated tile masks."""
+
+    def checked(lower: int, upper: int) -> tuple[int, int] | None:
+        # Generated tile coordinates use Int32 arithmetic.  Decline to reason
+        # through any intermediate that could wrap before the comparison.
+        if _INT32_MIN <= lower <= upper <= _INT32_MAX:
+            return lower, upper
+        return None
+
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, int) and not isinstance(node.value, bool):
+            return checked(node.value, node.value)
+        return None
+    if isinstance(node, ast.Name):
+        return (0, lane_extent - 1) if node.id == lane_var else None
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+        interval = _bounded_integer_interval(
+            node.operand,
+            lane_var=lane_var,
+            lane_extent=lane_extent,
+            thread_block_dims=thread_block_dims,
+        )
+        if interval is None:
+            return None
+        if isinstance(node.op, ast.UAdd):
+            return interval
+        return checked(-interval[1], -interval[0])
+    if (
+        isinstance(node, ast.Call)
+        and len(node.args) == 1
+        and not node.keywords
+        and _call_path(node.func) in {"cutlass.Int32", "cutlass.Int64"}
+    ):
+        interval = _bounded_integer_interval(
+            node.args[0],
+            lane_var=lane_var,
+            lane_extent=lane_extent,
+            thread_block_dims=thread_block_dims,
+        )
+        if interval is None:
+            return None
+        return checked(*interval)
+    if (
+        isinstance(node, ast.Subscript)
+        and isinstance(node.value, ast.Call)
+        and _call_path(node.value.func) == "cute.arch.thread_idx"
+        and not node.value.args
+        and not node.value.keywords
+        and isinstance(node.slice, ast.Constant)
+        and isinstance(node.slice.value, int)
+        and 0 <= node.slice.value < len(thread_block_dims)
+    ):
+        return 0, thread_block_dims[node.slice.value] - 1
+    if isinstance(node, ast.BinOp) and isinstance(
+        node.op, (ast.Add, ast.Sub, ast.Mult)
+    ):
+        left = _bounded_integer_interval(
+            node.left,
+            lane_var=lane_var,
+            lane_extent=lane_extent,
+            thread_block_dims=thread_block_dims,
+        )
+        right = _bounded_integer_interval(
+            node.right,
+            lane_var=lane_var,
+            lane_extent=lane_extent,
+            thread_block_dims=thread_block_dims,
+        )
+        if left is None or right is None:
+            return None
+        if isinstance(node.op, ast.Add):
+            return checked(left[0] + right[0], left[1] + right[1])
+        if isinstance(node.op, ast.Sub):
+            return checked(left[0] - right[1], left[1] - right[0])
+        products = (
+            left[0] * right[0],
+            left[0] * right[1],
+            left[1] * right[0],
+            left[1] * right[1],
+        )
+        return checked(min(products), max(products))
+    return None
+
+
+def _comparison_is_always_true(
+    node: ast.Compare,
+    *,
+    lane_var: str,
+    lane_extent: int,
+    thread_block_dims: tuple[int, int, int],
+) -> bool:
+    if len(node.ops) != 1 or len(node.comparators) != 1:
+        return False
+    left = _bounded_integer_interval(
+        node.left,
+        lane_var=lane_var,
+        lane_extent=lane_extent,
+        thread_block_dims=thread_block_dims,
+    )
+    right = _bounded_integer_interval(
+        node.comparators[0],
+        lane_var=lane_var,
+        lane_extent=lane_extent,
+        thread_block_dims=thread_block_dims,
+    )
+    if left is None or right is None:
+        return False
+    op = node.ops[0]
+    if isinstance(op, ast.Lt):
+        return left[1] < right[0]
+    if isinstance(op, ast.LtE):
+        return left[1] <= right[0]
+    if isinstance(op, ast.Gt):
+        return left[0] > right[1]
+    if isinstance(op, ast.GtE):
+        return left[0] >= right[1]
+    if isinstance(op, ast.Eq):
+        return left[0] == left[1] == right[0] == right[1]
+    if isinstance(op, ast.NotEq):
+        return left[1] < right[0] or right[1] < left[0]
+    return False
+
+
+def _simplify_full_lane_bounds(
+    loop: ast.For,
+    lane_var: str,
+    lane_extent: int,
+    thread_block_dims: tuple[int, int, int] | None,
+) -> ast.For:
+    """Erase generated bounds conjuncts proven true for the full lane tile."""
+    if thread_block_dims is None:
+        return loop
+
+    class _Simplifier(ast.NodeTransformer):
+        def visit_Compare(self, node: ast.Compare) -> ast.AST:
+            visited = self.generic_visit(node)
+            assert isinstance(visited, ast.Compare)
+            if _comparison_is_always_true(
+                visited,
+                lane_var=lane_var,
+                lane_extent=lane_extent,
+                thread_block_dims=thread_block_dims,
+            ):
+                return ast.copy_location(ast.Constant(value=True), visited)
+            return visited
+
+        def visit_BoolOp(self, node: ast.BoolOp) -> ast.AST:
+            visited = self.generic_visit(node)
+            assert isinstance(visited, ast.BoolOp)
+            if not isinstance(visited.op, ast.And):
+                return visited
+            values = [
+                value
+                for value in visited.values
+                if not (isinstance(value, ast.Constant) and value.value is True)
+            ]
+            if not values:
+                return ast.copy_location(ast.Constant(value=True), visited)
+            if len(values) == 1:
+                return ast.copy_location(values[0], visited)
+            visited.values = values
+            return visited
+
+    result = _Simplifier().visit(loop)
+    assert isinstance(result, ast.For)
+    return result
+
+
+def _is_warp_reduction_assignment(stmt: ast.stmt) -> bool:
+    if not (
+        isinstance(stmt, ast.Assign)
+        and len(stmt.targets) == 1
+        and isinstance(stmt.targets[0], ast.Name)
+    ):
+        return False
+    return any(
+        isinstance(child, ast.Call)
+        and ((_call_path(child.func) or "").startswith("cute.arch.warp_reduction_"))
+        for child in ast.walk(stmt.value)
+    )
+
+
+def _backward_slice(body: list[ast.stmt], target_index: int) -> set[int]:
+    target = body[target_index]
+    effects = _statement_effects(target)
+    needed = set(effects.writes)
+    if not needed:
+        return set()
+    selected: set[int] = set()
+    for index in range(target_index, -1, -1):
+        stmt_effects = _statement_effects(body[index])
+        if not (set(stmt_effects.writes) & needed):
+            continue
+        selected.add(index)
+        needed.difference_update(stmt_effects.writes)
+        needed.update(stmt_effects.live_in)
+    return selected
+
+
+def _slice_external_reads(body: list[ast.stmt], selected: set[int]) -> set[str]:
+    needed: set[str] = set()
+    for index in sorted(selected):
+        effects = _statement_effects(body[index])
+        needed.update(
+            set(effects.live_in)
+            - {
+                name
+                for prior in selected
+                if prior < index
+                for name in _statement_effects(body[prior]).writes
+            }
+        )
+    return needed
+
+
+def _slice_preserves_reaching_definitions(
+    body: list[ast.stmt], selected: set[int]
+) -> bool:
+    effects = [_statement_effects(stmt) for stmt in body]
+    # A selected read must not depend on a loop-carried or skipped definition.
+    for index in selected:
+        for name in effects[index].live_in:
+            prior = [j for j in range(index) if name in effects[j].writes]
+            if prior and prior[-1] not in selected:
+                return False
+            if not prior and any(name in effect.writes for effect in effects):
+                return False
+    # Hoisting a later definition must not shadow the value observed by an
+    # earlier statement left in the loop.
+    for index, effect in enumerate(effects):
+        if index in selected:
+            continue
+        for name in effect.live_in:
+            if any(j > index and name in effects[j].writes for j in selected):
+                return False
+    reaching_selected = {
+        name for index in selected for name in effects[index].writes
+    } | {name for index in selected for name in _mutation_roots(body[index])}
+    consumed_selected: set[str] = set()
+    for index, (stmt, effect) in enumerate(zip(body, effects, strict=True)):
+        if index in selected:
+            continue
+        consumed_selected.update(set(effect.live_in) & reaching_selected)
+        overwritten = set(effect.writes) | _mutation_roots(stmt)
+        # A selected value used by this iteration must survive unchanged until
+        # the next iteration because its defining slice no longer reruns.
+        if consumed_selected & overwritten:
+            return False
+        reaching_selected.difference_update(overwritten)
+    return True
+
+
+def _canonical_name(name: str, rename_groups: dict[str, str]) -> str:
+    seen: set[str] = set()
+    while name in rename_groups and name not in seen:
+        seen.add(name)
+        name = rename_groups[name]
+    return name
+
+
+def _is_uniform_name(
+    name: str, uniform_names: set[str], rename_groups: dict[str, str]
+) -> bool:
+    canonical = _canonical_name(name, rename_groups)
+    return canonical in uniform_names or canonical.startswith(
+        ("_BLOCK_SIZE_", "_RDIM_SIZE_")
+    )
+
+
+def _update_uniform_names(
+    stmt: ast.stmt,
+    uniform_names: set[str],
+    rename_groups: dict[str, str],
+) -> None:
+    effects = _statement_effects(stmt)
+    writes = {_canonical_name(name, rename_groups) for name in effects.writes}
+    if not writes:
+        return
+    source = ast.unparse(stmt)
+    if (
+        not isinstance(stmt, ast.Assign)
+        or _mutation_roots(stmt)
+        or not _has_only_known_effects(stmt)
+        or any(token in source for token in ("thread_idx", "lane_idx", "warp_idx"))
+        or not all(
+            _is_uniform_name(name, uniform_names, rename_groups)
+            for name in effects.live_in
+        )
+    ):
+        uniform_names.difference_update(writes)
+        return
+    uniform_names.update(writes)
+
+
+def _has_rename_alias_conflict(
+    body: list[ast.stmt],
+    selected: set[int],
+    rename_groups: dict[str, str],
+) -> bool:
+    """Reject hidden writes that become aliases under the final AST rename."""
+    if not rename_groups:
+        return False
+    selected_names: set[str] = set()
+    selected_writes: set[str] = set()
+    other_reads: set[str] = set()
+    other_writes: set[str] = set()
+    for index, stmt in enumerate(body):
+        effects = _statement_effects(stmt)
+        names = set(effects.live_in) | set(effects.writes) | _mutation_roots(stmt)
+        if index in selected:
+            selected_names.update(names)
+            selected_writes.update(effects.writes)
+            selected_writes.update(_mutation_roots(stmt))
+        else:
+            other_reads.update(effects.live_in)
+            other_writes.update(effects.writes)
+            other_writes.update(_mutation_roots(stmt))
+    selected_by_canonical: dict[str, set[str]] = {}
+    for name in selected_names:
+        selected_by_canonical.setdefault(
+            _canonical_name(name, rename_groups), set()
+        ).add(name)
+    if any(len(names) > 1 for names in selected_by_canonical.values()):
+        return True
+    selected_touched_by_other_write = any(
+        selected_name != other_name
+        and _canonical_name(selected_name, rename_groups)
+        == _canonical_name(other_name, rename_groups)
+        for selected_name in selected_names
+        for other_name in other_writes
+    )
+    selected_write_observed_by_other_read = any(
+        selected_name != other_name
+        and _canonical_name(selected_name, rename_groups)
+        == _canonical_name(other_name, rename_groups)
+        for selected_name in selected_writes
+        for other_name in other_reads
+    )
+    return selected_touched_by_other_write or selected_write_observed_by_other_read
+
+
+def _repeated_scalar_reaching_safe(
+    body: list[ast.stmt],
+    selected_names: set[str],
+    direct_assignments: dict[str, list[int]],
+) -> bool:
+    """Ensure no statement reads a selected name before its first definition.
+
+    Reads between selected definitions are valid because eligibility requires
+    every definition to have byte-identical RHS syntax.  Moving one canonical
+    definition to the preheader therefore preserves those values.
+    """
+    effects = [_statement_effects(stmt) for stmt in body]
+    return not any(
+        name in effects[index].live_in
+        for name in selected_names
+        for index in range(direct_assignments[name][0])
+    )
+
+
+def _global_store_roots(
+    loop: ast.For, tensor_names: set[str]
+) -> tuple[list[frozenset[str]], bool]:
+    roots: list[frozenset[str]] = []
+    for child in ast.walk(loop):
+        if not isinstance(child, ast.Call):
+            continue
+        if _is_atomic_call(child):
+            return [], False
+        if not _is_store_call(child):
+            continue
+        resolved = _store_tensor_roots(child, tensor_names)
+        if resolved is None:
+            return [], False
+        roots.append(resolved)
+    return roots, True
+
+
+def _loads_may_cross_loop_writes(
+    statements: Iterable[ast.stmt],
+    store_roots: list[frozenset[str]],
+    tensor_names: set[str],
+    proven_disjoint_tensor_pairs: set[frozenset[str]],
+) -> bool:
+    for stmt in statements:
+        for child in ast.walk(stmt):
+            if not isinstance(child, ast.Call):
+                continue
+            pointer = _load_pointer(child)
+            if pointer is None:
+                continue
+            load_roots = _tensor_arg_roots(pointer, tensor_names)
+            if load_roots is None:
+                return False
+            for load_root in load_roots:
+                for destinations in store_roots:
+                    for store_root in destinations:
+                        if (
+                            load_root == store_root
+                            or frozenset((load_root, store_root))
+                            not in proven_disjoint_tensor_pairs
+                        ):
+                            return False
+    return True
+
+
+@dataclasses.dataclass(frozen=True)
+class _RmemInfo:
+    extent: int
+    dtype: str
+
+
+@dataclasses.dataclass
+class _ConstexprLoopInfo:
+    outer_index: int
+    loop: ast.For
+    lane_var: str
+    extent: int
+    assignment_sites: dict[str, list[tuple[int, ast.Assign]]]
+
+
+@dataclasses.dataclass(frozen=True)
+class _CacheStore:
+    info: _ConstexprLoopInfo
+    body_index: int
+    statement: ast.Assign
+    target: ast.Subscript
+
+
+@dataclasses.dataclass
+class _VectorCandidate:
+    info: _ConstexprLoopInfo
+    body_index: int
+    statement: ast.Assign
+    target_name: str
+    canonical: str
+    dtype: str
+    selected_statement_ids: set[int]
+    cache_access_ids: dict[str, set[int]]
+    cache_store_ids: set[int]
+    cache_names: set[str]
+    math_calls: int
+    node_count: int
+
+
+class _VectorCacheReject(Exception):
+    pass
+
+
+def _rmem_declaration(stmt: ast.stmt) -> tuple[str, _RmemInfo] | None:
+    if not (
+        isinstance(stmt, ast.Assign)
+        and len(stmt.targets) == 1
+        and isinstance(stmt.targets[0], ast.Name)
+        and isinstance(stmt.value, ast.Call)
+        and _call_path(stmt.value.func) == "cute.make_rmem_tensor"
+        and len(stmt.value.args) == 2
+        and not stmt.value.keywords
+        and isinstance(stmt.value.args[0], ast.Constant)
+        and isinstance(stmt.value.args[0].value, int)
+        and stmt.value.args[0].value > 0
+    ):
+        return None
+    dtype = _call_path(cast("ast.expr", stmt.value.args[1]))
+    if dtype not in _CUTLASS_SCALAR_TYPES:
+        return None
+    return stmt.targets[0].id, _RmemInfo(stmt.value.args[0].value, dtype)
+
+
+def _subscript_root(node: ast.Subscript) -> str | None:
+    return node.value.id if isinstance(node.value, ast.Name) else None
+
+
+def _identity_lane_index(node: ast.AST, lane_var: str) -> bool:
+    if isinstance(node, ast.Name):
+        return node.id == lane_var
+    if (
+        isinstance(node, ast.BinOp)
+        and isinstance(node.op, ast.FloorDiv)
+        and isinstance(node.right, ast.Constant)
+        and node.right.value == 1
+    ):
+        node = node.left
+    if (
+        isinstance(node, ast.BinOp)
+        and isinstance(node.op, (ast.Add, ast.Sub))
+        and isinstance(node.right, ast.Constant)
+        and node.right.value == 0
+    ):
+        node = node.left
+    return isinstance(node, ast.Name) and node.id == lane_var
+
+
+def _collect_subscript_accesses(body: list[ast.stmt]) -> dict[str, set[int]]:
+    result: dict[str, set[int]] = {}
+    for stmt in body:
+        for node in ast.walk(stmt):
+            if not isinstance(node, ast.Subscript):
+                continue
+            root = _subscript_root(node)
+            if root is not None:
+                result.setdefault(root, set()).add(id(node))
+    return result
+
+
+def _non_subscript_access_names(body: list[ast.stmt]) -> set[str]:
+    """Find names used other than as direct ``name[index]`` handles."""
+
+    class _Visitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.result: set[str] = set()
+
+        def visit_Subscript(self, node: ast.Subscript) -> None:
+            if not isinstance(node.value, ast.Name):
+                self.visit(node.value)
+            self.visit(node.slice)
+
+        def visit_Name(self, node: ast.Name) -> None:
+            self.result.add(node.id)
+
+        def visit_Assign(self, node: ast.Assign) -> None:
+            declaration = _rmem_declaration(node)
+            if declaration is None:
+                self.generic_visit(node)
+                return
+            self.visit(node.value)
+
+    visitor = _Visitor()
+    for stmt in body:
+        visitor.visit(stmt)
+    return visitor.result
+
+
+def _constexpr_loop_info(stmt: ast.stmt, outer_index: int) -> _ConstexprLoopInfo | None:
+    if not (
+        isinstance(stmt, ast.For)
+        and _is_positive_constexpr_loop(stmt)
+        and isinstance(stmt.target, ast.Name)
+        and isinstance(stmt.iter, ast.Call)
+        and isinstance(stmt.iter.args[0], ast.Constant)
+        and isinstance(stmt.iter.args[0].value, int)
+        and not any(
+            isinstance(
+                node, (ast.Break, ast.Raise, ast.Return, ast.Yield, ast.YieldFrom)
+            )
+            for node in ast.walk(stmt)
+        )
+        and not any(
+            stmt.target.id in _statement_effects(child).writes for child in stmt.body
+        )
+    ):
+        return None
+    sites: dict[str, list[tuple[int, ast.Assign]]] = {}
+    for body_index, child in enumerate(stmt.body):
+        if (
+            isinstance(child, ast.Assign)
+            and len(child.targets) == 1
+            and isinstance(child.targets[0], ast.Name)
+        ):
+            sites.setdefault(child.targets[0].id, []).append((body_index, child))
+    return _ConstexprLoopInfo(
+        outer_index,
+        stmt,
+        stmt.target.id,
+        stmt.iter.args[0].value,
+        sites,
+    )
+
+
+def _cache_stores(
+    infos: list[_ConstexprLoopInfo],
+    rmem: dict[str, _RmemInfo],
+) -> dict[str, list[_CacheStore]]:
+    result: dict[str, list[_CacheStore]] = {}
+    for info in infos:
+        for body_index, stmt in enumerate(info.loop.body):
+            if not (
+                isinstance(stmt, ast.Assign)
+                and len(stmt.targets) == 1
+                and isinstance(stmt.targets[0], ast.Subscript)
+            ):
+                continue
+            target = stmt.targets[0]
+            root = _subscript_root(target)
+            if (
+                root not in rmem
+                or rmem[root].extent != info.extent
+                or not _identity_lane_index(target.slice, info.lane_var)
+            ):
+                continue
+            result.setdefault(root, []).append(
+                _CacheStore(info, body_index, stmt, target)
+            )
+    return result
+
+
+@dataclasses.dataclass(frozen=True)
+class _ExprContext:
+    outer_index: int
+    info: _ConstexprLoopInfo | None = None
+    body_index: int = -1
+
+
+class _VectorExpressionResolver:
+    def __init__(
+        self,
+        *,
+        outer_loop: ast.For,
+        infos: list[_ConstexprLoopInfo],
+        cache_stores: dict[str, list[_CacheStore]],
+        rmem: dict[str, _RmemInfo],
+        rename_groups: dict[str, str],
+        tensor_dtypes: dict[str, str],
+        tensor_names: set[str],
+        float_scalar_names: set[str],
+    ) -> None:
+        self.outer_loop = outer_loop
+        self.infos = infos
+        self.cache_stores = cache_stores
+        self.rmem = rmem
+        self.rename_groups = rename_groups
+        self.tensor_dtypes = tensor_dtypes
+        self.tensor_names = tensor_names
+        self.float_scalar_names = float_scalar_names
+        self.outer_lane = cast("ast.Name", outer_loop.target).id
+        self.outer_assignments: dict[str, list[tuple[int, ast.Assign]]] = {}
+        for index, stmt in enumerate(outer_loop.body):
+            if (
+                isinstance(stmt, ast.Assign)
+                and len(stmt.targets) == 1
+                and isinstance(stmt.targets[0], ast.Name)
+            ):
+                self.outer_assignments.setdefault(stmt.targets[0].id, []).append(
+                    (index, stmt)
+                )
+        self.outer_writes = set(_statement_effects(outer_loop).writes)
+        self.outer_mutations = set().union(
+            *(_mutation_roots(stmt) for stmt in outer_loop.body)
+        )
+        aliases = [
+            (stmt.targets[0].id, stmt.value.id)
+            for stmt in ast.walk(outer_loop)
+            if isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and isinstance(stmt.value, ast.Name)
+        ]
+        changed = True
+        while changed:
+            changed = False
+            for left, right in aliases:
+                if left in self.outer_mutations or right in self.outer_mutations:
+                    previous_size = len(self.outer_mutations)
+                    self.outer_mutations.update((left, right))
+                    changed |= len(self.outer_mutations) != previous_size
+        self.selected_statement_ids: set[int] = set()
+        self.cache_access_ids: dict[str, set[int]] = {}
+        self.cache_store_ids: set[int] = set()
+        self.cache_names: set[str] = set()
+
+    def normalize(self, node: ast.AST, context: _ExprContext) -> ast.AST:
+        return self._normalize(node, context, set())
+
+    def _normalize(
+        self,
+        node: ast.AST,
+        context: _ExprContext,
+        resolving: set[tuple[str, int]],
+    ) -> ast.AST:
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+            return self._normalize_name(node.id, context, resolving)
+        if isinstance(node, ast.Subscript) and isinstance(node.ctx, ast.Load):
+            cached = self._normalize_cache_read(node, context, resolving)
+            if cached is not None:
+                return cached
+
+        clone = cast("ast.AST", _clone_ast(node))
+        for field, value in ast.iter_fields(clone):
+            if isinstance(value, ast.AST):
+                setattr(clone, field, self._normalize(value, context, resolving))
+            elif isinstance(value, list):
+                setattr(
+                    clone,
+                    field,
+                    [
+                        self._normalize(item, context, resolving)
+                        if isinstance(item, ast.AST)
+                        else item
+                        for item in value
+                    ],
+                )
+        return clone
+
+    def _normalize_name(
+        self,
+        name: str,
+        context: _ExprContext,
+        resolving: set[tuple[str, int]],
+    ) -> ast.AST:
+        canonical = _canonical_name(name, self.rename_groups)
+        if canonical == _canonical_name(self.outer_lane, self.rename_groups):
+            raise _VectorCacheReject
+        if context.info is not None and name == context.info.lane_var:
+            return ast.Name(id="__constexpr_lane", ctx=ast.Load())
+        if context.info is not None and canonical == _canonical_name(
+            context.info.lane_var, self.rename_groups
+        ):
+            raise _VectorCacheReject
+
+        if context.info is not None and name in context.info.assignment_sites:
+            sites = context.info.assignment_sites[name]
+            if len(sites) != 1 or sites[0][0] >= context.body_index:
+                raise _VectorCacheReject
+            body_index, stmt = sites[0]
+            if any(
+                canonical
+                in {
+                    _canonical_name(item, self.rename_groups)
+                    for item in set(_statement_effects(prior).writes)
+                    | _mutation_roots(prior)
+                }
+                for prior in context.info.loop.body[body_index + 1 : context.body_index]
+            ) or canonical in {
+                _canonical_name(item, self.rename_groups)
+                for item in self.outer_mutations
+            }:
+                raise _VectorCacheReject
+            key = ("inner", id(stmt))
+            if key in resolving:
+                raise _VectorCacheReject
+            self.selected_statement_ids.add(id(stmt))
+            return self._normalize(
+                stmt.value,
+                _ExprContext(context.info.outer_index, context.info, body_index),
+                {*resolving, key},
+            )
+
+        preceding = [
+            (index, stmt)
+            for index, stmt in self.outer_assignments.get(name, ())
+            if index < context.outer_index
+        ]
+        if preceding:
+            outer_index, stmt = preceding[-1]
+            if any(
+                canonical
+                in {
+                    _canonical_name(item, self.rename_groups)
+                    for item in set(_statement_effects(prior).writes)
+                    | _mutation_roots(prior)
+                }
+                for prior in self.outer_loop.body[outer_index + 1 : context.outer_index]
+            ) or canonical in {
+                _canonical_name(item, self.rename_groups)
+                for item in self.outer_mutations
+            }:
+                raise _VectorCacheReject
+            key = ("outer", id(stmt))
+            if key in resolving:
+                raise _VectorCacheReject
+            self.selected_statement_ids.add(id(stmt))
+            return self._normalize(
+                stmt.value,
+                _ExprContext(outer_index),
+                {*resolving, key},
+            )
+
+        outer_mutations = self.outer_writes | self.outer_mutations
+        if name in outer_mutations or canonical in {
+            _canonical_name(item, self.rename_groups) for item in outer_mutations
+        }:
+            raise _VectorCacheReject
+        return ast.Name(id=canonical, ctx=ast.Load())
+
+    def _normalize_cache_read(
+        self,
+        node: ast.Subscript,
+        context: _ExprContext,
+        resolving: set[tuple[str, int]],
+    ) -> ast.AST | None:
+        root = _subscript_root(node)
+        if root not in self.rmem:
+            return None
+        if (
+            context.info is None
+            or self.rmem[root].extent != context.info.extent
+            or not _identity_lane_index(node.slice, context.info.lane_var)
+        ):
+            raise _VectorCacheReject
+        stores = self.cache_stores.get(root, ())
+        if len(stores) != 1:
+            raise _VectorCacheReject
+        producer = stores[0]
+        if producer.info.extent != context.info.extent or not (
+            producer.info.outer_index < context.info.outer_index
+            or producer.info.outer_index == context.info.outer_index
+            and producer.body_index < context.body_index
+        ):
+            raise _VectorCacheReject
+        key = ("cache", id(producer.statement))
+        if key in resolving:
+            raise _VectorCacheReject
+        self.cache_names.add(root)
+        self.cache_store_ids.add(id(producer.statement))
+        self.cache_access_ids.setdefault(root, set()).update(
+            (id(node), id(producer.target))
+        )
+        normalized = self._normalize(
+            producer.statement.value,
+            _ExprContext(
+                producer.info.outer_index,
+                producer.info,
+                producer.body_index,
+            ),
+            {*resolving, key},
+        )
+        if (
+            _infer_scalar_dtype(
+                normalized,
+                self.tensor_dtypes,
+                self.tensor_names,
+                self.float_scalar_names,
+            )
+            != self.rmem[root].dtype
+        ):
+            raise _VectorCacheReject
+        return normalized
+
+
+def _merge_scalar_dtype(left: str | None, right: str | None) -> str | None:
+    if left is None or right is None:
+        return None
+    python_scalars = {_PYTHON_FLOAT, _PYTHON_INT32}
+    if left in python_scalars or right in python_scalars:
+        other = right if left in python_scalars else left
+        return "cutlass.Float32" if other == "cutlass.Float32" else None
+    return left if left == right else None
+
+
+def _infer_scalar_dtype(
+    node: ast.AST,
+    tensor_dtypes: dict[str, str],
+    tensor_names: set[str],
+    float_scalar_names: set[str],
+) -> str | None:
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, float):
+            return _PYTHON_FLOAT
+        if (
+            isinstance(node.value, (bool, int))
+            and _INT32_MIN <= node.value <= _INT32_MAX
+        ):
+            return _PYTHON_INT32
+        return None
+    if isinstance(node, ast.Name):
+        return _PYTHON_FLOAT if node.id in float_scalar_names else None
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+        return _infer_scalar_dtype(
+            node.operand, tensor_dtypes, tensor_names, float_scalar_names
+        )
+    if isinstance(node, ast.BinOp) and isinstance(
+        node.op, (ast.Add, ast.Mult, ast.Sub)
+    ):
+        return _merge_scalar_dtype(
+            _infer_scalar_dtype(
+                node.left, tensor_dtypes, tensor_names, float_scalar_names
+            ),
+            _infer_scalar_dtype(
+                node.right, tensor_dtypes, tensor_names, float_scalar_names
+            ),
+        )
+    if isinstance(node, ast.IfExp):
+        body_dtype = _infer_scalar_dtype(
+            node.body, tensor_dtypes, tensor_names, float_scalar_names
+        )
+        else_dtype = _infer_scalar_dtype(
+            node.orelse, tensor_dtypes, tensor_names, float_scalar_names
+        )
+        return body_dtype if body_dtype == else_dtype else None
+    if not isinstance(node, ast.Call):
+        return None
+    path = _call_path(node.func)
+    if path in _CUTLASS_SCALAR_TYPES:
+        return path
+    if _is_proven_scalar_bitcast(node):
+        return _call_path(cast("ast.expr", node.args[0]))
+    pointer = _load_pointer(node)
+    if pointer is not None:
+        if not (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "load"
+            and not node.args
+            and not node.keywords
+        ):
+            if not _is_generated_arch_load(node):
+                return None
+            explicit_dtype = _call_path(cast("ast.expr", node.args[1]))
+            return explicit_dtype if explicit_dtype in _CUTLASS_SCALAR_TYPES else None
+        roots = _tensor_arg_roots(pointer, tensor_names)
+        if roots is None or len(roots) != 1:
+            return None
+        return tensor_dtypes.get(next(iter(roots)))
+    if path in _PURE_CUTE_MATH_CALLS and node.args:
+        result = _infer_scalar_dtype(
+            node.args[0], tensor_dtypes, tensor_names, float_scalar_names
+        )
+        for arg in node.args[1:]:
+            result = _merge_scalar_dtype(
+                result,
+                _infer_scalar_dtype(
+                    arg, tensor_dtypes, tensor_names, float_scalar_names
+                ),
+            )
+        return result if result not in {_PYTHON_FLOAT, _PYTHON_INT32} else None
+    return None
+
+
+def _vector_chain_expression_safe(expression: ast.expr, tensor_names: set[str]) -> bool:
+    if any(
+        isinstance(
+            node,
+            (
+                ast.Await,
+                ast.DictComp,
+                ast.GeneratorExp,
+                ast.Lambda,
+                ast.ListComp,
+                ast.NamedExpr,
+                ast.SetComp,
+                ast.Yield,
+                ast.YieldFrom,
+            ),
+        )
+        for node in ast.walk(expression)
+    ):
+        return False
+    for node in ast.walk(expression):
+        if not isinstance(node, ast.Call):
+            continue
+        if not _is_allowed_pure_call(node) or _is_store_call(node):
+            return False
+        pointer = _load_pointer(node)
+        if pointer is not None and _tensor_arg_roots(pointer, tensor_names) is None:
+            return False
+    return True
+
+
+def _vector_chain_assignment_safe(stmt: ast.stmt, tensor_names: set[str]) -> bool:
+    return (
+        isinstance(stmt, ast.Assign)
+        and len(stmt.targets) == 1
+        and isinstance(stmt.targets[0], ast.Name)
+        and _vector_chain_expression_safe(stmt.value, tensor_names)
+    )
+
+
+def _nested_rename_alias_conflict(
+    loop: ast.For,
+    selected_statement_ids: set[int],
+    rename_groups: dict[str, str],
+) -> bool:
+    if not rename_groups:
+        return False
+    leaves = [
+        node
+        for node in ast.walk(loop)
+        if isinstance(node, ast.stmt) and not isinstance(node, (ast.For, ast.If))
+    ]
+    selected = {
+        index for index, stmt in enumerate(leaves) if id(stmt) in selected_statement_ids
+    }
+    return _has_rename_alias_conflict(leaves, selected, rename_groups)
+
+
+def _candidate_used_later(info: _ConstexprLoopInfo, body_index: int, name: str) -> bool:
+    return any(name in _names_read(stmt) for stmt in info.loop.body[body_index + 1 :])
+
+
+def _build_vector_candidates(
+    loop: ast.For,
+    infos: list[_ConstexprLoopInfo],
+    stores: dict[str, list[_CacheStore]],
+    rmem: dict[str, _RmemInfo],
+    tensor_dtypes: dict[str, str],
+    tensor_names: set[str],
+    float_scalar_names: set[str],
+    rename_groups: dict[str, str],
+) -> list[_VectorCandidate]:
+    candidates: list[_VectorCandidate] = []
+    for info in infos:
+        for target_name, sites in info.assignment_sites.items():
+            if len(sites) != 1:
+                continue
+            body_index, stmt = sites[0]
+            if not all(
+                isinstance(prefix_stmt, ast.Assign)
+                for prefix_stmt in info.loop.body[: body_index + 1]
+            ):
+                continue
+            if not _candidate_used_later(info, body_index, target_name):
+                continue
+            resolver = _VectorExpressionResolver(
+                outer_loop=loop,
+                infos=infos,
+                cache_stores=stores,
+                rmem=rmem,
+                rename_groups=rename_groups,
+                tensor_dtypes=tensor_dtypes,
+                tensor_names=tensor_names,
+                float_scalar_names=float_scalar_names,
+            )
+            resolver.selected_statement_ids.add(id(stmt))
+            try:
+                normalized = resolver.normalize(
+                    stmt.value,
+                    _ExprContext(info.outer_index, info, body_index),
+                )
+            except _VectorCacheReject:
+                continue
+            selected_statements = [
+                node
+                for node in ast.walk(loop)
+                if isinstance(node, ast.stmt)
+                and id(node) in resolver.selected_statement_ids
+            ]
+            if not selected_statements or not all(
+                _vector_chain_assignment_safe(selected, tensor_names)
+                for selected in selected_statements
+            ):
+                continue
+            dtype = _infer_scalar_dtype(
+                normalized, tensor_dtypes, tensor_names, float_scalar_names
+            )
+            # Keep the first general form deliberately Float32-only.  CuTe's
+            # promotion rules for narrow floats and integers are operation
+            # dependent; widening this requires a complete promotion lattice.
+            if dtype != "cutlass.Float32":
+                continue
+            math_calls = sum(
+                isinstance(node, ast.Call)
+                and _call_path(node.func) in _PURE_CUTE_MATH_CALLS
+                for node in ast.walk(normalized)
+            )
+            if math_calls == 0:
+                continue
+            candidates.append(
+                _VectorCandidate(
+                    info,
+                    body_index,
+                    stmt,
+                    target_name,
+                    ast.dump(normalized, include_attributes=False),
+                    dtype,
+                    resolver.selected_statement_ids,
+                    resolver.cache_access_ids,
+                    resolver.cache_store_ids,
+                    resolver.cache_names,
+                    math_calls,
+                    sum(1 for _ in ast.walk(normalized)),
+                )
+            )
+    return candidates
+
+
+def _fresh_names(occupied: set[str], count: int) -> list[str]:
+    result: list[str] = []
+    suffix = 0
+    while len(result) < count:
+        candidate = f"_lane_invariant_{suffix}"
+        suffix += 1
+        if candidate not in occupied:
+            occupied.add(candidate)
+            result.append(candidate)
+    return result
+
+
+class _RenameNames(ast.NodeTransformer):
+    def __init__(self, renames: dict[str, str]) -> None:
+        self.renames = renames
+
+    def visit_Name(self, node: ast.Name) -> ast.Name:
+        replacement = self.renames.get(node.id)
+        if replacement is None:
+            return node
+        return ast.copy_location(ast.Name(id=replacement, ctx=node.ctx), node)
+
+
+def _rewrite_selected_loop_body(
+    info: _ConstexprLoopInfo,
+    *,
+    selected_statement_ids: set[int],
+    cache_store_ids: set[int],
+    replacements: dict[int, ast.Assign],
+    live_out: set[str],
+) -> None:
+    live = set(live_out)
+    kept_reversed: list[ast.stmt] = []
+    for stmt in reversed(info.loop.body):
+        statement_id = id(stmt)
+        replacement = replacements.get(statement_id)
+        if replacement is not None:
+            effects = _statement_effects(replacement)
+            live.difference_update(effects.writes)
+            live.update(effects.live_in)
+            kept_reversed.append(replacement)
+            continue
+        if statement_id in cache_store_ids:
+            continue
+        if statement_id in selected_statement_ids:
+            if not (
+                isinstance(stmt, ast.Assign)
+                and len(stmt.targets) == 1
+                and isinstance(stmt.targets[0], ast.Name)
+                and stmt.targets[0].id in live
+            ):
+                continue
+        effects = _statement_effects(stmt)
+        live.difference_update(effects.writes)
+        live.update(effects.live_in)
+        kept_reversed.append(stmt)
+    info.loop.body = list(reversed(kept_reversed))
+
+
+def _live_before(statements: list[ast.stmt]) -> set[str]:
+    live: set[str] = set()
+    for stmt in reversed(statements):
+        effects = _statement_effects(stmt)
+        live.difference_update(effects.writes)
+        live.update(effects.live_in)
+    return live
+
+
+def _prune_selected_outer_assignments(
+    loop: ast.For, selected_statement_ids: set[int]
+) -> None:
+    live: set[str] = set()
+    kept_reversed: list[ast.stmt] = []
+    for stmt in reversed(loop.body):
+        effects = _statement_effects(stmt)
+        if (
+            id(stmt) in selected_statement_ids
+            and isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and stmt.targets[0].id not in live
+        ):
+            continue
+        live.difference_update(effects.writes)
+        live.update(effects.live_in)
+        kept_reversed.append(stmt)
+    loop.body = list(reversed(kept_reversed))
+
+
+def _selected_cache_dependencies_are_private(
+    loop: ast.For,
+    group: list[_VectorCandidate],
+    selected_statement_ids: set[int],
+    cache_store_ids: set[int],
+    cache_names: set[str],
+) -> bool:
+    terminal_ids = {id(candidate.statement) for candidate in group}
+    terminal_names = {candidate.target_name for candidate in group}
+    assignments = [
+        node
+        for node in ast.walk(loop)
+        if isinstance(node, ast.Assign)
+        and id(node) in selected_statement_ids - terminal_ids
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+    ]
+    cache_dependent_names = {
+        cast("ast.Name", stmt.targets[0]).id
+        for stmt in assignments
+        if any(
+            isinstance(node, ast.Subscript)
+            and isinstance(node.ctx, ast.Load)
+            and _subscript_root(node) in cache_names
+            for node in ast.walk(stmt.value)
+        )
+    }
+    changed = True
+    while changed:
+        previous_size = len(cache_dependent_names)
+        cache_dependent_names.update(
+            cast("ast.Name", stmt.targets[0]).id
+            for stmt in assignments
+            if _names_read(stmt.value) & cache_dependent_names
+        )
+        changed = len(cache_dependent_names) != previous_size
+    if cache_dependent_names & terminal_names:
+        return False
+    allowed_owners = selected_statement_ids | cache_store_ids
+
+    class _ReadOwnerVisitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.owner: int | None = None
+            self.external_read = False
+
+        def generic_visit(self, node: ast.AST) -> None:
+            previous = self.owner
+            if isinstance(node, ast.stmt):
+                self.owner = id(node)
+            super().generic_visit(node)
+            self.owner = previous
+
+        def visit_Name(self, node: ast.Name) -> None:
+            if (
+                isinstance(node.ctx, ast.Load)
+                and node.id in cache_dependent_names
+                and self.owner not in allowed_owners
+            ):
+                self.external_read = True
+
+    visitor = _ReadOwnerVisitor()
+    visitor.visit(loop)
+    return not visitor.external_read
+
+
+def _hoist_lane_invariant_constexpr_chain(
+    loop: ast.For,
+    *,
+    lane_extent: int,
+    tensor_names: set[str],
+    tensor_dtypes: dict[str, str],
+    proven_disjoint_tensor_pairs: set[frozenset[str]],
+    rename_groups: dict[str, str],
+    rmem: dict[str, _RmemInfo],
+    all_cache_access_counts: dict[str, int],
+    non_subscript_access_names: set[str],
+    obsolete_rmem: set[str],
+    float_scalar_names: set[str],
+    occupied_names: set[str],
+) -> list[ast.stmt]:
+    """Cache one repeated row-invariant constexpr-lane value in registers."""
+    if (
+        not isinstance(loop.target, ast.Name)
+        or not _has_only_known_effects(loop)
+        or any(
+            isinstance(
+                node,
+                (
+                    ast.Break,
+                    ast.Continue,
+                    ast.Raise,
+                    ast.Return,
+                    ast.Yield,
+                    ast.YieldFrom,
+                ),
+            )
+            for node in ast.walk(loop)
+        )
+    ):
+        return [loop]
+    infos = [
+        info
+        for index, stmt in enumerate(loop.body)
+        if (info := _constexpr_loop_info(stmt, index)) is not None
+    ]
+    if len(infos) < 2:
+        return [loop]
+    stores = _cache_stores(infos, rmem)
+    candidates = _build_vector_candidates(
+        loop,
+        infos,
+        stores,
+        rmem,
+        tensor_dtypes,
+        tensor_names,
+        float_scalar_names,
+        rename_groups,
+    )
+    groups: dict[tuple[int, str, str], list[_VectorCandidate]] = {}
+    for candidate in candidates:
+        groups.setdefault(
+            (candidate.info.extent, candidate.dtype, candidate.canonical), []
+        ).append(candidate)
+    viable = [
+        group
+        for group in groups.values()
+        if len({id(candidate.info.loop) for candidate in group}) >= 2
+    ]
+    if not viable:
+        return [loop]
+    viable.sort(
+        key=lambda group: (
+            max(candidate.math_calls for candidate in group),
+            max(candidate.node_count for candidate in group),
+        ),
+        reverse=True,
+    )
+    group = viable[0]
+    selected_statement_ids = set().union(
+        *(candidate.selected_statement_ids for candidate in group)
+    )
+    cache_store_ids = set().union(*(candidate.cache_store_ids for candidate in group))
+    cache_names = set().union(*(candidate.cache_names for candidate in group))
+    cache_access_ids: dict[str, set[int]] = {}
+    for candidate in group:
+        for name, accesses in candidate.cache_access_ids.items():
+            cache_access_ids.setdefault(name, set()).update(accesses)
+    if not _selected_cache_dependencies_are_private(
+        loop,
+        group,
+        selected_statement_ids,
+        cache_store_ids,
+        cache_names,
+    ):
+        return [loop]
+    if (
+        not cache_names
+        or any(
+            name not in rmem
+            or name in non_subscript_access_names
+            or all_cache_access_counts.get(name, 0)
+            != len(cache_access_ids.get(name, set()))
+            for name in cache_names
+        )
+        or cache_names & set(_statement_effects(loop).writes)
+    ):
+        return [loop]
+    extent = group[0].info.extent
+    dtype = group[0].dtype
+    reusable = sorted(
+        name
+        for name in cache_names
+        if rmem[name] == _RmemInfo(extent=extent, dtype=dtype)
+    )
+    if not reusable:
+        return [loop]
+    cache_name = reusable[0]
+    source = next((candidate for candidate in group if not candidate.cache_names), None)
+    if source is None:
+        return [loop]
+    movable_statement_ids = selected_statement_ids | cache_store_ids
+    if _nested_rename_alias_conflict(loop, movable_statement_ids, rename_groups):
+        return [loop]
+    selected_statements = [
+        node
+        for node in ast.walk(loop)
+        if isinstance(node, ast.stmt) and id(node) in movable_statement_ids
+    ]
+    if not all(
+        _vector_chain_expression_safe(node.value, tensor_names)
+        for node in selected_statements
+        if id(node) in cache_store_ids and isinstance(node, ast.Assign)
+    ):
+        return [loop]
+    store_roots, stores_resolved = _global_store_roots(loop, tensor_names)
+    if not stores_resolved or not _loads_may_cross_loop_writes(
+        selected_statements,
+        store_roots,
+        tensor_names,
+        proven_disjoint_tensor_pairs,
+    ):
+        return [loop]
+
+    source_top = [
+        stmt for stmt in loop.body if id(stmt) in source.selected_statement_ids
+    ]
+    source_inner = [
+        stmt
+        for stmt in source.info.loop.body
+        if id(stmt) in source.selected_statement_ids
+    ]
+    if not source_inner or source.statement not in source_inner:
+        return [loop]
+    assigned_names = [
+        cast("ast.Name", stmt.targets[0]).id
+        for stmt in [*source_top, *source_inner]
+        if isinstance(stmt, ast.Assign)
+        and len(stmt.targets) == 1
+        and isinstance(stmt.targets[0], ast.Name)
+    ]
+    fresh = _fresh_names(occupied_names, len(set(assigned_names)) + 1)
+    fresh_lane = fresh[0]
+    ordered_assigned = list(dict.fromkeys(assigned_names))
+    renames = dict(zip(ordered_assigned, fresh[1:], strict=True))
+    renames[source.info.lane_var] = fresh_lane
+    rename = _RenameNames(renames)
+    hoisted_top = [
+        rename.visit(cast("ast.stmt", _clone_ast(stmt))) for stmt in source_top
+    ]
+    hoisted_inner = [
+        rename.visit(cast("ast.stmt", _clone_ast(stmt))) for stmt in source_inner
+    ]
+    terminal_name = renames[source.target_name]
+    hoisted_inner.append(
+        statement_from_string(f"{cache_name}[{fresh_lane}] = {terminal_name}")
+    )
+    precompute = create(
+        ast.For,
+        target=create(ast.Name, id=fresh_lane, ctx=ast.Store()),
+        iter=expr_from_string(f"cutlass.range_constexpr({extent})"),
+        body=hoisted_inner,
+        orelse=[],
+        type_comment=None,
+    )
+    if not repeated_work_is_profitable(
+        [*cast("list[ast.stmt]", hoisted_top), precompute],
+        repeat_extent=lane_extent,
+        # Only the cached vector remains live across the row loop; scalar
+        # temporaries feeding its precompute die before that loop starts.
+        live_scalars=extent,
+    ):
+        return [loop]
+
+    replacements: dict[int, ast.Assign] = {}
+    for candidate in group:
+        replacement = statement_from_string(
+            f"{candidate.target_name} = {cache_name}[{candidate.info.lane_var}]"
+        )
+        assert isinstance(replacement, ast.Assign)
+        replacements[id(candidate.statement)] = replacement
+    for info in reversed(infos):
+        live_out = _live_before(loop.body[info.outer_index + 1 :])
+        _rewrite_selected_loop_body(
+            info,
+            selected_statement_ids=selected_statement_ids,
+            cache_store_ids=cache_store_ids,
+            replacements=replacements,
+            live_out=live_out,
+        )
+    _prune_selected_outer_assignments(loop, selected_statement_ids)
+    obsolete_rmem.update(cache_names - {cache_name})
+    return [*cast("list[ast.stmt]", hoisted_top), precompute, loop]
+
+
+def _hoist_constexpr_scalar_invariants(
+    loop: ast.For,
+    tensor_names: set[str],
+    proven_disjoint_tensor_pairs: set[frozenset[str]],
+    rename_groups: dict[str, str],
+) -> list[ast.stmt]:
+    """Move scalar assignments independent of a positive constexpr loop.
+
+    This is intentionally limited to a flat generated assignment block.  It
+    primarily removes head-scalar loads, exp/rcp, and norm rsqrt operations
+    that would otherwise execute once per vector lane.
+    """
+    if not _is_positive_constexpr_loop(loop) or not isinstance(loop.target, ast.Name):
+        return [loop]
+    loop_extent = _static_lane_extent(loop)
+    assert loop_extent is not None
+    body = list(loop.body)
+    if not body or not all(isinstance(stmt, ast.Assign) for stmt in body):
+        return [loop]
+    # An unknown call can mutate an otherwise invariant scalar through an
+    # opaque alias.  Generated arithmetic/load calls are all covered by the
+    # explicit purity grammar.
+    if any(
+        isinstance(child, ast.Call)
+        and not (_is_allowed_pure_call(child) or _is_store_call(child))
+        for stmt in body
+        for child in ast.walk(stmt)
+    ):
+        return [loop]
+
+    effects = [_statement_effects(stmt) for stmt in body]
+    write_sites: dict[str, list[int]] = {}
+    for index, effect in enumerate(effects):
+        for name in effect.writes:
+            write_sites.setdefault(name, []).append(index)
+
+    selected: set[int] = set()
+    for index, stmt in enumerate(body):
+        if not (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+        ):
+            continue
+        target = stmt.targets[0].id
+        if write_sites.get(target) != [index]:
+            continue
+        if not _is_hoistable_statement(stmt, tensor_names):
+            continue
+        dependencies_ok = True
+        for name in effects[index].live_in:
+            if name == loop.target.id:
+                dependencies_ok = False
+                break
+            sites = write_sites.get(name)
+            if sites is not None and (len(sites) != 1 or sites[0] not in selected):
+                dependencies_ok = False
+                break
+        if dependencies_ok:
+            selected.add(index)
+
+    if not selected:
+        return [loop]
+    if not _slice_preserves_reaching_definitions(body, selected):
+        return [loop]
+    if _has_rename_alias_conflict(body, selected, rename_groups):
+        return [loop]
+    selected_external_reads = _slice_external_reads(body, selected)
+    if any(selected_external_reads & _mutation_roots(stmt) for stmt in body):
+        return [loop]
+    store_roots, stores_resolved = _global_store_roots(loop, tensor_names)
+    if not stores_resolved or not _loads_may_cross_loop_writes(
+        (body[index] for index in sorted(selected)),
+        store_roots,
+        tensor_names,
+        proven_disjoint_tensor_pairs,
+    ):
+        return [loop]
+    invariant = [body[index] for index in sorted(selected)]
+    remainder = [stmt for index, stmt in enumerate(body) if index not in selected]
+    if not remainder:
+        return [loop]
+    invariant_writes = set().union(
+        *(set(effects[index].writes) for index in selected),
+        set(),
+    )
+    remainder_reads = _names_read(ast.Module(body=remainder, type_ignores=[]))
+    if not repeated_work_is_profitable(
+        invariant,
+        repeat_extent=loop_extent,
+        live_scalars=max(1, len(invariant_writes & remainder_reads)),
+    ):
+        return [loop]
+    return [*invariant, _clone_lane_loop(loop, remainder)]
+
+
+def _rewrite_inner_constexpr_loops(
+    body: list[ast.stmt],
+    tensor_names: set[str],
+    proven_disjoint_tensor_pairs: set[frozenset[str]],
+    rename_groups: dict[str, str],
+) -> list[ast.stmt]:
+    result: list[ast.stmt] = []
+    for stmt in body:
+        for field in ("body", "orelse", "finalbody"):
+            child = getattr(stmt, field, None)
+            if isinstance(child, list) and all(
+                isinstance(item, ast.stmt) for item in child
+            ):
+                setattr(
+                    stmt,
+                    field,
+                    _rewrite_inner_constexpr_loops(
+                        child,
+                        tensor_names,
+                        proven_disjoint_tensor_pairs,
+                        rename_groups,
+                    ),
+                )
+        if isinstance(stmt, ast.For) and _is_positive_constexpr_loop(stmt):
+            result.extend(
+                _hoist_constexpr_scalar_invariants(
+                    stmt,
+                    tensor_names,
+                    proven_disjoint_tensor_pairs,
+                    rename_groups,
+                )
+            )
+        else:
+            result.append(stmt)
+    return result
+
+
+def _hoist_repeated_scalar_invariants(
+    loop: ast.For,
+    lane_var: str,
+    lane_extent: int,
+    tensor_names: set[str],
+    proven_disjoint_tensor_pairs: set[frozenset[str]],
+    rename_groups: dict[str, str],
+) -> list[ast.stmt]:
+    """Hoist identical scalar definitions shared by every row iteration.
+
+    Inner-loop LICM exposes expensive scalar chains at row-loop scope.  The
+    generated code often repeats the exact same definition in its projection
+    and state-update sweeps.  A name is eligible only when *every* write to it
+    is a simple assignment with the same RHS and all in-loop dependencies are
+    themselves already proven invariant.
+    """
+    body = list(loop.body)
+    effects = [_statement_effects(stmt) for stmt in body]
+    all_write_sites: dict[str, list[int]] = {}
+    direct_assignments: dict[str, list[int]] = {}
+    for index, (stmt, effect) in enumerate(zip(body, effects, strict=True)):
+        for name in effect.writes:
+            all_write_sites.setdefault(name, []).append(index)
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+        ):
+            direct_assignments.setdefault(stmt.targets[0].id, []).append(index)
+
+    selected_names: set[str] = set()
+    selected_indices: set[int] = set()
+    ordered_names = sorted(
+        direct_assignments, key=lambda name: direct_assignments[name][0]
+    )
+    changed = True
+    while changed:
+        changed = False
+        for name in ordered_names:
+            if name in selected_names:
+                continue
+            sites = direct_assignments[name]
+            if all_write_sites.get(name) != sites:
+                continue
+            first = cast("ast.Assign", body[sites[0]])
+            if isinstance(
+                first.value,
+                (
+                    ast.Dict,
+                    ast.DictComp,
+                    ast.List,
+                    ast.ListComp,
+                    ast.Set,
+                    ast.SetComp,
+                    ast.Tuple,
+                ),
+            ):
+                continue
+            rhs = ast.unparse(first.value)
+            if any(
+                ast.unparse(cast("ast.Assign", body[index]).value) != rhs
+                or not _is_hoistable_statement(body[index], tensor_names)
+                for index in sites
+            ):
+                continue
+            dependencies = set().union(*(effects[index].live_in for index in sites))
+            if lane_var in dependencies or name in dependencies:
+                continue
+            dependencies_ok = True
+            for dependency in dependencies:
+                dependency_sites = all_write_sites.get(dependency)
+                if dependency_sites is None:
+                    continue
+                if dependency not in selected_names:
+                    dependencies_ok = False
+                    break
+                if min(dependency_sites) > min(sites):
+                    dependencies_ok = False
+                    break
+            if not dependencies_ok:
+                continue
+            tentative_indices = selected_indices | set(sites)
+            tentative_names = selected_names | {name}
+            if not _repeated_scalar_reaching_safe(
+                body, tentative_names, direct_assignments
+            ):
+                continue
+            if _has_rename_alias_conflict(body, tentative_indices, rename_groups):
+                continue
+            tentative_external_reads = _slice_external_reads(body, tentative_indices)
+            if any(
+                tentative_external_reads & _mutation_roots(stmt)
+                for index, stmt in enumerate(body)
+                if index not in tentative_indices
+            ):
+                continue
+            selected_names.add(name)
+            selected_indices.update(sites)
+            changed = True
+
+    if not selected_indices:
+        return [loop]
+    # Opaque calls elsewhere in the row loop may mutate a loaded source behind
+    # an alias.  The generated calls accepted here are explicit and audited.
+    if not _has_only_known_effects(loop):
+        return [loop]
+
+    store_roots, stores_resolved = _global_store_roots(loop, tensor_names)
+    if not stores_resolved or not _loads_may_cross_loop_writes(
+        (body[index] for index in sorted(selected_indices)),
+        store_roots,
+        tensor_names,
+        proven_disjoint_tensor_pairs,
+    ):
+        return [loop]
+    # Keep one canonical definition per name, in first-definition order.
+    hoisted = [
+        body[direct_assignments[name][0]]
+        for name in ordered_names
+        if name in selected_names
+    ]
+    remainder = [
+        stmt for index, stmt in enumerate(body) if index not in selected_indices
+    ]
+    if not remainder:
+        return [loop]
+    remainder_reads = _names_read(ast.Module(body=remainder, type_ignores=[]))
+    if not repeated_work_is_profitable(
+        hoisted,
+        repeat_extent=lane_extent,
+        live_scalars=max(1, len(selected_names & remainder_reads)),
+    ):
+        return [loop]
+    return [*hoisted, _clone_lane_loop(loop, remainder)]
+
+
+def _clone_lane_loop(loop: ast.For, body: list[ast.stmt]) -> ast.For:
+    assert isinstance(loop.target, ast.Name)
+    result = create(
+        ast.For,
+        target=create(ast.Name, id=loop.target.id, ctx=ast.Store()),
+        iter=expr_from_string(ast.unparse(loop.iter)),
+        body=body,
+        orelse=[],
+        type_comment=loop.type_comment,
+    )
+    lane_var = getattr(loop, HELION_LANE_LOOP_VAR_ATTR, None)
+    if lane_var is not None:
+        setattr(result, HELION_LANE_LOOP_VAR_ATTR, lane_var)
+    return result
+
+
+def _hoist_reductions_from_loop(
+    loop: ast.For,
+    lane_var: str,
+    lane_extent: int,
+    tensor_names: set[str],
+    proven_disjoint_tensor_pairs: set[frozenset[str]],
+    rename_groups: dict[str, str],
+) -> list[ast.stmt]:
+    if not _has_only_known_effects(loop):
+        return [loop]
+    body = list(loop.body)
+    selected: set[int] = set()
+    for index, stmt in enumerate(body):
+        if not _is_warp_reduction_assignment(stmt):
+            continue
+        candidate = _backward_slice(body, index)
+        if not candidate:
+            continue
+        external_reads = _slice_external_reads(body, candidate)
+        if lane_var in external_reads:
+            continue
+        if not all(_is_hoistable_statement(body[i], tensor_names) for i in candidate):
+            continue
+        combined = selected | candidate
+        if not _slice_preserves_reaching_definitions(body, combined):
+            continue
+        if _has_rename_alias_conflict(body, combined, rename_groups):
+            continue
+        combined_external_reads = _slice_external_reads(body, combined)
+        if any(
+            combined_external_reads & _mutation_roots(other)
+            for other_index, other in enumerate(body)
+            if other_index not in combined
+        ):
+            continue
+        marginal = candidate - selected
+        marginal_writes = set().union(
+            *(set(_statement_effects(body[i]).writes) for i in marginal),
+            set(),
+        )
+        remaining_reads = _names_read(
+            ast.Module(
+                body=[
+                    other
+                    for other_index, other in enumerate(body)
+                    if other_index not in combined
+                ],
+                type_ignores=[],
+            )
+        )
+        if not repeated_work_is_profitable(
+            (body[i] for i in sorted(marginal)),
+            repeat_extent=lane_extent,
+            live_scalars=max(1, len(marginal_writes & remaining_reads)),
+        ):
+            continue
+        selected = combined
+
+    if not selected:
+        return [loop]
+    store_roots, stores_resolved = _global_store_roots(loop, tensor_names)
+    if not stores_resolved or not _loads_may_cross_loop_writes(
+        (body[index] for index in sorted(selected)),
+        store_roots,
+        tensor_names,
+        proven_disjoint_tensor_pairs,
+    ):
+        return [loop]
+    hoisted = [body[index] for index in sorted(selected)]
+    remainder = [stmt for index, stmt in enumerate(body) if index not in selected]
+    if not remainder:
+        return [loop]
+    remaining_loop = _clone_lane_loop(loop, remainder)
+    return [
+        *hoisted,
+        *_hoist_repeated_scalar_invariants(
+            remaining_loop,
+            lane_var,
+            lane_extent,
+            tensor_names,
+            proven_disjoint_tensor_pairs,
+            rename_groups,
+        ),
+    ]
+
+
+def _try_unswitch_and_hoist(
+    loop: ast.For,
+    lane_var: str,
+    lane_extent: int,
+    tensor_names: set[str],
+    tensor_dtypes: dict[str, str],
+    proven_disjoint_tensor_pairs: set[frozenset[str]],
+    rename_groups: dict[str, str],
+    uniform_names: set[str],
+    float_scalar_names: set[str],
+    rmem: dict[str, _RmemInfo],
+    all_cache_access_counts: dict[str, int],
+    non_subscript_access_names: set[str],
+    obsolete_rmem: set[str],
+    occupied_names: set[str],
+) -> list[ast.stmt] | None:
+    if not _has_only_known_effects(loop):
+        return None
+    body = list(loop.body)
+    if not body or not isinstance(body[-1], ast.If):
+        return None
+    branch = body[-1]
+    if not isinstance(branch.test, ast.Name):
+        return None
+    prefix = body[:-1]
+    condition_names = _names_read(branch.test)
+    selected: set[int] = set()
+    needed = set(condition_names)
+    for index in range(len(prefix) - 1, -1, -1):
+        effects = _statement_effects(prefix[index])
+        if not (set(effects.writes) & needed):
+            continue
+        selected.add(index)
+        needed.difference_update(effects.writes)
+        needed.update(effects.live_in)
+    if lane_var in needed:
+        return None
+    if not all(_is_uniform_name(name, uniform_names, rename_groups) for name in needed):
+        return None
+    condition_slice = [prefix[index] for index in sorted(selected)]
+    if not all(_is_hoistable_statement(stmt, tensor_names) for stmt in condition_slice):
+        return None
+    if not _slice_preserves_reaching_definitions(prefix, selected):
+        return None
+    if _has_rename_alias_conflict(prefix, selected, rename_groups):
+        return None
+    protected_condition_names = set(condition_names) | set(needed)
+    for index in selected:
+        effects = _statement_effects(prefix[index])
+        protected_condition_names.update(effects.live_in)
+        protected_condition_names.update(effects.writes)
+    remaining_statements = [
+        *(stmt for index, stmt in enumerate(prefix) if index not in selected),
+        *branch.body,
+        *branch.orelse,
+    ]
+    protected_condition_canonical = {
+        _canonical_name(name, rename_groups) for name in protected_condition_names
+    }
+    if any(
+        protected_condition_canonical
+        & {
+            _canonical_name(name, rename_groups)
+            for name in (set(_statement_effects(stmt).writes) | _mutation_roots(stmt))
+        }
+        for stmt in remaining_statements
+    ):
+        return None
+    # A guard may be unswitched only when its condition is uniform across the
+    # thread block.  The generated prefix is self-contained, so direct CUDA
+    # thread-coordinate use is a sufficient fail-closed rejection here.
+    condition_text = "\n".join(
+        [ast.unparse(branch.test), *(ast.unparse(stmt) for stmt in condition_slice)]
+    )
+    if any(token in condition_text for token in ("thread_idx", "lane_idx", "warp_idx")):
+        return None
+    store_roots, stores_resolved = _global_store_roots(loop, tensor_names)
+    if not stores_resolved or not _loads_may_cross_loop_writes(
+        condition_slice,
+        store_roots,
+        tensor_names,
+        proven_disjoint_tensor_pairs,
+    ):
+        return None
+
+    selected_set = set(selected)
+    lane_prefix = [
+        statement_from_string(ast.unparse(stmt))
+        for index, stmt in enumerate(prefix)
+        if index not in selected_set
+    ]
+
+    def make_branch(statements: list[ast.stmt]) -> ast.For:
+        branch_body = _rewrite_inner_constexpr_loops(
+            [
+                *(statement_from_string(ast.unparse(stmt)) for stmt in lane_prefix),
+                *(statement_from_string(ast.unparse(stmt)) for stmt in statements),
+            ],
+            tensor_names,
+            proven_disjoint_tensor_pairs,
+            rename_groups,
+        )
+        return _clone_lane_loop(
+            loop,
+            branch_body,
+        )
+
+    body_loop = make_branch(branch.body)
+    else_loop = make_branch(branch.orelse)
+    lifted = create(
+        ast.If,
+        test=expr_from_string(ast.unparse(branch.test)),
+        body=[body_loop],
+        orelse=[else_loop],
+    )
+    old_access_counts = {
+        name: len(accesses)
+        for name, accesses in _collect_subscript_accesses([loop]).items()
+    }
+    new_access_counts = {
+        name: len(accesses)
+        for name, accesses in _collect_subscript_accesses(
+            [*condition_slice, lifted]
+        ).items()
+    }
+    effective_access_counts = dict(all_cache_access_counts)
+    for name in old_access_counts.keys() | new_access_counts.keys():
+        effective_access_counts[name] = (
+            effective_access_counts.get(name, 0)
+            - old_access_counts.get(name, 0)
+            + new_access_counts.get(name, 0)
+        )
+
+    def optimize_branch(branch_loop: ast.For) -> tuple[list[ast.stmt], bool]:
+        vectorized = _hoist_lane_invariant_constexpr_chain(
+            branch_loop,
+            lane_extent=lane_extent,
+            tensor_names=tensor_names,
+            tensor_dtypes=tensor_dtypes,
+            proven_disjoint_tensor_pairs=proven_disjoint_tensor_pairs,
+            rename_groups=rename_groups,
+            rmem=rmem,
+            all_cache_access_counts=effective_access_counts,
+            non_subscript_access_names=non_subscript_access_names,
+            obsolete_rmem=obsolete_rmem,
+            float_scalar_names=float_scalar_names,
+            occupied_names=occupied_names,
+        )
+        rewritten_loop = cast("ast.For", vectorized[-1])
+        rewritten = [
+            *vectorized[:-1],
+            *_hoist_reductions_from_loop(
+                rewritten_loop,
+                lane_var,
+                lane_extent,
+                tensor_names,
+                proven_disjoint_tensor_pairs,
+                rename_groups,
+            ),
+        ]
+        return rewritten, len(rewritten) > 1
+
+    old_obsolete_rmem = set(obsolete_rmem)
+    old_occupied_names = set(occupied_names)
+    lifted.body, body_changed = optimize_branch(body_loop)
+    lifted.orelse, else_changed = optimize_branch(else_loop)
+
+    def profitable_path(rewritten: list[ast.stmt]) -> bool:
+        moved = [*condition_slice, *rewritten[:-1]]
+        moved_writes = set().union(
+            *(set(_statement_effects(statement).writes) for statement in moved),
+            set(),
+        )
+        remaining_reads = _names_read(rewritten[-1]) | _names_read(branch.test)
+        return repeated_work_is_profitable(
+            moved,
+            repeat_extent=lane_extent,
+            live_scalars=max(1, len(moved_writes & remaining_reads)),
+            # Unswitching duplicates a branch and loop header in the static
+            # kernel even though only one path executes.  Charge a small fixed
+            # cost so a two-row loop is not rewritten for a trivial predicate.
+            fixed_work=2,
+        )
+
+    changed_paths = [
+        rewritten
+        for rewritten, changed in (
+            (lifted.body, body_changed),
+            (lifted.orelse, else_changed),
+        )
+        if changed
+    ]
+    if changed_paths:
+        profitable = all(profitable_path(rewritten) for rewritten in changed_paths)
+    else:
+        profitable = bool(condition_slice) and repeated_work_is_profitable(
+            condition_slice,
+            repeat_extent=lane_extent,
+            live_scalars=1,
+            fixed_work=2,
+        )
+    if not profitable:
+        obsolete_rmem.clear()
+        obsolete_rmem.update(old_obsolete_rmem)
+        occupied_names.clear()
+        occupied_names.update(old_occupied_names)
+        return None
+    return [*condition_slice, lifted]
+
+
+def _rewrite_block(
+    body: list[ast.stmt],
+    tensor_names: set[str],
+    tensor_dtypes: dict[str, str],
+    proven_disjoint_tensor_pairs: set[frozenset[str]],
+    rename_groups: dict[str, str],
+    uniform_names: set[str],
+    float_scalar_names: set[str],
+    thread_block_dims: tuple[int, int, int] | None,
+    rmem: dict[str, _RmemInfo],
+    all_cache_access_counts: dict[str, int],
+    non_subscript_access_names: set[str],
+    obsolete_rmem: set[str],
+    occupied_names: set[str],
+) -> list[ast.stmt]:
+    result: list[ast.stmt] = []
+    known_uniform = set(uniform_names)
+    known_rmem = dict(rmem)
+    for stmt in body:
+        lane_var = getattr(stmt, HELION_LANE_LOOP_VAR_ATTR, None)
+        extent = _static_lane_extent(stmt) if isinstance(stmt, ast.For) else None
+        if (
+            isinstance(stmt, ast.For)
+            and isinstance(lane_var, str)
+            and isinstance(stmt.target, ast.Name)
+            and stmt.target.id == lane_var
+            and not stmt.orelse
+            and extent is not None
+            and extent > 1
+        ):
+            stmt = _simplify_full_lane_bounds(
+                stmt,
+                lane_var,
+                extent,
+                thread_block_dims,
+            )
+            replacement = _try_unswitch_and_hoist(
+                stmt,
+                lane_var,
+                extent,
+                tensor_names,
+                tensor_dtypes,
+                proven_disjoint_tensor_pairs,
+                rename_groups,
+                known_uniform,
+                float_scalar_names,
+                known_rmem,
+                all_cache_access_counts,
+                non_subscript_access_names,
+                obsolete_rmem,
+                occupied_names,
+            )
+            if replacement is not None:
+                result.extend(replacement)
+                for rewritten in replacement:
+                    _update_uniform_names(rewritten, known_uniform, rename_groups)
+                continue
+            vectorized = _hoist_lane_invariant_constexpr_chain(
+                stmt,
+                lane_extent=extent,
+                tensor_names=tensor_names,
+                tensor_dtypes=tensor_dtypes,
+                proven_disjoint_tensor_pairs=proven_disjoint_tensor_pairs,
+                rename_groups=rename_groups,
+                rmem=known_rmem,
+                all_cache_access_counts=all_cache_access_counts,
+                non_subscript_access_names=non_subscript_access_names,
+                obsolete_rmem=obsolete_rmem,
+                float_scalar_names=float_scalar_names,
+                occupied_names=occupied_names,
+            )
+            rewritten_loop = cast("ast.For", vectorized[-1])
+            replacement = [
+                *vectorized[:-1],
+                *_hoist_reductions_from_loop(
+                    rewritten_loop,
+                    lane_var,
+                    extent,
+                    tensor_names,
+                    proven_disjoint_tensor_pairs,
+                    rename_groups,
+                ),
+            ]
+            if len(replacement) > 1:
+                result.extend(replacement)
+                for rewritten in replacement:
+                    _update_uniform_names(rewritten, known_uniform, rename_groups)
+                continue
+        for field in ("body", "orelse", "finalbody"):
+            child = getattr(stmt, field, None)
+            if isinstance(child, list) and all(
+                isinstance(item, ast.stmt) for item in child
+            ):
+                setattr(
+                    stmt,
+                    field,
+                    _rewrite_block(
+                        child,
+                        tensor_names,
+                        tensor_dtypes,
+                        proven_disjoint_tensor_pairs,
+                        rename_groups,
+                        set(known_uniform),
+                        float_scalar_names,
+                        thread_block_dims,
+                        dict(known_rmem),
+                        all_cache_access_counts,
+                        non_subscript_access_names,
+                        obsolete_rmem,
+                        occupied_names,
+                    ),
+                )
+        result.append(stmt)
+        _update_uniform_names(stmt, known_uniform, rename_groups)
+        declaration = _rmem_declaration(stmt)
+        written = set(_statement_effects(stmt).writes)
+        for name in written:
+            known_rmem.pop(name, None)
+        if declaration is not None:
+            known_rmem[declaration[0]] = declaration[1]
+    return result
+
+
+def _prune_obsolete_rmem_declarations(
+    body: list[ast.stmt], obsolete_rmem: set[str]
+) -> list[ast.stmt]:
+    loaded = {
+        node.id
+        for stmt in body
+        for node in ast.walk(stmt)
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
+    }
+    result: list[ast.stmt] = []
+    for stmt in body:
+        declaration = _rmem_declaration(stmt)
+        if (
+            declaration is not None
+            and declaration[0] in obsolete_rmem
+            and declaration[0] not in loaded
+        ):
+            continue
+        for field in ("body", "orelse", "finalbody"):
+            child = getattr(stmt, field, None)
+            if isinstance(child, list) and all(
+                isinstance(item, ast.stmt) for item in child
+            ):
+                setattr(
+                    stmt,
+                    field,
+                    _prune_obsolete_rmem_declarations(child, obsolete_rmem),
+                )
+        result.append(stmt)
+    return result
+
+
+def hoist_lane_invariant_reductions(
+    body: list[ast.stmt],
+    *,
+    tensor_names: set[str],
+    tensor_dtypes: dict[str, str] | None = None,
+    proven_disjoint_tensor_pairs: set[frozenset[str]] | None = None,
+    rename_groups: dict[str, str] | None = None,
+    uniform_names: set[str] | None = None,
+    float_scalar_names: set[str] | None = None,
+    thread_block_dims: tuple[int, int, int] | None = None,
+) -> list[ast.stmt]:
+    """Hoist profitable row-invariant reductions from grid lane loops."""
+    renames = rename_groups or {}
+    initial_uniform = {
+        _canonical_name(name, renames)
+        for name in {*_UNIFORM_GLOBAL_NAMES, *tensor_names, *(uniform_names or set())}
+    }
+    float_scalars = {
+        _canonical_name(name, renames) for name in (float_scalar_names or set())
+    }
+    all_cache_access_counts = {
+        name: len(accesses)
+        for name, accesses in _collect_subscript_accesses(body).items()
+    }
+    non_subscript_access_names = _non_subscript_access_names(body)
+    occupied_names = {
+        node.id
+        for stmt in body
+        for node in ast.walk(stmt)
+        if isinstance(node, ast.Name)
+    }
+    occupied_names.update(renames)
+    occupied_names.update(renames.values())
+    occupied_names.update(_canonical_name(name, renames) for name in renames)
+    obsolete_rmem: set[str] = set()
+    result = _rewrite_block(
+        body,
+        tensor_names,
+        tensor_dtypes or {},
+        proven_disjoint_tensor_pairs or set(),
+        renames,
+        initial_uniform,
+        float_scalars,
+        thread_block_dims,
+        {},
+        all_cache_access_counts,
+        non_subscript_access_names,
+        obsolete_rmem,
+        occupied_names,
+    )
+    result = _prune_obsolete_rmem_declarations(result, obsolete_rmem)
+    return [ast.fix_missing_locations(stmt) for stmt in result]

--- a/helion/_compiler/cute/layout_propagation.py
+++ b/helion/_compiler/cute/layout_propagation.py
@@ -21,6 +21,7 @@ import torch
 
 from ... import exc
 from ...language import _tracing_ops
+from ...language import matmul_ops
 from ...language import memory_ops
 from ...language import reduce_ops
 from ..compile_environment import CompileEnvironment
@@ -397,13 +398,13 @@ def _forward_propagate(graph_info: GraphInfo) -> None:
         if result is None:
             continue
         layout, input_node = result
-        # Shape-collapsing reductions (e.g. ``aten.amax``/``aten.sum``) cover
-        # fewer elements than their input.  Forward inheriting the input layout
-        # would describe the wrong tile, so leave the output flexible and let
-        # backward propagation pick a layout that matches the reduced tile.
-        if _is_reduction_target(node.target) and not _numels_match(
-            _node_tile_numel(node), _node_tile_numel(input_node)
-        ):
+        if _layout_has_zero_values(layout):
+            continue
+        # Shape-changing operations cover a different tile from this input.
+        # Forward inheriting its layout would describe the wrong tile, so leave
+        # the output flexible and let another full-sized operand or a consumer
+        # choose it.  This covers reductions as well as broadcast expansion.
+        if _is_shape_changing_passthrough_user(input_node, node):
             continue
         inherited = layout.with_tag(LayoutTag.INHERITED)
         constraint.preferred_input = inherited
@@ -451,7 +452,7 @@ def _backward_propagate(graph_info: GraphInfo) -> None:
 
         # All users agree on the same layout?
         first = user_layouts[0]
-        if all(first.is_compatible(ul) for ul in user_layouts[1:]):
+        if all(_layouts_compatible(first, ul) for ul in user_layouts[1:]):
             inherited = first.with_tag(LayoutTag.INHERITED)
             if _is_passthrough_layout_node(node):
                 constraint.preferred_input = inherited
@@ -496,8 +497,12 @@ def _insert_layout_changes(graph_info: GraphInfo) -> None:
             if user_lc is None or user_lc.input_layout is None:
                 continue
             consumer_layout = user_lc.input_layout
+            if _layout_has_zero_values(producer_layout) or _layout_has_zero_values(
+                consumer_layout
+            ):
+                continue
 
-            if producer_layout.is_compatible(consumer_layout):
+            if _layouts_compatible(producer_layout, consumer_layout):
                 continue
 
             # Only insert a layout change when both layouts describe the
@@ -569,17 +574,20 @@ def _validate_layout_contracts(graph_info: GraphInfo) -> None:
             user_lc = user.meta.get(META_KEY)
             if user_lc is None or user_lc.input_layout is None:
                 continue
-            if user.target is reduce_ops._reduce:
+            if _is_reduction_target(user.target):
                 # Reduction lowering still has custom fallbacks for arbitrary
                 # producer layouts, so a missed relayout here is not fatal.
                 continue
-            if _is_shape_reducing_user(node, user):
-                # Shape-collapsing reductions (e.g. ``aten.amax``/``aten.sum``)
-                # consume the producer's full tile and own the layout transition
-                # to the reduced output themselves (warp/shared reduce), so a
-                # producer/consumer layout difference here is expected.
+            if _is_shape_changing_passthrough_user(node, user):
+                # Reductions and broadcast operations own their tile-shape
+                # transition, so a producer/consumer layout difference at that
+                # boundary is expected.
                 continue
             consumer_layout = user_lc.input_layout
+            if _layout_has_zero_values(producer_layout) or _layout_has_zero_values(
+                consumer_layout
+            ):
+                continue
             if (
                 producer_layout.tag is LayoutTag.MMA_ACCUMULATOR
                 and node.op == "call_function"
@@ -595,7 +603,15 @@ def _validate_layout_contracts(graph_info: GraphInfo) -> None:
                 # scalar fallback, both of which own the accumulator transition
                 # directly instead of requiring an explicit relayout node.
                 continue
-            if producer_layout.is_compatible(consumer_layout):
+            if _layouts_compatible(producer_layout, consumer_layout):
+                continue
+            if consumer_layout.tag is LayoutTag.INHERITED and _only_reaches_reduction(
+                user
+            ):
+                # Backward propagation deliberately keeps a reduction-only
+                # pointwise path from imposing its layout on a producer that
+                # also feeds a non-reduction consumer. The eventual reduction
+                # owns that layout transition, so this mismatch is expected.
                 continue
             raise exc.BackendUnsupported(
                 "cute",
@@ -635,15 +651,10 @@ def _first_input_layout_node(
 def _collect_user_layouts(node: torch.fx.Node) -> list[ThreadLayout]:
     """Collect preferred/resolved consumer input layouts from all users.
 
-    A reduction user that never received a proper reduction-axis layout and
-    instead picked up a *degenerate scalar* layout from its own consumer
-    (covering far fewer elements than the producer's own tile) cannot legally
-    describe *node*'s full tile.  Adopting such a layout would corrupt the
-    producer (every thread reading a single reduced element instead of its
-    slice of the full tile), so those reduction users are skipped.  A
-    correctly-seeded reduction keeps a full reduction-axis input layout — at
-    least as large as the producer's tile — so it is retained and continues to
-    drive the producer onto the shared reduction layout.
+    A shape-changing user cannot impose its output layout on a differently
+    sized operand.  This includes a reduction that inherited its scalar output
+    layout and a pointwise op that broadcasts a smaller input.  A reduction
+    with an explicitly seeded reduction-axis input layout remains authoritative.
     """
     layouts: list[ThreadLayout] = []
     for user in node.users:
@@ -653,8 +664,16 @@ def _collect_user_layouts(node: torch.fx.Node) -> list[ThreadLayout]:
         layout = lc.input_layout or lc.preferred_input
         if layout is None:
             continue
+        if _layout_has_zero_values(layout):
+            continue
+        if layout.tag is LayoutTag.INHERITED and _only_reaches_reduction(user):
+            continue
+        if _is_shape_changing_passthrough_user(node, user) and not (
+            _is_reduction_target(user.target) and layout.tag is LayoutTag.REDUCTION
+        ):
+            continue
         if _is_reduction_target(user.target) and _reduction_layout_is_degenerate(
-            node, layout
+            node, user, layout
         ):
             continue
         layouts.append(layout)
@@ -667,10 +686,16 @@ _ATEN_REDUCTION_TARGETS = frozenset(
         torch.ops.aten.sum.default,
         torch.ops.aten.amax.default,
         torch.ops.aten.amin.default,
+        torch.ops.aten.prod.default,
         torch.ops.aten.prod.dim_int,
+        torch.ops.aten.mean.default,
         torch.ops.aten.mean.dim,
+        torch.ops.aten.max.default,
         torch.ops.aten.max.dim,
+        torch.ops.aten.min.default,
         torch.ops.aten.min.dim,
+        torch.ops.aten.argmax.default,
+        torch.ops.aten.argmin.default,
     }
 )
 
@@ -680,8 +705,34 @@ def _is_reduction_target(target: object) -> bool:
     return target is reduce_ops._reduce or target in _ATEN_REDUCTION_TARGETS
 
 
+def _only_reaches_reduction(
+    node: torch.fx.Node,
+    *,
+    _visited: set[torch.fx.Node] | None = None,
+) -> bool:
+    """True when every path through *node* terminates at a reduction.
+
+    An inherited layout on such a pointwise path is an implementation detail
+    of the reduction input, not a useful vote for a producer which also feeds a
+    non-reduction consumer.
+    """
+    if _is_reduction_target(node.target):
+        return True
+    if not _is_passthrough_layout_node(node) or not node.users:
+        return False
+    visited = set() if _visited is None else _visited
+    if node in visited:
+        return False
+    visited.add(node)
+    return all(
+        _only_reaches_reduction(user, _visited=visited.copy()) for user in node.users
+    )
+
+
 def _reduction_layout_is_degenerate(
-    node: torch.fx.Node, reduction_layout: ThreadLayout
+    node: torch.fx.Node,
+    user: torch.fx.Node,
+    reduction_layout: ThreadLayout,
 ) -> bool:
     """True if a reduction user's input layout is degenerate w.r.t. *node*.
 
@@ -692,15 +743,21 @@ def _reduction_layout_is_degenerate(
     consumer) covers strictly fewer elements than the producer's tile — that is
     the only case backward propagation must ignore.
 
-    Comparing the two thread/value layouts (rather than the fake-tensor numels)
-    keeps this provable: both layouts are built from concrete thread counts and
-    block sizes, whereas a node's fake-tensor numel may be symbolic and would
-    spuriously flag every reduction as degenerate.
+    Prefer comparing the two thread/value layouts, which are normally concrete.
+    Dynamic kernels can retain symbolic layout extents, though, and an inherited
+    output layout is not a semantic reduction-axis constraint.  In that case,
+    use the producer/output shapes to recognize a shape-collapsing reduction.
+    Explicitly seeded reduction layouts remain authoritative.
     """
     producer_layout = _node_layout(node) or _first_input_layout(node)
     if producer_layout is None:
         return False
-    return _known_lt(reduction_layout.tile_numel(), producer_layout.tile_numel())
+    if _known_lt(reduction_layout.tile_numel(), producer_layout.tile_numel()):
+        return True
+    return (
+        reduction_layout.tag is not LayoutTag.REDUCTION
+        and _is_shape_changing_passthrough_user(node, user)
+    )
 
 
 def _node_layout(node: torch.fx.Node) -> ThreadLayout | None:
@@ -711,25 +768,41 @@ def _node_layout(node: torch.fx.Node) -> ThreadLayout | None:
     return lc.output_layout or lc.preferred_output
 
 
-def _is_shape_reducing_user(node: torch.fx.Node, user: torch.fx.Node) -> bool:
-    """True if *user* is a reduction consuming a smaller tile than *node*.
+def _is_shape_changing_passthrough_user(
+    node: torch.fx.Node, user: torch.fx.Node
+) -> bool:
+    """True if a passthrough *user* changes *node*'s tile element count.
 
-    A reduction (e.g. ``aten.amax``/``aten.sum``) collapses one or more of
-    *node*'s dims, so the user's tensor has fewer elements.  Such users own
-    the layout transition from the producer's full tile to the reduced output
-    in their own lowering, so an edge-level layout mismatch is expected.
+    Reductions collapse a tile and broadcasting expands one.  Their lowerings
+    own that shape transition, so the user's output layout must not propagate
+    backward onto the differently sized operand and an edge-layout mismatch is
+    expected at that boundary.
     """
-    if not _is_reduction_target(user.target):
+    is_reduction = _is_reduction_target(user.target)
+    if not is_reduction and not _is_passthrough_layout_node(user):
         return False
-    node_numel = _node_tile_numel(node)
-    user_numel = _node_tile_numel(user)
-    if node_numel is None or user_numel is None:
+    node_val = node.meta.get("val")
+    user_val = user.meta.get("val")
+    if not isinstance(node_val, torch.Tensor) or not isinstance(user_val, torch.Tensor):
         return False
-    if isinstance(node_numel, int) and isinstance(user_numel, int):
-        return user_numel < node_numel
-    # Symbolic: a reduction either preserves or shrinks the tile, so treat it
-    # as reducing whenever the numels are not provably equal.
-    return not _numels_match(node_numel, user_numel)
+    if is_reduction:
+        return not _numels_match(node_val.numel(), user_val.numel())
+
+    # Pointwise broadcasting only expands singleton or missing leading dims.
+    # Prove that transition dimension-by-dimension so unrelated symbolic
+    # shapes are not conservatively classified as broadcasts.
+    if user_val.ndim < node_val.ndim:
+        return False
+    padded_input_shape = (1,) * (user_val.ndim - node_val.ndim) + tuple(node_val.shape)
+    expanded = False
+    for input_size, output_size in zip(padded_input_shape, user_val.shape, strict=True):
+        if _symbolic_equal(input_size, output_size):
+            continue
+        if _symbolic_equal(input_size, 1):
+            expanded = True
+            continue
+        return False
+    return expanded
 
 
 def _node_tile_numel(node: torch.fx.Node) -> SymIntLike | None:
@@ -753,9 +826,7 @@ def _numels_match(a: SymIntLike | None, b: SymIntLike | None) -> bool:
     """
     if a is None or b is None:
         return True
-    if isinstance(a, int) and isinstance(b, int):
-        return a == b
-    return CompileEnvironment.current().known_equal(a, b)
+    return _symbolic_equal(a, b)
 
 
 def _known_lt(a: SymIntLike, b: SymIntLike) -> bool:
@@ -768,6 +839,40 @@ def _known_lt(a: SymIntLike, b: SymIntLike) -> bool:
     if isinstance(a, int) and isinstance(b, int):
         return a < b
     return False
+
+
+def _layouts_compatible(a: ThreadLayout, b: ThreadLayout) -> bool:
+    """Compare layouts without guarding on data-dependent SymInts."""
+    return all(
+        len(lhs) == len(rhs) and all(map(_symbolic_equal, lhs, rhs))
+        for lhs, rhs in (
+            (a.thread_shape, b.thread_shape),
+            (a.thread_stride, b.thread_stride),
+            (a.value_shape, b.value_shape),
+            (a.value_stride, b.value_stride),
+        )
+    )
+
+
+def _symbolic_equal(a: SymIntLike, b: SymIntLike) -> bool:
+    """Return only proven equality, without evaluating symbolic ``==``."""
+    if a is b:
+        return True
+    if isinstance(a, int) and isinstance(b, int):
+        return a == b
+    if not CompileEnvironment.has_current():
+        return False
+    return CompileEnvironment.current().known_equal(a, b)
+
+
+def _layout_has_zero_values(layout: ThreadLayout) -> bool:
+    """True for an over-provisioned symbolic layout with no local values.
+
+    Such layouts arise when mutually-exclusive branches share the widest
+    thread axis and a narrower branch masks the surplus lanes.  They do not
+    provide a meaningful pointwise propagation contract for that branch.
+    """
+    return _symbolic_equal(layout.num_values(), 0)
 
 
 def _constraint_for_node(node: torch.fx.Node) -> LayoutConstraint:
@@ -783,7 +888,13 @@ def _is_passthrough_layout_node(node: torch.fx.Node) -> bool:
         return False
     if node.target is memory_ops.load or node.target is memory_ops.store:
         return False
-    if node.target is reduce_ops._reduce:
+    if _is_reduction_target(node.target):
+        return False
+    if _is_helion_contraction(node):
+        # A contraction's output coordinates are not a one-to-one passthrough
+        # of either operand.  In particular, inheriting the lhs layout across
+        # (M, K) @ (K, N) assigns the result the K layout even though it is
+        # shaped (M, N).  The contraction lowering owns this layout boundary.
         return False
     return not _tracing_ops.is_for_loop_target(node.target)
 
@@ -793,7 +904,16 @@ def _is_output_flexible_layout_node(node: torch.fx.Node) -> bool:
         return False
     if node.target is memory_ops.store or node.target is reduce_ops._reduce:
         return False
+    if _is_helion_contraction(node):
+        # Until hl.dot has an explicit input/output layout contract, do not let
+        # a downstream consumer manufacture one through backward propagation.
+        return False
     return not _tracing_ops.is_for_loop_target(node.target)
+
+
+def _is_helion_contraction(node: torch.fx.Node) -> bool:
+    """Return whether *node* changes coordinates through a Helion contraction."""
+    return node.target in (matmul_ops.dot, matmul_ops.dot_scaled)
 
 
 def _tile_numels_match(a: ThreadLayout, b: ThreadLayout) -> bool:
@@ -804,14 +924,7 @@ def _tile_numels_match(a: ThreadLayout, b: ThreadLayout) -> bool:
     (e.g. reductions) produce outputs with fewer elements, so the
     producer's tile_numel differs from the consumer's.
     """
-    na, nb = a.tile_numel(), b.tile_numel()
-    if isinstance(na, int) and isinstance(nb, int):
-        return na == nb
-    # Symbolic comparison — conservative: only match when provably equal.
-    try:
-        return bool(na == nb)
-    except (TypeError, RuntimeError):
-        return False
+    return _symbolic_equal(a.tile_numel(), b.tile_numel())
 
 
 def _values_are_scalar(a: ThreadLayout, b: ThreadLayout) -> bool:
@@ -834,10 +947,4 @@ def _thread_counts_match(a: ThreadLayout, b: ThreadLayout) -> bool:
     so it requires every writing thread to have a corresponding reading
     thread (and vice-versa).
     """
-    na, nb = a.num_threads(), b.num_threads()
-    if isinstance(na, int) and isinstance(nb, int):
-        return na == nb
-    try:
-        return bool(na == nb)
-    except (TypeError, RuntimeError):
-        return False
+    return _symbolic_equal(a.num_threads(), b.num_threads())

--- a/helion/_compiler/cute/licm_profitability.py
+++ b/helion/_compiler/cute/licm_profitability.py
@@ -1,0 +1,130 @@
+"""Small static cost model shared by CuTe loop-invariant-code motion passes."""
+
+from __future__ import annotations
+
+import ast
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+# Moving a scalar result across a loop extends its live range.  Require enough
+# statically visible work to pay for that pressure, as well as a small absolute
+# floor so a two-iteration loop containing only casts is left alone.  These are
+# instruction-cost units, not shape- or kernel-specific thresholds.
+_MIN_SAVED_WORK = 8
+_LIVE_SCALAR_COST = 4
+
+
+def _call_path(node: ast.expr) -> str | None:
+    parts: list[str] = []
+    current: ast.expr = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if not isinstance(current, ast.Name):
+        return None
+    parts.append(current.id)
+    return ".".join(reversed(parts))
+
+
+def _constexpr_extent(loop: ast.For) -> int | None:
+    call = loop.iter
+    if (
+        not isinstance(call, ast.Call)
+        or _call_path(call.func) not in {"range", "cutlass.range_constexpr"}
+        or len(call.args) != 1
+        or call.keywords
+        or not isinstance(call.args[0], ast.Constant)
+        or not isinstance(call.args[0].value, int)
+        or isinstance(call.args[0].value, bool)
+        or call.args[0].value <= 0
+    ):
+        return None
+    return call.args[0].value
+
+
+def _expression_work(expression: ast.AST) -> int:
+    """Estimate scalar instruction work while avoiding target-specific tables."""
+    work = 0
+    for node in ast.walk(expression):
+        if isinstance(node, ast.Call):
+            path = _call_path(node.func)
+            # A warp reduction expands to multiple shuffle/combine operations.
+            # Transcendentals and memory operations also deserve more weight
+            # than a scalar cast or ordinary helper call.
+            if (
+                path is not None and path.startswith("cute.arch.warp_reduction_")
+            ) or path in {
+                "cute.arch.load",
+                "cute.math.exp",
+                "cute.math.exp2",
+                "cute.math.log",
+                "cute.math.log2",
+                "cute.math.rcp",
+                "cute.math.rsqrt",
+                "cute.math.sqrt",
+            }:
+                work += 4
+            else:
+                work += 1
+        elif isinstance(
+            node,
+            (
+                ast.BinOp,
+                ast.BoolOp,
+                ast.Compare,
+                ast.IfExp,
+                ast.Subscript,
+                ast.UnaryOp,
+            ),
+        ):
+            work += 1
+    return work
+
+
+def _statement_work(statement: ast.stmt) -> int:
+    if isinstance(statement, ast.For):
+        extent = _constexpr_extent(statement)
+        if extent is None:
+            return 0
+        return _expression_work(statement.iter) + extent * sum(
+            _statement_work(child) for child in statement.body
+        )
+    if isinstance(statement, ast.If):
+        return _expression_work(statement.test) + max(
+            sum(_statement_work(child) for child in statement.body),
+            sum(_statement_work(child) for child in statement.orelse),
+        )
+    if isinstance(statement, ast.Assign):
+        return _expression_work(statement.value)
+    if isinstance(statement, ast.AnnAssign) and statement.value is not None:
+        return _expression_work(statement.value)
+    if isinstance(statement, ast.AugAssign):
+        return _expression_work(statement.value) + 1
+    return 0
+
+
+def repeated_work_is_profitable(
+    statements: Iterable[ast.stmt],
+    *,
+    repeat_extent: int,
+    live_scalars: int = 1,
+    fixed_work: int = 0,
+) -> bool:
+    """Return whether statically saved work pays for longer scalar liveness.
+
+    Safety and invariance are proved by the calling transformation.  This
+    helper only replaces fixed outer-loop extent gates with a structural cost
+    test: at least two iterations, statically countable work, and enough work
+    removed to cover both a small absolute floor and the number of results
+    kept live across the remaining loop.
+    """
+    if repeat_extent <= 1 or live_scalars < 0 or fixed_work < 0:
+        return False
+    work = sum(_statement_work(statement) for statement in statements)
+    saved_work = (repeat_extent - 1) * work
+    return saved_work >= (
+        max(_MIN_SAVED_WORK, live_scalars * _LIVE_SCALAR_COST) + fixed_work
+    )

--- a/helion/_compiler/cute/memory_ops.py
+++ b/helion/_compiler/cute/memory_ops.py
@@ -52,6 +52,7 @@ from ...language.memory_ops import load
 from ...language.memory_ops import store
 from ..ast_extension import expr_from_string
 from ..ast_extension import statement_from_string
+from ..ast_read_writes import ReadWrites
 from ..compile_environment import CompileEnvironment
 from ..compile_environment import RuntimeInputSpecialization
 from ..compile_environment import _replay_tensor_input_source
@@ -393,6 +394,68 @@ def _cute_scalar_storage_dtype(dtype: torch.dtype) -> str:
     return CompileEnvironment.current().backend.dtype_str(dtype)
 
 
+_PERSISTENT_BRANCH_VEC_LOAD = "_helion_persistent_branch_vec_load"
+_PERSISTENT_BRANCH_VEC_STORE = "_helion_persistent_branch_vec_store"
+
+
+def _persistent_branch_vec_load_marker(
+    block_id: int,
+    vec_width: int,
+    dtype: torch.dtype,
+    eviction_suffix: str,
+    pointer: str,
+    scalar_value: ast.expr,
+) -> ast.expr:
+    """Preserve a proven vec candidate until its branch-local loop exists."""
+    pointer_expr = expr_from_string(pointer)
+    assert isinstance(pointer_expr, ast.expr)
+    return ast.fix_missing_locations(
+        ast.Call(
+            func=ast.Name(id=_PERSISTENT_BRANCH_VEC_LOAD, ctx=ast.Load()),
+            args=[
+                ast.Constant(value=block_id),
+                ast.Constant(value=vec_width),
+                ast.Constant(value=_cute_scalar_storage_dtype(dtype)),
+                ast.Constant(value=eviction_suffix),
+                pointer_expr,
+                scalar_value,
+            ],
+            keywords=[],
+        )
+    )
+
+
+def _persistent_branch_vec_store_marker(
+    block_id: int,
+    vec_width: int,
+    dtype: torch.dtype,
+    pointer: str,
+    value: ast.expr,
+    mask_expr: str | None,
+) -> ast.stmt:
+    """Emit a removable marker for a branch-local exact-fragment store."""
+    pointer_expr = expr_from_string(pointer)
+    assert isinstance(pointer_expr, ast.expr)
+    mask = expr_from_string(mask_expr) if mask_expr is not None else ast.Constant(None)
+    assert isinstance(mask, ast.expr)
+    return ast.fix_missing_locations(
+        ast.Expr(
+            value=ast.Call(
+                func=ast.Name(id=_PERSISTENT_BRANCH_VEC_STORE, ctx=ast.Load()),
+                args=[
+                    ast.Constant(value=block_id),
+                    ast.Constant(value=vec_width),
+                    ast.Constant(value=_cute_scalar_storage_dtype(dtype)),
+                    pointer_expr,
+                    value,
+                    mask,
+                ],
+                keywords=[],
+            )
+        )
+    )
+
+
 def _cute_scalar_store_expr(
     tensor_name: str, index_exprs: list[str], value: str
 ) -> str:
@@ -447,13 +510,14 @@ def _cute_vector_store_expr(
 
 def _cute_register_unroll_vec_hoist(
     state: CodegenState,
-    strategy: object,  # LoopedReductionStrategy at runtime
+    strategy: object,  # Looped/PersistentReductionStrategy at runtime
     tensor: torch.Tensor,
     tensor_name: str,
     index_exprs: list[str],
     vec_width: int,
+    mask_expr: str | None = None,
     eviction_suffix: str = "",
-) -> str:
+) -> str | None:
     """Register an integer-carrier vec load to be hoisted above the constexpr V-loop
     in the active lane body and return the per-element extract expression.
 
@@ -467,9 +531,15 @@ def _cute_register_unroll_vec_hoist(
     lane_body = getattr(strategy, "_cute_lane_body", None)
     assert isinstance(base_index_var, str)
     assert isinstance(lane_body, list)
-    # The inner reduction-axis index_expr is the last entry; swap it with
-    # the per-lane base so the vec load points at the start of the V-wide
-    # chunk this thread owns.
+    from ..reduction_strategy import PersistentReductionStrategy
+
+    if isinstance(strategy, PersistentReductionStrategy):
+        # Persistent memory order is only complete after lane splitting.  The
+        # caller leaves an exact-fragment marker for the late pass instead of
+        # installing a wrapper-global hoist that could cross a later write.
+        return None
+    # Looped reductions expose their reduction index directly in the last
+    # position, so replacing that component is sufficient.
     base_exprs = list(index_exprs)
     base_exprs[-1] = base_index_var
     base_ptr_expr = _cute_scalar_pointer_expr(tensor_name, base_exprs)
@@ -502,6 +572,457 @@ def _cute_register_unroll_vec_hoist(
     assert isinstance(constexpr_loop.target, ast.Name)
     vec_lane_var = constexpr_loop.target.id
     return f"{carrier}({hoist_var}[{vec_lane_var}]).bitcast({elem_dtype})"
+
+
+def _persistent_assignment_definitions(state: CodegenState) -> dict[str, ast.expr]:
+    """Collect visible single-name definitions used by persistent lane code."""
+    definitions: dict[str, ast.expr] = {}
+    grid = state.codegen.current_grid_state
+    statement_lists = [*state.codegen.statements_stack]
+    if grid is not None:
+        statement_lists.append(grid.lane_setup_statements)
+    for statements in statement_lists:
+        for stmt in statements:
+            if (
+                isinstance(stmt, ast.Assign)
+                and len(stmt.targets) == 1
+                and isinstance(stmt.targets[0], ast.Name)
+            ):
+                definitions[stmt.targets[0].id] = stmt.value
+    return definitions
+
+
+def _persistent_expr_depends_on_inner_lane(
+    state: CodegenState,
+    strategy: object,
+    expression: str,
+) -> bool:
+    """Whether an expression transitively reads this persistent V-lane."""
+    block_index = getattr(strategy, "block_index", None)
+    if not isinstance(block_index, int):
+        return False
+    lane_var = getattr(strategy, "_synthetic_cute_lane_var", None)
+    inner_names = {
+        name
+        for name in (cast("Any", strategy).index_var(block_index), lane_var)
+        if isinstance(name, str)
+    }
+    try:
+        expression_node = ast.parse(expression, mode="eval").body
+    except SyntaxError:
+        return False
+    definitions = _persistent_assignment_definitions(state)
+    pending = list(ReadWrites.from_ast(expression_node).reads)
+    seen: set[str] = set()
+    while pending:
+        name = pending.pop()
+        if name in inner_names:
+            return True
+        if name in seen:
+            continue
+        seen.add(name)
+        definition = definitions.get(name)
+        if definition is not None:
+            pending.extend(ReadWrites.from_ast(definition).reads)
+    return False
+
+
+def _persistent_vec_base_index_exprs(
+    state: CodegenState,
+    strategy: object,
+    index_exprs: list[str],
+    *,
+    preserve_lane_independent_aliases: bool = False,
+) -> list[str] | None:
+    """Rebase affine persistent-lane indices at the vector chunk start.
+
+    Packed tensors commonly index a K slice as ``head * K + k_offset``.  The
+    scalar index arrives here through generated aliases, while the vector
+    transaction is emitted before the constexpr lane loop that defines those
+    aliases.  Inline pure assignment chains and replace the reduction index by
+    its chunk base.  A chain containing a memory load remains scalar.
+    """
+    base_index_var = getattr(strategy, "_cute_lane_base_index_var", None)
+    block_index = getattr(strategy, "block_index", None)
+    if not isinstance(base_index_var, str) or not isinstance(block_index, int):
+        return None
+    reduction_index_var = cast("Any", strategy).index_var(block_index)
+    lane_var = getattr(strategy, "_synthetic_cute_lane_var", None)
+    definitions = _persistent_assignment_definitions(state)
+
+    class _InlineIndexAliases(ast.NodeTransformer):
+        def __init__(self) -> None:
+            super().__init__()
+            self.expanding: set[str] = set()
+            self.rebased = False
+
+        def visit_Name(self, node: ast.Name) -> ast.AST:
+            if not isinstance(node.ctx, ast.Load):
+                return node
+            if node.id == reduction_index_var:
+                self.rebased = True
+                return ast.copy_location(
+                    ast.Name(id=base_index_var, ctx=ast.Load()), node
+                )
+            if isinstance(lane_var, str) and node.id == lane_var:
+                self.rebased = True
+                return ast.copy_location(ast.Constant(value=0), node)
+            value = definitions.get(node.id)
+            if value is None or node.id in self.expanding:
+                return node
+            if preserve_lane_independent_aliases and not (
+                _persistent_expr_depends_on_inner_lane(state, strategy, node.id)
+            ):
+                # A late branch-local hoist can retain a scalar/load-derived
+                # outer index as an opaque value.  Expand only aliases that
+                # carry the reduction lane so the affine proof below still
+                # rejects reversed, strided, or otherwise non-unit access.
+                return node
+            # Stop at a symbol already defined in the hoist's enclosing
+            # scope.  Expanding outer grid aliases such as ``tile_offset_*``
+            # or host scalar arguments can expose host-only expressions (for
+            # example ``tensor.size(0)``) inside the CuTe device function.
+            if _persistent_vec_scope_safe(state, strategy, node.id):
+                return node
+            self.expanding.add(node.id)
+            replacement = self.visit(ast.parse(ast.unparse(value), mode="eval").body)
+            self.expanding.remove(node.id)
+            return ast.copy_location(replacement, node)
+
+    def unit_affine_in_reduction_index(node: ast.AST) -> tuple[bool, bool]:
+        """Return ``(depends_on_reduction_index, is_unit_affine)``."""
+        if isinstance(node, ast.Name):
+            return node.id == base_index_var, True
+        if isinstance(node, ast.BinOp):
+            left_depends, left_valid = unit_affine_in_reduction_index(node.left)
+            right_depends, right_valid = unit_affine_in_reduction_index(node.right)
+            depends = left_depends or right_depends
+            if not depends:
+                return False, left_valid and right_valid
+            if not left_valid or not right_valid or left_depends and right_depends:
+                return True, False
+            if isinstance(node.op, ast.Add):
+                return True, True
+            if isinstance(node.op, ast.Sub) and left_depends:
+                return True, True
+            return True, False
+        if isinstance(node, ast.Call):
+            dependencies = [unit_affine_in_reduction_index(arg) for arg in node.args]
+            depends = any(item[0] for item in dependencies)
+            if not depends:
+                return False, all(item[1] for item in dependencies)
+            is_cutlass_cast = (
+                len(node.args) == 1
+                and not node.keywords
+                and ast.unparse(node.func).startswith("cutlass.")
+            )
+            return True, is_cutlass_cast and all(item[1] for item in dependencies)
+        dependencies = [
+            unit_affine_in_reduction_index(child)
+            for child in ast.iter_child_nodes(node)
+        ]
+        depends = any(item[0] for item in dependencies)
+        return depends, not depends and all(item[1] for item in dependencies)
+
+    rewritten: list[str] = []
+    rebased = False
+    for expression in index_exprs:
+        try:
+            parsed = ast.parse(expression, mode="eval").body
+        except SyntaxError:
+            return None
+        rewriter = _InlineIndexAliases()
+        parsed = rewriter.visit(parsed)
+        rebased = rebased or rewriter.rebased
+        depends, is_unit_affine = unit_affine_in_reduction_index(parsed)
+        if depends and not is_unit_affine:
+            return None
+        if any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in ("load", "store")
+            for node in ast.walk(parsed)
+        ):
+            return None
+        rewritten.append(ast.unparse(parsed))
+    return rewritten if rebased else None
+
+
+def _persistent_vec_is_exact_aligned(
+    state: CodegenState,
+    strategy: object,
+    index_exprs: list[str],
+    tensor: torch.Tensor,
+    vec_width: int,
+) -> bool:
+    """Whether the lane tensor dimension starts at a complete aligned fragment.
+
+    The late branch-local pass cannot scalarize a partially valid vector.  In
+    particular, ``cols + 1`` leaves seven valid values in the final fragment;
+    guarding the transaction as a whole would either read one element OOB or
+    drop those seven stores.  Restrict late vectorization to the reduction
+    coordinate plus an offset provably divisible by the vector width.  The
+    late pass separately turns the scalar bounds into a whole-fragment guard.
+    """
+    base_var = getattr(strategy, "_cute_lane_base_index_var", None)
+    if not isinstance(base_var, str):
+        return False
+    rebased = _persistent_vec_base_index_exprs(
+        state,
+        strategy,
+        index_exprs,
+        preserve_lane_independent_aliases=True,
+    )
+    if rebased is None:
+        return False
+
+    definitions = _persistent_assignment_definitions(state)
+    resolving: set[str] = set()
+
+    def is_aligned_offset(node: ast.expr) -> bool:
+        if isinstance(node, ast.Constant) and isinstance(node.value, int):
+            return node.value % vec_width == 0
+        if isinstance(node, ast.Name):
+            definition = definitions.get(node.id)
+            if definition is None or node.id in resolving:
+                return False
+            resolving.add(node.id)
+            result = is_aligned_offset(definition)
+            resolving.remove(node.id)
+            return result
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+            return is_aligned_offset(node.operand)
+        if (
+            isinstance(node, ast.Call)
+            and len(node.args) == 1
+            and not node.keywords
+            and ast.unparse(node.func).startswith("cutlass.")
+        ):
+            return is_aligned_offset(node.args[0])
+        if isinstance(node, ast.BinOp):
+            if isinstance(node.op, (ast.Add, ast.Sub)):
+                return is_aligned_offset(node.left) and is_aligned_offset(node.right)
+            if isinstance(node.op, ast.Mult):
+                return is_aligned_offset(node.left) or is_aligned_offset(node.right)
+        return False
+
+    class _RemoveBase(ast.NodeTransformer):
+        def visit_Name(self, node: ast.Name) -> ast.AST:
+            if isinstance(node.ctx, ast.Load) and node.id == base_var:
+                return ast.copy_location(ast.Constant(value=0), node)
+            return node
+
+    dependent: list[tuple[int, ast.expr]] = []
+    for dim, expression in enumerate(rebased):
+        try:
+            parsed = ast.parse(expression, mode="eval").body
+        except SyntaxError:
+            return False
+        if base_var in ReadWrites.from_ast(parsed).reads:
+            dependent.append((dim, parsed))
+    if len(dependent) != 1:
+        return False
+    offset = _RemoveBase().visit(
+        ast.parse(ast.unparse(dependent[0][1]), mode="eval").body
+    )
+    if not isinstance(offset, ast.expr) or not is_aligned_offset(offset):
+        return False
+
+    env = CompileEnvironment.current()
+    runtime_tensor = env.runtime_value_for_tensor(tensor)
+    if isinstance(runtime_tensor, torch.Tensor) and not isinstance(
+        runtime_tensor, FakeTensor
+    ):
+        strides = tuple(int(stride) for stride in runtime_tensor.stride())
+        sizes = tuple(int(size) for size in runtime_tensor.shape)
+        element_size = runtime_tensor.element_size()
+        required_alignment = vec_width * element_size
+        if not runtime_tensor_has_specialized_alignment(
+            env, tensor, required_alignment
+        ):
+            return False
+    else:
+        # Kernel-owned allocations are suitably aligned by the backend.  A
+        # nonzero or symbolic view offset cannot establish that guarantee.
+        if env.tensor_input_source(tensor) is not None:
+            return False
+        storage_offset = tensor.storage_offset()
+        if not isinstance(storage_offset, int) or storage_offset != 0:
+            return False
+        strides = tensor.stride()
+        sizes = tensor.shape
+        element_size = tensor.element_size()
+        required_alignment = vec_width * element_size
+
+    if len(strides) != len(rebased):
+        return False
+    lane_dim = dependent[0][0]
+    lane_size = sizes[lane_dim]
+    if not isinstance(lane_size, int) or lane_size % vec_width:
+        return False
+    for dim, stride in enumerate(strides):
+        if not isinstance(stride, int):
+            return False
+        if dim == lane_dim:
+            if stride != 1:
+                return False
+        elif stride * element_size % required_alignment:
+            return False
+    return True
+
+
+def _persistent_vec_scope_safe(
+    state: CodegenState,
+    strategy: object,
+    expression: str,
+) -> bool:
+    """Whether ``expression`` is available outside a persistent V-loop.
+
+    Persistent reductions wrap a complete root graph rather than a dedicated
+    device-loop graph.  A vec transaction is spliced before their constexpr
+    V-loop, so it may only reference kernel/global values or coordinates from
+    an *outer* grid lane.  Definitions emitted in the root body itself, and
+    setup definitions that depend on this reduction's synthetic lane, are not
+    available there.
+    """
+    try:
+        expr = ast.parse(expression, mode="eval").body
+    except SyntaxError:
+        return False
+    reads = set(ReadWrites.from_ast(expr).reads)
+
+    statement_stack = getattr(state.codegen, "statements_stack", None)
+    if isinstance(statement_stack, list) and statement_stack:
+        # The persistent wrapper is appended to ``hoist_parent_statements``.
+        # Existing definitions in that exact list dominate it; every list
+        # pushed after that point is a nested branch/loop body that will sit
+        # below the wrapper.  Inspect all of those nested parent scopes, not
+        # merely the current innermost list.
+        grid = state.codegen.current_grid_state
+        hoist_parent = getattr(grid, "hoist_parent_statements", None)
+        try:
+            hoist_parent_index = next(
+                index
+                for index, statements in enumerate(statement_stack)
+                if statements is hoist_parent
+            )
+        except StopIteration:
+            hoist_parent_index = -1
+        locally_written = {
+            name
+            for statements in statement_stack[hoist_parent_index + 1 :]
+            if isinstance(statements, list)
+            for stmt in statements
+            for name in ReadWrites.from_ast(stmt).writes
+        }
+        if reads & locally_written:
+            return False
+
+    grid = state.codegen.current_grid_state
+    if grid is None:
+        return False
+    lane_var = getattr(strategy, "_synthetic_cute_lane_var", None)
+    base_var = getattr(strategy, "_cute_lane_base_index_var", None)
+
+    # A persistent wrapper is inserted according to ``lane_loops`` nesting.
+    # Targets belonging to a deeper lane loop do not exist at its hoist site.
+    # Earlier lane targets are outer scopes and remain available (for example
+    # the row lane in a row-by-K reduction).
+    persistent_depth = next(
+        (
+            depth
+            for depth, (candidate, _extent) in enumerate(grid.lane_loops)
+            if candidate == lane_var
+        ),
+        None,
+    )
+    if persistent_depth is None:
+        return False
+
+    # Resolve the exact lane nesting depth of every setup definition.  Merely
+    # checking a setup statement's direct reads is insufficient: a seemingly
+    # harmless alias can transitively read an inner lane (``b = a + 1`` where
+    # ``a = inner_lane + 7``) and would then be referenced by the hoist before
+    # either definition exists.  Unknown/fallback setup belongs to the
+    # innermost scope, matching ``DeviceGridState.wrap_body`` conservatively.
+    lane_scope_names: list[set[str]] = []
+    for candidate, _extent in grid.lane_loops:
+        names = {candidate}
+        wrapper = grid.vec_lane_wrappers.get(candidate)
+        if wrapper is not None:
+            names.update((wrapper.vec_lane_var, wrapper.base_index_var))
+        lane_scope_names.append(names)
+    setup_name_depths: dict[str, int] = {}
+    innermost_depth = len(grid.lane_loops) - 1
+    for stmt in grid.lane_setup_statements:
+        rw = ReadWrites.from_ast(stmt)
+        stmt_reads = set(rw.reads)
+        dependency_depths = [
+            depth for depth, names in enumerate(lane_scope_names) if stmt_reads & names
+        ]
+        dependency_depths.extend(
+            setup_name_depths[name] for name in stmt_reads if name in setup_name_depths
+        )
+        definition_depth = (
+            max(dependency_depths) if dependency_depths else innermost_depth
+        )
+        for name in rw.writes:
+            setup_name_depths[name] = definition_depth
+
+    for depth, names in enumerate(lane_scope_names):
+        if depth < persistent_depth:
+            continue
+        unavailable_names = set(names)
+        if depth == persistent_depth and isinstance(base_var, str):
+            # The wrapper defines its chunk base immediately before the
+            # hoisted transaction; only its constexpr lane target is local to
+            # the loop body.
+            unavailable_names.discard(base_var)
+        if reads & unavailable_names:
+            return False
+    if any(
+        name in setup_name_depths and setup_name_depths[name] >= persistent_depth
+        for name in reads
+    ):
+        return False
+
+    # Device-loop induction variables are definitions owned by an enclosing
+    # ``for`` node, rather than assignments in ``statements_stack``.  Treat
+    # them as local: the persistent wrapper may be emitted outside that loop
+    # when grid/lane bodies are reconstructed later.
+    seen_loop_states: set[int] = set()
+    for loop_states in state.codegen.active_device_loops.values():
+        for loop_state in loop_states:
+            if id(loop_state) in seen_loop_states:
+                continue
+            seen_loop_states.add(id(loop_state))
+            for_node = getattr(loop_state, "for_node", None)
+            if isinstance(for_node, ast.For):
+                loop_writes = set(ReadWrites.from_ast(for_node.target).writes)
+                if reads & loop_writes:
+                    return False
+    return True
+
+
+def _cute_lane_strategy(state: CodegenState, block_id: int) -> object | None:
+    """Return the live lane strategy, including persistent reductions.
+
+    A persistent reduction contributes its synthetic lane wrapper to the
+    current grid but is not itself pushed into ``active_device_loops``.  Look
+    it up through the tile dispatcher when the active loop belongs only to the
+    enclosing free-tile strategy.
+    """
+    loops = state.codegen.active_device_loops.get(block_id)
+    if loops:
+        return loops[-1].strategy
+    env = CompileEnvironment.current()
+    if env.block_sizes[block_id].reduction:
+        from ..reduction_strategy import PersistentReductionStrategy
+
+        strategy = state.device_function.tile_strategy.get_reduction_strategy(block_id)
+        if isinstance(strategy, PersistentReductionStrategy):
+            return strategy
+    return None
 
 
 def _cute_stack_tensor_offset_expr(
@@ -731,6 +1252,7 @@ def _codegen_cute_store_stack_load(
         backend.ast_to_dtype_expr("{value}", target_dtype),
         value=value,
     )
+    assert isinstance(value, ast.expr)
     store_expr = expr_from_string(
         _cute_scalar_store_expr(tensor_name, rewritten_index_exprs, "{value}"),
         value=value,
@@ -2042,6 +2564,7 @@ def _(state: CodegenState) -> ast.AST:
         backend.ast_to_dtype_expr("{value}", target_dtype),
         value=value,
     )
+    assert isinstance(value, ast.expr)
     index_exprs = _cute_index_exprs(
         state,
         subscript,
@@ -2065,6 +2588,7 @@ def _(state: CodegenState) -> ast.AST:
         index_exprs[-1] = topk_lane_expr
     store_uses_pointer = "None" not in index_exprs
     mask_expr = _cute_combined_mask(state, subscript, extra_mask, tensor=tensor)
+    branch_vec_store_candidate: tuple[int, int] | None = None
 
     # Vectorized store: when this store's stride-1 axis is a vec-partitioned
     # lane loop (same predicates as the vec-load hoist, so the per-element
@@ -2082,9 +2606,7 @@ def _(state: CodegenState) -> ast.AST:
             from ..tile_strategy import BlockSizeTileStrategy
 
             _vec_width, vec_block_id, _mode = vec_ctx
-            loops = state.codegen.active_device_loops.get(vec_block_id)
-            assert loops
-            strategy = loops[-1].strategy
+            strategy = _cute_lane_strategy(state, vec_block_id)
             assert isinstance(strategy, BlockSizeTileStrategy)
             append_stmt = _cute_register_tile_unroll_vec_store(
                 state,
@@ -2101,24 +2623,57 @@ def _(state: CodegenState) -> ast.AST:
                 return ast.Constant(value=None)
         elif vec_ctx is not None and vec_ctx[2] == "unroll":
             from ..reduction_strategy import LoopedReductionStrategy
+            from ..reduction_strategy import PersistentReductionStrategy
 
             _vec_width, vec_block_id, _mode = vec_ctx
-            loops = state.codegen.active_device_loops.get(vec_block_id)
-            assert loops
-            red_strategy = loops[-1].strategy
-            if isinstance(red_strategy, LoopedReductionStrategy):
-                append_stmt = _cute_register_reduction_unroll_vec_store(
-                    state,
-                    red_strategy,
-                    tensor_name,
-                    index_exprs,
-                    ast.unparse(value),
-                    mask_expr,
-                    tensor.dtype,
-                )
+            red_strategy = _cute_lane_strategy(state, vec_block_id)
+            append_stmt = None
+            if isinstance(
+                red_strategy,
+                (LoopedReductionStrategy, PersistentReductionStrategy),
+            ):
+                can_vectorize = True
+                if isinstance(red_strategy, PersistentReductionStrategy):
+                    # Delay persistent stores until the complete lane body is
+                    # visible. The late pass keeps interleaved stores in place
+                    # when a later potentially-aliasing load needs ordering.
+                    can_vectorize = False
+                    if _persistent_vec_is_exact_aligned(
+                        state,
+                        red_strategy,
+                        index_exprs,
+                        tensor,
+                        _vec_width,
+                    ):
+                        branch_vec_store_candidate = (vec_block_id, _vec_width)
+                if can_vectorize:
+                    assert isinstance(red_strategy, LoopedReductionStrategy)
+                    append_stmt = _cute_register_reduction_unroll_vec_store(
+                        state,
+                        red_strategy,
+                        tensor_name,
+                        index_exprs,
+                        ast.unparse(value),
+                        mask_expr,
+                        tensor.dtype,
+                    )
                 if append_stmt is not None:
                     state.add_statement(append_stmt)
                     return ast.Constant(value=None)
+
+    if branch_vec_store_candidate is not None:
+        vec_block_id, vec_width = branch_vec_store_candidate
+        state.add_statement(
+            _persistent_branch_vec_store_marker(
+                vec_block_id,
+                vec_width,
+                tensor.dtype,
+                _cute_scalar_pointer_expr(tensor_name, index_exprs),
+                value,
+                mask_expr,
+            )
+        )
+        return ast.Constant(value=None)
 
     store_expr = _cute_scalar_store_expr(tensor_name, index_exprs, "{value}")
     assign_expr = expr_from_string(store_expr, value=value)
@@ -2245,6 +2800,7 @@ def _cute_vector_load_ctx(
     case the caller falls back to ``_cute_scalar_load_expr``.
     """
     from ..reduction_strategy import LoopedReductionStrategy
+    from ..reduction_strategy import PersistentReductionStrategy
 
     env = CompileEnvironment.current()
     if env.backend.name != "cute":
@@ -2328,7 +2884,17 @@ def _cute_vector_load_ctx(
         expr_pos += 1
         if isinstance(idx, torch.SymInt):
             bid = env.get_block_id(idx)
-            if bid is not None and state.codegen.active_device_loops.get(bid):
+            if bid is not None and _cute_lane_strategy(state, bid) is not None:
+                if tensor_dim == stride1_tensor_dim or inner_block_id is None:
+                    inner_block_id = bid
+                    lane_axis_pos = expr_pos
+                    lane_on_stride1 = tensor_dim == stride1_tensor_dim
+        elif isinstance(idx, torch.Tensor) and idx.ndim == 1:
+            # ``hl.arange(K)`` reaches indexing lowering as a 1-D FakeTensor,
+            # not as the SymInt that identifies K. Resolve its static extent
+            # back to the persistent reduction block.
+            bid = env.resolve_block_id(idx.numel())
+            if bid is not None and _cute_lane_strategy(state, bid) is not None:
                 if tensor_dim == stride1_tensor_dim or inner_block_id is None:
                     inner_block_id = bid
                     lane_axis_pos = expr_pos
@@ -2365,9 +2931,10 @@ def _cute_vector_load_ctx(
                             dim_int = None
                     if dim_int is None:
                         continue
-                    if env.known_equal(
-                        bs_int, dim_int
-                    ) and state.codegen.active_device_loops.get(cand_bid):
+                    if (
+                        env.known_equal(bs_int, dim_int)
+                        and _cute_lane_strategy(state, cand_bid) is not None
+                    ):
                         matches.append(cand_bid)
                 if matches:
                     # Matching by extent alone is ambiguous when a
@@ -2386,11 +2953,13 @@ def _cute_vector_load_ctx(
         tensor_dim += 1
     if inner_block_id is None or lane_axis_pos is None:
         return None
-    loops = state.codegen.active_device_loops.get(inner_block_id)
-    if not loops:
-        return None
-    strategy = getattr(loops[-1], "strategy", None)
-    if isinstance(strategy, LoopedReductionStrategy):
+    strategy = _cute_lane_strategy(state, inner_block_id)
+    if isinstance(
+        strategy,
+        (LoopedReductionStrategy, PersistentReductionStrategy),
+    ):
+        if not lane_on_stride1:
+            return None
         vec_width = getattr(strategy, "_cute_reduction_vec_width", 1)
         if vec_width <= 1:
             return None
@@ -2665,13 +3234,15 @@ def _(state: CodegenState) -> object:
                 eviction_suffix = _CUTE_L2_LAST_SUFFIX
             elif mapped := _CUTE_EVICTION_POLICY_MAP.get(policy, ""):
                 eviction_suffix = f", level1_eviction_priority={mapped!r}"
+    load_expr: str | None = None
+    branch_vec_candidate: tuple[int, int] | None = None
     vec_ctx = _cute_vector_load_ctx(state, tensor, subscript, index_exprs, extra_mask)
     if vec_ctx is not None:
         vec_width, vec_block_id, vec_mode = vec_ctx
         from ..reduction_strategy import LoopedReductionStrategy
+        from ..reduction_strategy import PersistentReductionStrategy
 
-        loops = state.codegen.active_device_loops.get(vec_block_id)
-        strategy = loops[-1].strategy if loops else None
+        strategy = _cute_lane_strategy(state, vec_block_id)
         if vec_mode == "vec":
             load_expr = _cute_vector_load_expr(
                 tensor_name,
@@ -2694,7 +3265,10 @@ def _(state: CodegenState) -> object:
             # base_index) pair, then return ``hoist_var[vi].bitcast(dtype)``
             # so the existing scalar pipeline sees a scalar of the original
             # dtype.
-            assert isinstance(strategy, LoopedReductionStrategy)
+            assert isinstance(
+                strategy,
+                (LoopedReductionStrategy, PersistentReductionStrategy),
+            )
             load_expr = _cute_register_unroll_vec_hoist(
                 state,
                 strategy,
@@ -2702,8 +3276,20 @@ def _(state: CodegenState) -> object:
                 tensor_name,
                 index_exprs,
                 vec_width,
+                mask_expr=mask_expr,
                 eviction_suffix=eviction_suffix,
             )
+            # A persistent vec wrapper cannot hoist an address component
+            # produced by its own root body. ``None`` keeps that site scalar
+            # until the late branch-local vectorizer can place it legally.
+            if (
+                load_expr is None
+                and isinstance(strategy, PersistentReductionStrategy)
+                and _persistent_vec_is_exact_aligned(
+                    state, strategy, index_exprs, tensor, vec_width
+                )
+            ):
+                branch_vec_candidate = (vec_block_id, vec_width)
         else:
             assert vec_mode == "tile_unroll"
             # Same hoist protocol as ``LoopedReductionStrategy``'s
@@ -2721,7 +3307,7 @@ def _(state: CodegenState) -> object:
                 vec_width,
                 eviction_suffix=eviction_suffix,
             )
-    else:
+    if load_expr is None:
         load_expr = _cute_scalar_load_expr(
             tensor_name,
             index_exprs,
@@ -2762,6 +3348,30 @@ def _(state: CodegenState) -> object:
         state.fx_node.meta["cute_sortable_load"] = sortable_load
         return sortable_load.expr
     if mask_expr is None:
-        return expr_from_string(load_expr)
+        result = expr_from_string(load_expr)
+        assert isinstance(result, ast.expr)
+        if branch_vec_candidate is not None:
+            vec_block_id, vec_width = branch_vec_candidate
+            return _persistent_branch_vec_load_marker(
+                vec_block_id,
+                vec_width,
+                tensor.dtype,
+                eviction_suffix,
+                _cute_scalar_pointer_expr(tensor_name, index_exprs),
+                result,
+            )
+        return result
     zero = _cute_scalar_storage_dtype(tensor.dtype)
-    return expr_from_string(f"({load_expr} if {mask_expr} else {zero}(0))")
+    result = expr_from_string(f"({load_expr} if {mask_expr} else {zero}(0))")
+    assert isinstance(result, ast.expr)
+    if branch_vec_candidate is not None:
+        vec_block_id, vec_width = branch_vec_candidate
+        return _persistent_branch_vec_load_marker(
+            vec_block_id,
+            vec_width,
+            tensor.dtype,
+            eviction_suffix,
+            _cute_scalar_pointer_expr(tensor_name, index_exprs),
+            result,
+        )
+    return result

--- a/helion/_compiler/cute/persistent_branch_vec.py
+++ b/helion/_compiler/cute/persistent_branch_vec.py
@@ -1,0 +1,1635 @@
+"""Late branch-local vectorization for exact persistent-reduction fragments.
+
+Persistent reduction lanes wrap the whole grid body.  A load whose address is
+defined inside a runtime branch therefore cannot use the normal wrapper-level
+vector hoist.  Memory lowering marks only sites that already passed the
+stride-1, dtype, and exact-fragment checks; this pass places their vector
+transaction immediately outside the materialized constexpr lane loop, where
+branch-local indices dominate it.
+"""
+
+from __future__ import annotations
+
+import ast
+import math
+import re
+from typing import TYPE_CHECKING
+
+from ..ast_read_writes import ReadWrites
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+_LOAD_MARKER = "_helion_persistent_branch_vec_load"
+_STORE_MARKER = "_helion_persistent_branch_vec_store"
+_SYNTHETIC_LANE_RE = re.compile(r"synthetic_lane_(\d+)")
+_DTYPE_INFO = {
+    "cutlass.BFloat16": ("cutlass.Uint16", 2, "_cute_store_u16_vec"),
+    "cutlass.Float16": ("cutlass.Uint16", 2, "_cute_store_u16_vec"),
+    "cutlass.Float32": ("cutlass.Uint32", 4, "_cute_store_u32_vec"),
+}
+
+
+def _clone_expr(node: ast.AST) -> ast.expr:
+    """Clone generated/extended AST without relying on ``deepcopy``."""
+    return ast.parse(ast.unparse(node), mode="eval").body
+
+
+def _marker_call(node: ast.AST, name: str, nargs: int) -> ast.Call | None:
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == name
+        and len(node.args) == nargs
+        and not node.keywords
+    ):
+        return node
+    return None
+
+
+def _literal(node: ast.AST, typ: type[int | str]) -> int | str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, typ):
+        return node.value
+    return None
+
+
+def _range_extent(loop: ast.For) -> int | None:
+    call = loop.iter
+    if not (
+        isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Attribute)
+        and call.func.attr == "range_constexpr"
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id == "cutlass"
+        and len(call.args) == 1
+        and not call.keywords
+    ):
+        return None
+    value = _literal(call.args[0], int)
+    return value if isinstance(value, int) and value > 1 else None
+
+
+def _single_name_definitions(statements: list[ast.stmt]) -> dict[str, ast.expr]:
+    definitions: dict[str, ast.expr] = {}
+    for stmt in statements:
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+        ):
+            definitions[stmt.targets[0].id] = stmt.value
+    return definitions
+
+
+def _binding_write_roots(node: ast.AST) -> set[str]:
+    """Return names whose bindings or reachable values may be mutated."""
+
+    def root_name(target: ast.AST) -> str | None:
+        while isinstance(target, (ast.Attribute, ast.Subscript)):
+            target = target.value
+        return target.id if isinstance(target, ast.Name) else None
+
+    result: set[str] = set()
+    for child in ast.walk(node):
+        if isinstance(child, ast.Name) and isinstance(child.ctx, (ast.Store, ast.Del)):
+            result.add(child.id)
+        elif isinstance(child, (ast.Attribute, ast.Subscript)) and isinstance(
+            child.ctx, (ast.Store, ast.Del)
+        ):
+            if (name := root_name(child)) is not None:
+                result.add(name)
+        elif isinstance(child, ast.ExceptHandler) and child.name is not None:
+            result.add(child.name)
+    return result
+
+
+def _mutated_value_roots(node: ast.AST) -> set[str]:
+    """Return base names mutated through an attribute or subscript."""
+
+    def root_name(target: ast.AST) -> str | None:
+        while isinstance(target, (ast.Attribute, ast.Subscript)):
+            target = target.value
+        return target.id if isinstance(target, ast.Name) else None
+
+    return {
+        name
+        for child in ast.walk(node)
+        if isinstance(child, (ast.Attribute, ast.Subscript))
+        and isinstance(child.ctx, (ast.Store, ast.Del))
+        and (name := root_name(child)) is not None
+    }
+
+
+def _freeze_definition(
+    node: ast.expr,
+    definitions: dict[str, ast.expr],
+) -> ast.expr:
+    """Inline known values so a definition keeps assignment-time semantics."""
+
+    class _FreezeNames(ast.NodeTransformer):
+        def __init__(self) -> None:
+            super().__init__()
+            self.expanding: set[str] = set()
+
+        def visit_Name(self, node: ast.Name) -> ast.AST:
+            if not isinstance(node.ctx, ast.Load) or node.id in self.expanding:
+                return node
+            definition = definitions.get(node.id)
+            if definition is None:
+                return node
+            self.expanding.add(node.id)
+            replacement = self.visit(_clone_expr(definition))
+            self.expanding.remove(node.id)
+            return ast.copy_location(replacement, node)
+
+    result = _FreezeNames().visit(_clone_expr(node))
+    assert isinstance(result, ast.expr)
+    return result
+
+
+def _definition_snapshots(
+    statements: list[ast.stmt],
+) -> list[dict[str, ast.expr]]:
+    """Return the definitions dominating each top-level statement."""
+    definitions: dict[str, ast.expr] = {}
+    result: list[dict[str, ast.expr]] = []
+    for statement in statements:
+        result.append(dict(definitions))
+        exact_definitions = _single_name_definitions([statement])
+        # Definitions retain source expressions rather than assignment-time
+        # values.  Invalidate every definition that transitively depends on a
+        # written name before recording the new exact definitions.  Otherwise
+        # a later reassignment could make two historically different address
+        # aliases expand to the same current expression.  Unmodelled writes
+        # (AugAssign, structured assignment, and control flow) also kill the
+        # name itself because they have no unconditional post-value to inline.
+        invalidated = {
+            *ReadWrites.from_ast(statement).writes,
+            *_binding_write_roots(statement),
+        }
+        # A structured write through ``alias`` also mutates the object named
+        # by ``alias = original``.  Frozen definitions retain that referent as
+        # a read, so invalidate it (and all definitions depending on it) too.
+        # This is deliberately conservative for non-name RHS expressions.
+        for name in _mutated_value_roots(statement):
+            definition = definitions.get(name)
+            if definition is not None:
+                invalidated.update(ReadWrites.from_ast(definition).reads)
+        while invalidated:
+            newly_invalidated: set[str] = set()
+            for name, value in tuple(definitions.items()):
+                if name in invalidated or (
+                    set(ReadWrites.from_ast(value).reads) & invalidated
+                ):
+                    definitions.pop(name)
+                    newly_invalidated.add(name)
+            invalidated = newly_invalidated
+        definitions.update(
+            {
+                name: _freeze_definition(value, definitions)
+                for name, value in exact_definitions.items()
+            }
+        )
+    return result
+
+
+def _unstable_address_names(
+    body: list[ast.stmt], lane_var: str, load_index: int, store_index: int
+) -> set[str]:
+    """Names whose value may differ across a load/store loop backedge."""
+    definitely_written: set[str] = set()
+    live_in: set[str] = set()
+    may_writes: set[str] = set()
+    for statement in body:
+        effects = ReadWrites.from_ast(statement)
+        live_in.update(set(effects.reads) - definitely_written - {lane_var})
+        may_writes.update(effects.writes)
+        if isinstance(statement, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+            definitely_written.update(effects.writes)
+    result = live_in & may_writes
+    if store_index > load_index:
+        for crossed_statement in body[load_index + 1 : store_index + 1]:
+            result.update(ReadWrites.from_ast(crossed_statement).writes)
+    return result
+
+
+class _CollectMemoryLoads(ast.NodeVisitor):
+    """Collect logical loads without double-counting a marker's scalar fallback."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[ast.Call] = []
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if _marker_call(node, _LOAD_MARKER, 6) is not None:
+            self.calls.append(node)
+            return
+        if isinstance(node.func, ast.Attribute) and node.func.attr == "load":
+            self.calls.append(node)
+            return
+        self.generic_visit(node)
+
+
+def _memory_load_calls(node: ast.AST) -> list[ast.Call]:
+    collector = _CollectMemoryLoads()
+    collector.visit(node)
+    return collector.calls
+
+
+def _lane_dependent_alias_expansion(
+    node: ast.expr,
+    definitions: dict[str, ast.expr],
+    lane_var: str,
+) -> ast.expr:
+    dependency_cache: dict[str, bool] = {}
+    resolving: set[str] = set()
+
+    def depends_on_lane(name: str) -> bool:
+        if name == lane_var:
+            return True
+        cached = dependency_cache.get(name)
+        if cached is not None:
+            return cached
+        definition = definitions.get(name)
+        if definition is None or name in resolving:
+            dependency_cache[name] = False
+            return False
+        resolving.add(name)
+        result = any(
+            depends_on_lane(read) for read in ReadWrites.from_ast(definition).reads
+        )
+        resolving.remove(name)
+        dependency_cache[name] = result
+        return result
+
+    class _ExpandLaneAliases(ast.NodeTransformer):
+        def __init__(self) -> None:
+            super().__init__()
+            self.expanding: set[str] = set()
+
+        def visit_Name(self, node: ast.Name) -> ast.AST:
+            if (
+                not isinstance(node.ctx, ast.Load)
+                or node.id == lane_var
+                or not depends_on_lane(node.id)
+                or node.id in self.expanding
+            ):
+                return node
+            definition = definitions.get(node.id)
+            if definition is None:
+                return node
+            self.expanding.add(node.id)
+            replacement = self.visit(_clone_expr(definition))
+            self.expanding.remove(node.id)
+            return ast.copy_location(replacement, node)
+
+    expanded = _ExpandLaneAliases().visit(_clone_expr(node))
+    assert isinstance(expanded, ast.expr)
+    return expanded
+
+
+def _is_affine_in_lane(node: ast.AST, lane_var: str) -> tuple[bool, bool]:
+    """Return ``(depends_on_lane, is_affine)`` for pointer arithmetic."""
+    if isinstance(node, ast.Name):
+        return node.id == lane_var, True
+    if isinstance(node, ast.UnaryOp):
+        depends, valid = _is_affine_in_lane(node.operand, lane_var)
+        return depends, valid and isinstance(node.op, (ast.UAdd, ast.USub))
+    if isinstance(node, ast.BinOp):
+        left_depends, left_valid = _is_affine_in_lane(node.left, lane_var)
+        right_depends, right_valid = _is_affine_in_lane(node.right, lane_var)
+        depends = left_depends or right_depends
+        if not depends:
+            return False, left_valid and right_valid
+        if not left_valid or not right_valid or left_depends and right_depends:
+            return True, False
+        if isinstance(node.op, ast.Add):
+            return True, True
+        if isinstance(node.op, ast.Sub):
+            return True, left_depends
+        if isinstance(node.op, ast.Mult):
+            return True, True
+        return True, False
+    if isinstance(node, ast.Call):
+        dependencies = [_is_affine_in_lane(arg, lane_var) for arg in node.args]
+        depends = any(item[0] for item in dependencies)
+        if not depends:
+            return False, all(item[1] for item in dependencies)
+        is_cutlass_cast = (
+            len(node.args) == 1
+            and not node.keywords
+            and ast.unparse(node.func).startswith("cutlass.")
+        )
+        return True, is_cutlass_cast and all(item[1] for item in dependencies)
+    dependencies = [
+        _is_affine_in_lane(child, lane_var) for child in ast.iter_child_nodes(node)
+    ]
+    depends = any(item[0] for item in dependencies)
+    return depends, not depends and all(item[1] for item in dependencies)
+
+
+def _plain_scalar_load_pointer(call: ast.Call) -> ast.expr | None:
+    """Return the pointer of a generated scalar ``PTR.load()`` call."""
+    if (
+        isinstance(call.func, ast.Attribute)
+        and call.func.attr == "load"
+        and not call.args
+        and not call.keywords
+    ):
+        return call.func.value
+    return None
+
+
+def _plain_scalar_store_pointer(call: ast.Call) -> ast.expr | None:
+    """Return the pointer of a generated scalar ``PTR.store(value)`` call."""
+    if (
+        isinstance(call.func, ast.Attribute)
+        and call.func.attr == "store"
+        and len(call.args) == 1
+        and not call.keywords
+    ):
+        return call.func.value
+    return None
+
+
+def _single_tensor_iterator_root(node: ast.AST) -> str | None:
+    roots = {
+        child.value.id
+        for child in ast.walk(node)
+        if isinstance(child, ast.Attribute)
+        and child.attr == "iterator"
+        and isinstance(child.value, ast.Name)
+    }
+    return next(iter(roots)) if len(roots) == 1 else None
+
+
+def _tensor_stride_reference(node: ast.AST) -> tuple[str, int] | None:
+    while (
+        isinstance(node, ast.Call)
+        and len(node.args) == 1
+        and not node.keywords
+        and ast.unparse(node.func) in ("cutlass.Int32", "cutlass.Int64")
+    ):
+        node = node.args[0]
+    if not (
+        isinstance(node, ast.Subscript)
+        and isinstance(node.slice, ast.Constant)
+        and isinstance(node.slice.value, int)
+        and isinstance(node.value, ast.Attribute)
+        and node.value.attr == "stride"
+        and isinstance(node.value.value, ast.Attribute)
+        and node.value.value.attr == "layout"
+        and isinstance(node.value.value.value, ast.Name)
+    ):
+        return None
+    return node.value.value.value.id, node.slice.value
+
+
+def _lane_scale_value(
+    node: ast.AST,
+    proven_tensor_stride_values: Mapping[tuple[str, int], int],
+) -> int | None:
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, int) and not isinstance(node.value, bool):
+            return node.value
+        return None
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+        value = _lane_scale_value(node.operand, proven_tensor_stride_values)
+        if value is None:
+            return None
+        return value if isinstance(node.op, ast.UAdd) else -value
+    if (
+        isinstance(node, ast.Call)
+        and len(node.args) == 1
+        and not node.keywords
+        and ast.unparse(node.func) in ("cutlass.Int32", "cutlass.Int64")
+    ):
+        return _lane_scale_value(node.args[0], proven_tensor_stride_values)
+    if isinstance(node, ast.BinOp) and isinstance(
+        node.op, (ast.Add, ast.Sub, ast.Mult)
+    ):
+        left = _lane_scale_value(node.left, proven_tensor_stride_values)
+        right = _lane_scale_value(node.right, proven_tensor_stride_values)
+        if left is None or right is None:
+            return None
+        if isinstance(node.op, ast.Add):
+            return left + right
+        if isinstance(node.op, ast.Sub):
+            return left - right
+        return left * right
+    stride = _tensor_stride_reference(node)
+    return proven_tensor_stride_values.get(stride) if stride is not None else None
+
+
+def _scalar_pointer_calls_are_known(node: ast.AST) -> bool:
+    """Whether every call has transparent integer-coordinate semantics."""
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        name = ast.unparse(child.func)
+        if name in ("cutlass.Int32", "cutlass.Int64"):
+            if len(child.args) != 1 or child.keywords:
+                return False
+            continue
+        if name in (
+            "cute.arch.block_idx",
+            "cute.arch.thread_idx",
+            "cute.arch.warp_idx",
+        ):
+            if child.args or child.keywords:
+                return False
+            continue
+        return False
+    return True
+
+
+def _scalar_pointer_is_known_affine(node: ast.AST, lane_var: str) -> bool:
+    """Reject pointer expressions whose affine semantics are not transparent."""
+    if not _scalar_pointer_calls_are_known(node):
+        return False
+    depends, affine = _is_affine_in_lane(node, lane_var)
+    return depends and affine
+
+
+def _scalar_lane_mapping_is_injective(
+    node: ast.AST,
+    lane_var: str,
+    lane_extent: int,
+    proven_tensor_stride_values: Mapping[tuple[str, int], int],
+) -> bool:
+    """Prove distinct lanes produce distinct scalar pointer offsets."""
+
+    def visit(expr: ast.AST) -> tuple[bool, int | None]:
+        if isinstance(expr, ast.Name):
+            return (True, 1) if expr.id == lane_var else (False, 0)
+        if isinstance(expr, ast.UnaryOp):
+            depends, coefficient = visit(expr.operand)
+            if not isinstance(expr.op, (ast.UAdd, ast.USub)):
+                return depends, None if depends else 0
+            if coefficient is None:
+                return depends, None
+            return depends, coefficient if isinstance(
+                expr.op, ast.UAdd
+            ) else -coefficient
+        if isinstance(expr, ast.BinOp):
+            left_depends, left_coefficient = visit(expr.left)
+            right_depends, right_coefficient = visit(expr.right)
+            if not left_depends and not right_depends:
+                return False, 0
+            if left_depends and right_depends:
+                return True, None
+            coefficient = left_coefficient if left_depends else right_coefficient
+            if coefficient is None:
+                return True, None
+            if isinstance(expr.op, ast.Add):
+                return True, coefficient
+            if isinstance(expr.op, ast.Sub):
+                return True, coefficient if left_depends else -coefficient
+            if isinstance(expr.op, ast.Mult):
+                scale = expr.right if left_depends else expr.left
+                scale_value = _lane_scale_value(scale, proven_tensor_stride_values)
+                return (
+                    True,
+                    None if scale_value is None else coefficient * scale_value,
+                )
+            return True, None
+        if isinstance(expr, ast.Call):
+            dependencies = [visit(arg) for arg in expr.args]
+            depends = any(item[0] for item in dependencies)
+            if not depends:
+                return False, 0
+            is_integer_cast = (
+                len(expr.args) == 1
+                and not expr.keywords
+                and ast.unparse(expr.func) in ("cutlass.Int32", "cutlass.Int64")
+            )
+            return True, dependencies[0][1] if is_integer_cast else None
+        dependencies = [visit(child) for child in ast.iter_child_nodes(expr)]
+        depends = any(item[0] for item in dependencies)
+        return depends, 0 if not depends else None
+
+    depends, coefficient = visit(node)
+    if not depends or coefficient in (None, 0):
+        return False
+    # Generated scalar indices may narrow through Int32.  Checking every
+    # finite lane delta modulo 2**32 proves injectivity even when a known
+    # coefficient itself wraps; it is conservative for wider arithmetic.
+    return all(
+        (coefficient * delta) % (1 << 32) != 0 for delta in range(1, lane_extent)
+    )
+
+
+def _pointer_integer_affine_form(
+    node: ast.AST,
+    lane_var: str,
+    proven_tensor_stride_values: Mapping[tuple[str, int], int],
+    unstable_names: set[str],
+    site: str,
+) -> tuple[int, dict[str, int], int] | None:
+    """Return ``(lane coefficient, opaque coefficients, constant)``.
+
+    Generated pointer offsets are integer-affine combinations of coordinates
+    and exact tensor strides.  Lane-independent coordinates need not be equal
+    at two accesses: retaining them as opaque integer atoms lets the caller
+    prove that every possible base difference is a multiple of a safe row
+    stride.  Unknown tensor strides and lane-dependent nonlinear expressions
+    fail closed.
+    """
+
+    def add_forms(
+        left: tuple[int, dict[str, int], int],
+        right: tuple[int, dict[str, int], int],
+        sign: int = 1,
+    ) -> tuple[int, dict[str, int], int]:
+        lane = left[0] + sign * right[0]
+        opaque = dict(left[1])
+        for key, coefficient in right[1].items():
+            updated = opaque.get(key, 0) + sign * coefficient
+            if updated:
+                opaque[key] = updated
+            else:
+                opaque.pop(key, None)
+        return lane, opaque, left[2] + sign * right[2]
+
+    def scale_form(
+        form: tuple[int, dict[str, int], int], coefficient: int
+    ) -> tuple[int, dict[str, int], int]:
+        return (
+            form[0] * coefficient,
+            {
+                key: value * coefficient
+                for key, value in form[1].items()
+                if value * coefficient
+            },
+            form[2] * coefficient,
+        )
+
+    def opaque_atom(expr: ast.AST) -> tuple[int, dict[str, int], int] | None:
+        if lane_var in ReadWrites.from_ast(expr).reads:
+            return None
+        if not _scalar_pointer_calls_are_known(expr):
+            return None
+        key = ast.dump(expr, include_attributes=False)
+        if set(ReadWrites.from_ast(expr).reads) & unstable_names:
+            key = f"{site}:{key}"
+        return 0, {key: 1}, 0
+
+    def visit(expr: ast.AST) -> tuple[int, dict[str, int], int] | None:
+        stride = _tensor_stride_reference(expr)
+        if stride is not None:
+            value = proven_tensor_stride_values.get(stride)
+            return None if value is None else (0, {}, value)
+        if isinstance(expr, ast.Constant):
+            if isinstance(expr.value, int) and not isinstance(expr.value, bool):
+                return 0, {}, expr.value
+            return None
+        if isinstance(expr, ast.Name):
+            if expr.id == lane_var:
+                return 1, {}, 0
+            return opaque_atom(expr)
+        if isinstance(expr, ast.UnaryOp) and isinstance(expr.op, (ast.UAdd, ast.USub)):
+            operand = visit(expr.operand)
+            if operand is None:
+                return None
+            return operand if isinstance(expr.op, ast.UAdd) else scale_form(operand, -1)
+        if (
+            isinstance(expr, ast.Call)
+            and len(expr.args) == 1
+            and not expr.keywords
+            and ast.unparse(expr.func) in ("cutlass.Int32", "cutlass.Int64")
+        ):
+            return visit(expr.args[0])
+        if isinstance(expr, ast.BinOp) and isinstance(
+            expr.op, (ast.Add, ast.Sub, ast.Mult)
+        ):
+            if isinstance(expr.op, ast.Mult):
+                left_constant = _lane_scale_value(
+                    expr.left, proven_tensor_stride_values
+                )
+                right_constant = _lane_scale_value(
+                    expr.right, proven_tensor_stride_values
+                )
+                if left_constant is not None:
+                    right = visit(expr.right)
+                    return None if right is None else scale_form(right, left_constant)
+                if right_constant is not None:
+                    left = visit(expr.left)
+                    return None if left is None else scale_form(left, right_constant)
+                return None
+            left = visit(expr.left)
+            right = visit(expr.right)
+            if left is None or right is None:
+                return None
+            return add_forms(left, right, -1 if isinstance(expr.op, ast.Sub) else 1)
+        return opaque_atom(expr)
+
+    return visit(node)
+
+
+def _scalar_pointers_are_modularly_lane_disjoint(
+    load_pointer: ast.expr,
+    store_pointer: ast.expr,
+    *,
+    lane_var: str,
+    lane_extent: int,
+    proven_tensor_stride_values: Mapping[tuple[str, int], int],
+    unstable_names: set[str],
+) -> bool:
+    """Prove cross-lane disjointness despite different row/checkpoint bases.
+
+    If both pointers advance by the same nonzero lane step and every possible
+    difference between their lane-independent bases is a multiple of ``M``, a
+    cross-iteration dependence is impossible when ``step * delta`` is nonzero
+    modulo ``M`` for every live lane delta.  Including the Int32 modulus keeps
+    the proof sound under generated index narrowing.
+    """
+    load_root = _single_tensor_iterator_root(load_pointer)
+    store_root = _single_tensor_iterator_root(store_pointer)
+    if load_root is None or load_root != store_root:
+        return False
+    if not _scalar_pointer_calls_are_known(
+        load_pointer
+    ) or not _scalar_pointer_calls_are_known(store_pointer):
+        return False
+    load_form = _pointer_integer_affine_form(
+        load_pointer,
+        lane_var,
+        proven_tensor_stride_values,
+        unstable_names,
+        "load",
+    )
+    store_form = _pointer_integer_affine_form(
+        store_pointer,
+        lane_var,
+        proven_tensor_stride_values,
+        unstable_names,
+        "store",
+    )
+    if load_form is None or store_form is None:
+        return False
+    lane_coefficient = load_form[0]
+    if lane_coefficient == 0 or lane_coefficient != store_form[0]:
+        return False
+    base_coefficients = dict(load_form[1])
+    for key, coefficient in store_form[1].items():
+        updated = base_coefficients.get(key, 0) - coefficient
+        if updated:
+            base_coefficients[key] = updated
+        else:
+            base_coefficients.pop(key, None)
+    modulus = 1 << 32
+    modulus = math.gcd(modulus, abs(load_form[2] - store_form[2]))
+    for coefficient in base_coefficients.values():
+        modulus = math.gcd(modulus, abs(coefficient))
+    return modulus > 1 and all(
+        (lane_coefficient * delta) % modulus != 0 for delta in range(1, lane_extent)
+    )
+
+
+def _same_stable_address_aliases(
+    node: ast.AST,
+    load_definitions: dict[str, ast.expr],
+    store_definitions: dict[str, ast.expr],
+    lane_var: str,
+    unstable_names: set[str],
+) -> bool:
+    """Ensure opaque lane-independent locals mean the same value at both sites."""
+    visiting: set[str] = set()
+    checked: set[str] = set()
+
+    def check(name: str) -> bool:
+        if name == lane_var or name in checked:
+            return True
+        if name in unstable_names:
+            return False
+        load_definition = load_definitions.get(name)
+        store_definition = store_definitions.get(name)
+        if load_definition is None or store_definition is None:
+            return load_definition is store_definition
+        if name in visiting:
+            return False
+        if ast.dump(load_definition, include_attributes=False) != ast.dump(
+            store_definition, include_attributes=False
+        ):
+            return False
+        if not _scalar_pointer_calls_are_known(load_definition):
+            return False
+        visiting.add(name)
+        result = all(
+            check(dependency)
+            for dependency in ReadWrites.from_ast(load_definition).reads
+        )
+        visiting.remove(name)
+        if result:
+            checked.add(name)
+        return result
+
+    return all(
+        check(name) for name in ReadWrites.from_ast(node).reads if name != lane_var
+    )
+
+
+def _lane_accesses_are_iteration_independent(
+    load_call: ast.Call,
+    store_call: ast.Call,
+    *,
+    lane_var: str,
+    lane_extent: int | None,
+    load_definitions: dict[str, ast.expr],
+    store_definitions: dict[str, ast.expr],
+    proven_tensor_stride_values: Mapping[tuple[str, int], int] | None = None,
+    loop_carried_names: set[str] | None = None,
+) -> bool:
+    """Prove an exact load/store pair cannot communicate across lane iterations.
+
+    Persistent vector markers prove injectivity through their matching exact-
+    fragment metadata.  Plain scalar accesses instead require one known tensor
+    iterator, stable address aliases, an identical affine pointer function, and
+    an injective lane step backed by literals and cache-safe exact tensor-stride
+    values.  Both paths preserve same-iteration load-before-store order while
+    proving that iteration ``i`` cannot access iteration ``j``'s element.
+    Shifted/unknown scalar accesses and atomics deliberately fail closed.
+    """
+    if lane_extent is None:
+        return False
+    load_marker = _marker_call(load_call, _LOAD_MARKER, 6)
+    store_marker = _marker_call(store_call, _STORE_MARKER, 6)
+    if (load_marker is None) != (store_marker is None):
+        return False
+    if load_marker is None:
+        load_pointer = _plain_scalar_load_pointer(load_call)
+        store_pointer = _plain_scalar_store_pointer(store_call)
+        if load_pointer is None or store_pointer is None:
+            return False
+        unstable_names = loop_carried_names or set()
+        expanded_load = _lane_dependent_alias_expansion(
+            load_pointer, load_definitions, lane_var
+        )
+        expanded_store = _lane_dependent_alias_expansion(
+            store_pointer, store_definitions, lane_var
+        )
+        exact_mapping = (
+            ast.dump(expanded_load, include_attributes=False)
+            == ast.dump(expanded_store, include_attributes=False)
+            and _single_tensor_iterator_root(expanded_load) is not None
+            and not bool(
+                (set(ReadWrites.from_ast(expanded_load).reads) - {lane_var})
+                & unstable_names
+            )
+            and _same_stable_address_aliases(
+                expanded_load,
+                load_definitions,
+                store_definitions,
+                lane_var,
+                unstable_names,
+            )
+            and _scalar_pointer_is_known_affine(expanded_load, lane_var)
+        )
+        if exact_mapping and _scalar_lane_mapping_is_injective(
+            expanded_load,
+            lane_var,
+            lane_extent,
+            proven_tensor_stride_values or {},
+        ):
+            return True
+        return _scalar_pointers_are_modularly_lane_disjoint(
+            expanded_load,
+            expanded_store,
+            lane_var=lane_var,
+            lane_extent=lane_extent,
+            proven_tensor_stride_values=proven_tensor_stride_values or {},
+            unstable_names=unstable_names,
+        )
+    assert store_marker is not None
+    load_block = _literal(load_marker.args[0], int)
+    load_width = _literal(load_marker.args[1], int)
+    load_dtype = _literal(load_marker.args[2], str)
+    store_block = _literal(store_marker.args[0], int)
+    store_width = _literal(store_marker.args[1], int)
+    store_dtype = _literal(store_marker.args[2], str)
+    lane_match = _SYNTHETIC_LANE_RE.fullmatch(lane_var)
+    if (
+        lane_match is None
+        or not isinstance(load_block, int)
+        or load_block != store_block
+        or load_block != int(lane_match.group(1))
+        or not isinstance(load_width, int)
+        or load_width != store_width
+        or load_width != lane_extent
+        or load_dtype != store_dtype
+    ):
+        return False
+
+    load_pointer = load_marker.args[4]
+    store_pointer = store_marker.args[3]
+    if not isinstance(load_pointer, ast.expr) or not isinstance(
+        store_pointer, ast.expr
+    ):
+        return False
+    expanded_load = _lane_dependent_alias_expansion(
+        load_pointer, load_definitions, lane_var
+    )
+    expanded_store = _lane_dependent_alias_expansion(
+        store_pointer, store_definitions, lane_var
+    )
+    unstable_names = loop_carried_names or set()
+    if ast.dump(expanded_load, include_attributes=False) == ast.dump(
+        expanded_store, include_attributes=False
+    ) and _same_stable_address_aliases(
+        expanded_load,
+        load_definitions,
+        store_definitions,
+        lane_var,
+        unstable_names,
+    ):
+        depends, affine = _is_affine_in_lane(expanded_load, lane_var)
+        if depends and affine:
+            return True
+    return _scalar_pointers_are_modularly_lane_disjoint(
+        expanded_load,
+        expanded_store,
+        lane_var=lane_var,
+        lane_extent=lane_extent,
+        proven_tensor_stride_values=proven_tensor_stride_values or {},
+        unstable_names=unstable_names,
+    )
+
+
+def _store_accesses_are_iteration_independent(
+    first_call: ast.Call,
+    second_call: ast.Call,
+    *,
+    lane_var: str,
+    lane_extent: int,
+    first_definitions: dict[str, ast.expr],
+    second_definitions: dict[str, ast.expr],
+    proven_tensor_stride_values: Mapping[tuple[str, int], int],
+    unstable_names: set[str],
+) -> bool:
+    """Prove two ordinary exact-fragment stores independent across lanes."""
+    first_marker = _marker_call(first_call, _STORE_MARKER, 6)
+    second_marker = _marker_call(second_call, _STORE_MARKER, 6)
+    if first_marker is None or second_marker is None:
+        return False
+    lane_match = _SYNTHETIC_LANE_RE.fullmatch(lane_var)
+    signatures = [
+        (
+            _literal(marker.args[0], int),
+            _literal(marker.args[1], int),
+            _literal(marker.args[2], str),
+        )
+        for marker in (first_marker, second_marker)
+    ]
+    if (
+        lane_match is None
+        or signatures[0] != signatures[1]
+        or signatures[0][0] != int(lane_match.group(1))
+        or signatures[0][1] != lane_extent
+    ):
+        return False
+    first_pointer = first_marker.args[3]
+    second_pointer = second_marker.args[3]
+    if not isinstance(first_pointer, ast.expr) or not isinstance(
+        second_pointer, ast.expr
+    ):
+        return False
+    expanded_first = _lane_dependent_alias_expansion(
+        first_pointer, first_definitions, lane_var
+    )
+    expanded_second = _lane_dependent_alias_expansion(
+        second_pointer, second_definitions, lane_var
+    )
+    if ast.dump(expanded_first, include_attributes=False) == ast.dump(
+        expanded_second, include_attributes=False
+    ) and _same_stable_address_aliases(
+        expanded_first,
+        first_definitions,
+        second_definitions,
+        lane_var,
+        unstable_names,
+    ):
+        depends, affine = _is_affine_in_lane(expanded_first, lane_var)
+        if depends and affine:
+            return True
+    return _scalar_pointers_are_modularly_lane_disjoint(
+        expanded_first,
+        expanded_second,
+        lane_var=lane_var,
+        lane_extent=lane_extent,
+        proven_tensor_stride_values=proven_tensor_stride_values,
+        unstable_names=unstable_names,
+    )
+
+
+class _ExpandLocalAliases(ast.NodeTransformer):
+    def __init__(
+        self,
+        definitions: dict[str, ast.expr],
+        lane_var: str,
+        lane_replacement: ast.expr | None,
+    ) -> None:
+        super().__init__()
+        self.definitions = definitions
+        self.lane_var = lane_var
+        self.lane_replacement = lane_replacement
+        self.expanding: set[str] = set()
+
+    def visit_Name(self, node: ast.Name) -> ast.AST:
+        if not isinstance(node.ctx, ast.Load):
+            return node
+        if node.id == self.lane_var:
+            if self.lane_replacement is None:
+                return node
+            return ast.copy_location(_clone_expr(self.lane_replacement), node)
+        value = self.definitions.get(node.id)
+        if value is None or node.id in self.expanding:
+            return node
+        self.expanding.add(node.id)
+        replacement = self.visit(_clone_expr(value))
+        self.expanding.remove(node.id)
+        return ast.copy_location(replacement, node)
+
+
+def _expand(
+    node: ast.expr,
+    definitions: dict[str, ast.expr],
+    lane_var: str,
+    lane_replacement: ast.expr | None = None,
+) -> ast.expr:
+    result = _ExpandLocalAliases(definitions, lane_var, lane_replacement).visit(
+        _clone_expr(node)
+    )
+    assert isinstance(result, ast.expr)
+    return result
+
+
+def _and_terms(node: ast.expr) -> list[ast.expr]:
+    if isinstance(node, ast.BoolOp) and isinstance(node.op, ast.And):
+        return [term for value in node.values for term in _and_terms(value)]
+    return [node]
+
+
+def _uniform_guard(
+    mask: ast.expr | None,
+    definitions: dict[str, ast.expr],
+    lane_var: str,
+    width: int,
+    local_writes: set[str],
+) -> tuple[bool, ast.expr | None]:
+    if mask is None:
+        return True, None
+    expanded = _expand(mask, definitions, lane_var)
+    uniform: list[ast.expr] = []
+    for term in _and_terms(expanded):
+        reads = set(ReadWrites.from_ast(term).reads)
+        if lane_var in reads:
+            if not isinstance(term, ast.Compare):
+                return False, None
+            # Prove the complete contiguous fragment is live by checking both
+            # endpoints outside the loop.  The candidate's earlier unit-affine
+            # proof makes this sufficient for generated tensor-bound compares.
+            endpoints = (
+                _expand(term, definitions, lane_var, ast.Constant(value=0)),
+                _expand(
+                    term,
+                    definitions,
+                    lane_var,
+                    ast.Constant(value=width - 1),
+                ),
+            )
+            if any(
+                set(ReadWrites.from_ast(endpoint).reads) & local_writes
+                for endpoint in endpoints
+            ):
+                return False, None
+            uniform.extend(endpoints)
+            continue
+        if reads & local_writes:
+            return False, None
+        uniform.append(term)
+    if any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in ("load", "store")
+        for term in uniform
+        for node in ast.walk(term)
+    ):
+        return False, None
+    if not uniform:
+        return True, None
+    if len(uniform) == 1:
+        return True, uniform[0]
+    return True, ast.BoolOp(op=ast.And(), values=uniform)
+
+
+def _flatten_add(node: ast.expr) -> list[ast.expr]:
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        return [*_flatten_add(node.left), *_flatten_add(node.right)]
+    return [node]
+
+
+def _sum_terms(terms: list[ast.expr]) -> ast.expr:
+    assert terms
+    result = _clone_expr(terms[0])
+    for term in terms[1:]:
+        result = ast.BinOp(left=result, op=ast.Add(), right=_clone_expr(term))
+    return result
+
+
+def _safe_base_pointer(
+    pointer: ast.expr,
+    definitions: dict[str, ast.expr],
+    lane_var: str,
+    local_writes: set[str],
+    guard: ast.expr | None,
+) -> ast.expr | None:
+    expanded_with_lane = _expand(pointer, definitions, lane_var)
+    if lane_var not in set(ReadWrites.from_ast(expanded_with_lane).reads):
+        return None
+    base = _expand(pointer, definitions, lane_var, ast.Constant(value=0))
+    if set(ReadWrites.from_ast(base).reads) & local_writes:
+        return None
+    if any(
+        isinstance(node, ast.Call)
+        and (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr in ("load", "store")
+            or isinstance(node.func, ast.Name)
+            and node.func.id in (_LOAD_MARKER, _STORE_MARKER)
+        )
+        for node in ast.walk(base)
+    ):
+        return None
+    if guard is None:
+        return base
+
+    terms = _flatten_add(base)
+    iterator_indices = [
+        index
+        for index, term in enumerate(terms)
+        if isinstance(term, ast.Attribute)
+        and term.attr == "iterator"
+        and isinstance(term.value, ast.Name)
+    ]
+    if len(iterator_indices) != 1 or len(terms) == 1:
+        return None
+    iterator_index = iterator_indices[0]
+    iterator = terms[iterator_index]
+    offset = _sum_terms(
+        [term for index, term in enumerate(terms) if index != iterator_index]
+    )
+    return ast.BinOp(
+        left=_clone_expr(iterator),
+        op=ast.Add(),
+        right=ast.IfExp(
+            test=_clone_expr(guard),
+            body=offset,
+            orelse=ast.parse("cutlass.Int32(0)", mode="eval").body,
+        ),
+    )
+
+
+def _scalar_load_and_mask(node: ast.expr) -> tuple[ast.Call, ast.expr | None] | None:
+    if isinstance(node, ast.IfExp):
+        value = node.body
+        mask = node.test
+    else:
+        value = node
+        mask = None
+    if (
+        isinstance(value, ast.Call)
+        and isinstance(value.func, ast.Attribute)
+        and value.func.attr == "load"
+    ):
+        return value, mask
+    return None
+
+
+class _ReplaceCall(ast.NodeTransformer):
+    def __init__(self, target: ast.Call, replacement: ast.expr) -> None:
+        super().__init__()
+        self.target = ast.dump(target, include_attributes=False)
+        self.replacement = replacement
+        self.replaced = False
+
+    def visit_Call(self, node: ast.Call) -> ast.AST:
+        if (
+            not self.replaced
+            and ast.dump(node, include_attributes=False) == self.target
+        ):
+            self.replaced = True
+            return _clone_expr(self.replacement)
+        return self.generic_visit(node)
+
+
+class _RestoreLoadMarkers(ast.NodeTransformer):
+    def visit_Call(self, node: ast.Call) -> ast.AST:
+        marker = _marker_call(node, _LOAD_MARKER, 6)
+        if marker is not None:
+            return self.visit(_clone_expr(marker.args[5]))
+        return self.generic_visit(node)
+
+
+class _BranchLocalPersistentVectorizer:
+    def __init__(
+        self,
+        body: list[ast.stmt],
+        proven_disjoint_tensor_pairs: set[frozenset[str]],
+        proven_tensor_stride_values: Mapping[tuple[str, int], int],
+    ) -> None:
+        self.used_names = {
+            node.id
+            for stmt in body
+            for node in ast.walk(stmt)
+            if isinstance(node, ast.Name)
+        }
+        self.counter = 0
+        self.proven_disjoint_tensor_pairs = proven_disjoint_tensor_pairs
+        self.proven_tensor_stride_values = proven_tensor_stride_values
+
+    def _fresh(self, prefix: str) -> str:
+        while True:
+            name = f"{prefix}_{self.counter}"
+            self.counter += 1
+            if name not in self.used_names:
+                self.used_names.add(name)
+                return name
+
+    @staticmethod
+    def _store_marker(stmt: ast.stmt) -> ast.Call | None:
+        if not isinstance(stmt, ast.Expr):
+            return None
+        return _marker_call(stmt.value, _STORE_MARKER, 6)
+
+    @staticmethod
+    def _restore_store(marker: ast.Call) -> list[ast.stmt]:
+        pointer, value, mask = marker.args[3:]
+        store = ast.Expr(
+            value=ast.Call(
+                func=ast.Attribute(
+                    value=_clone_expr(pointer), attr="store", ctx=ast.Load()
+                ),
+                args=[_clone_expr(value)],
+                keywords=[],
+            )
+        )
+        if isinstance(mask, ast.Constant) and mask.value is None:
+            return [store]
+        return [
+            ast.If(test=_clone_expr(mask), body=[store], orelse=[]),
+        ]
+
+    @staticmethod
+    def _pointer_roots(node: ast.AST) -> frozenset[str] | None:
+        roots: set[str] = set()
+        unresolved = False
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Attribute) or child.attr != "iterator":
+                continue
+            if isinstance(child.value, ast.Name):
+                roots.add(child.value.id)
+            else:
+                unresolved = True
+        if unresolved:
+            return None
+        return frozenset(roots) if roots else None
+
+    def _may_alias(
+        self,
+        left: frozenset[str] | None,
+        right: frozenset[str] | None,
+    ) -> bool:
+        if left is None or right is None:
+            return True
+        return any(
+            left_name == right_name
+            or frozenset((left_name, right_name))
+            not in self.proven_disjoint_tensor_pairs
+            for left_name in left
+            for right_name in right
+        )
+
+    @staticmethod
+    def _contains_arch_attribute(node: ast.AST) -> bool:
+        return any(
+            isinstance(child, ast.Attribute) and child.attr == "arch"
+            for child in ast.walk(node)
+        )
+
+    @classmethod
+    def _load_pointer(cls, node: ast.Call) -> ast.AST | None:
+        marker = _marker_call(node, _LOAD_MARKER, 6)
+        if marker is not None:
+            return marker.args[4]
+        if not (isinstance(node.func, ast.Attribute) and node.func.attr == "load"):
+            return None
+        if node.args and cls._contains_arch_attribute(node.func.value):
+            return node.args[0]
+        return node.func.value
+
+    @classmethod
+    def _store_pointer(cls, node: ast.Call) -> ast.AST | None:
+        marker = _marker_call(node, _STORE_MARKER, 6)
+        if marker is not None:
+            return marker.args[3]
+        func = node.func
+        if isinstance(func, ast.Name) and func.id.startswith(
+            ("_cute_store_", "_cute_atomic_")
+        ):
+            return node.args[0] if node.args else None
+        if not isinstance(func, ast.Attribute):
+            return None
+        if func.attr.startswith("atomic_"):
+            return node.args[0] if node.args else None
+        if func.attr == "store":
+            if node.args and cls._contains_arch_attribute(func.value):
+                return node.args[0]
+            return func.value
+        if func.attr == "__setitem__":
+            return func.value
+        return None
+
+    def _has_aliasing_write_in_loop(
+        self,
+        body: list[ast.stmt],
+        load_marker: ast.Call,
+        load_index: int,
+        lane_var: str,
+        lane_extent: int,
+    ) -> bool:
+        """Whether any loop iteration can write storage read by this load.
+
+        A write lexically after the load still runs before that load in the
+        next constexpr-lane iteration.  Hoisting the vector load above the
+        loop would observe the pre-write value for every lane. Such a write is
+        a barrier unless its tensor is disjoint or both exact accesses have the
+        same injective lane mapping.
+        """
+        load_pointer = load_marker.args[4]
+        load_roots = self._pointer_roots(load_pointer)
+        definition_snapshots = _definition_snapshots(body)
+        for store_index, stmt in enumerate(body):
+            for node in ast.walk(stmt):
+                if not isinstance(node, ast.Call):
+                    continue
+                store_pointer = self._store_pointer(node)
+                if store_pointer is None or not self._may_alias(
+                    self._pointer_roots(store_pointer), load_roots
+                ):
+                    continue
+                # A later exact store preserves this load's same-iteration
+                # ordering. Its identical injective lane mapping additionally
+                # rules out a dependence through the loop backedge.
+                if (
+                    store_index > load_index
+                    and _lane_accesses_are_iteration_independent(
+                        load_marker,
+                        node,
+                        lane_var=lane_var,
+                        lane_extent=lane_extent,
+                        load_definitions=definition_snapshots[load_index],
+                        store_definitions=definition_snapshots[store_index],
+                        proven_tensor_stride_values=(self.proven_tensor_stride_values),
+                        loop_carried_names=_unstable_address_names(
+                            body,
+                            lane_var,
+                            load_index,
+                            store_index,
+                        ),
+                    )
+                ):
+                    continue
+                return True
+        return False
+
+    def _has_other_aliasing_access_in_loop(
+        self,
+        body: list[ast.stmt],
+        store_marker: ast.Call,
+        store_index: int,
+        lane_var: str,
+        lane_extent: int,
+    ) -> bool:
+        """Whether sinking a store can cross an aliasing memory access.
+
+        A load lexically before the store executes after that store on the
+        next lane iteration.  Likewise, another write on either side can race
+        the sunk vector transaction across iterations.  Exclude only the
+        candidate marker itself; every other load/store/atomic in the repeated
+        loop must be proven disjoint, except a preceding exact load with the
+        same injective lane mapping.
+        """
+        store_roots = self._pointer_roots(store_marker.args[3])
+        definition_snapshots = _definition_snapshots(body)
+        for access_index, stmt in enumerate(body):
+            for node in _memory_load_calls(stmt):
+                pointer = self._load_pointer(node)
+                if pointer is not None and self._may_alias(
+                    store_roots, self._pointer_roots(pointer)
+                ):
+                    # Sinking the store retains a preceding load's within-lane
+                    # order. Matching exact lane mappings rule out only the
+                    # cross-iteration dependence introduced by the sink.
+                    if (
+                        access_index < store_index
+                        and _lane_accesses_are_iteration_independent(
+                            node,
+                            store_marker,
+                            lane_var=lane_var,
+                            lane_extent=lane_extent,
+                            load_definitions=definition_snapshots[access_index],
+                            store_definitions=definition_snapshots[store_index],
+                            proven_tensor_stride_values=(
+                                self.proven_tensor_stride_values
+                            ),
+                            loop_carried_names=_unstable_address_names(
+                                body,
+                                lane_var,
+                                access_index,
+                                store_index,
+                            ),
+                        )
+                    ):
+                        continue
+                    return True
+            for node in ast.walk(stmt):
+                if node is store_marker or not isinstance(node, ast.Call):
+                    continue
+                pointer = self._store_pointer(node)
+                if pointer is not None and self._may_alias(
+                    store_roots, self._pointer_roots(pointer)
+                ):
+                    if _store_accesses_are_iteration_independent(
+                        store_marker,
+                        node,
+                        lane_var=lane_var,
+                        lane_extent=lane_extent,
+                        first_definitions=definition_snapshots[store_index],
+                        second_definitions=definition_snapshots[access_index],
+                        proven_tensor_stride_values=(self.proven_tensor_stride_values),
+                        unstable_names=_unstable_address_names(
+                            body,
+                            lane_var,
+                            min(store_index, access_index),
+                            max(store_index, access_index),
+                        ),
+                    ):
+                        continue
+                    return True
+        return False
+
+    def _vectorize_loop(
+        self, loop: ast.For, block_id: int, width: int
+    ) -> tuple[list[ast.stmt], ast.For, list[ast.stmt]]:
+        assert isinstance(loop.target, ast.Name)
+        lane_var = loop.target.id
+        all_local_writes = {
+            name for stmt in loop.body for name in ReadWrites.from_ast(stmt).writes
+        }
+        definitions: dict[str, ast.expr] = {}
+        before: list[ast.stmt] = []
+        after: list[ast.stmt] = []
+        rewritten_body: list[ast.stmt] = []
+
+        for stmt_index, stmt in enumerate(loop.body):
+            load_markers: list[ast.Call] = []
+            for node in ast.walk(stmt):
+                marker_call = _marker_call(node, _LOAD_MARKER, 6)
+                if marker_call is not None:
+                    load_markers.append(marker_call)
+            if len(load_markers) == 1:
+                marker = load_markers[0]
+                marker_block = _literal(marker.args[0], int)
+                marker_width = _literal(marker.args[1], int)
+                dtype = _literal(marker.args[2], str)
+                eviction = _literal(marker.args[3], str)
+                original = marker.args[5]
+                load_info = (
+                    _scalar_load_and_mask(original)
+                    if isinstance(original, ast.expr)
+                    else None
+                )
+                dtype_info = _DTYPE_INFO.get(dtype) if isinstance(dtype, str) else None
+                if (
+                    marker_block == block_id
+                    and marker_width == width
+                    and isinstance(eviction, str)
+                    and dtype_info is not None
+                    and load_info is not None
+                    and not self._has_aliasing_write_in_loop(
+                        loop.body,
+                        marker,
+                        stmt_index,
+                        lane_var,
+                        width,
+                    )
+                ):
+                    scalar_load, mask = load_info
+                    guard_ok, guard = _uniform_guard(
+                        mask, definitions, lane_var, width, all_local_writes
+                    )
+                    base = (
+                        _safe_base_pointer(
+                            marker.args[4],
+                            definitions,
+                            lane_var,
+                            all_local_writes,
+                            guard,
+                        )
+                        if guard_ok and isinstance(marker.args[4], ast.expr)
+                        else None
+                    )
+                    if base is not None:
+                        carrier, itemsize, _store_helper = dtype_info
+                        vec_name = self._fresh("_persistent_branch_vec")
+                        vector_type = (
+                            f"ir.VectorType.get([{width}], {carrier}.mlir_type)"
+                        )
+                        if eviction == "__l2_last__":
+                            load_source = (
+                                f"_cute_load_l2_evict_last({ast.unparse(base)}, "
+                                f"{vector_type})"
+                                if width * itemsize == 16
+                                else f"cute.arch.load({ast.unparse(base)}, {vector_type})"
+                            )
+                        else:
+                            load_source = (
+                                f"cute.arch.load({ast.unparse(base)}, {vector_type}"
+                                f"{eviction})"
+                            )
+                        vector_load = ast.parse(load_source, mode="eval").body
+                        before.append(
+                            ast.Assign(
+                                targets=[ast.Name(id=vec_name, ctx=ast.Store())],
+                                value=vector_load,
+                            )
+                        )
+                        extract = ast.parse(
+                            f"{carrier}({vec_name}[{lane_var}]).bitcast({dtype})",
+                            mode="eval",
+                        ).body
+                        replacement = _ReplaceCall(scalar_load, extract).visit(
+                            _clone_expr(original)
+                        )
+                        assert isinstance(replacement, ast.expr)
+                        stmt = _ReplaceCall(marker, replacement).visit(stmt)
+                        assert isinstance(stmt, ast.stmt)
+
+            store_marker = self._store_marker(stmt)
+            if store_marker is not None:
+                marker_block = _literal(store_marker.args[0], int)
+                marker_width = _literal(store_marker.args[1], int)
+                dtype = _literal(store_marker.args[2], str)
+                dtype_info = _DTYPE_INFO.get(dtype) if isinstance(dtype, str) else None
+                mask_arg = store_marker.args[5]
+                mask = (
+                    None
+                    if isinstance(mask_arg, ast.Constant) and mask_arg.value is None
+                    else mask_arg
+                )
+                guard_ok, guard = (
+                    _uniform_guard(mask, definitions, lane_var, width, all_local_writes)
+                    if isinstance(mask, (ast.expr, type(None)))
+                    else (False, None)
+                )
+                base = (
+                    _safe_base_pointer(
+                        store_marker.args[3],
+                        definitions,
+                        lane_var,
+                        all_local_writes,
+                        None,
+                    )
+                    if guard_ok and isinstance(store_marker.args[3], ast.expr)
+                    else None
+                )
+                if (
+                    marker_block == block_id
+                    and marker_width == width
+                    and dtype_info is not None
+                    and base is not None
+                    and not self._has_other_aliasing_access_in_loop(
+                        loop.body,
+                        store_marker,
+                        stmt_index,
+                        lane_var,
+                        width,
+                    )
+                ):
+                    carrier, _itemsize, store_helper = dtype_info
+                    values_name = self._fresh("_persistent_branch_store_values")
+                    before.append(
+                        ast.Assign(
+                            targets=[ast.Name(id=values_name, ctx=ast.Store())],
+                            value=ast.List(elts=[], ctx=ast.Load()),
+                        )
+                    )
+                    append = ast.Expr(
+                        value=ast.Call(
+                            func=ast.Attribute(
+                                value=ast.Name(id=values_name, ctx=ast.Load()),
+                                attr="append",
+                                ctx=ast.Load(),
+                            ),
+                            args=[
+                                ast.Call(
+                                    func=ast.Attribute(
+                                        value=_clone_expr(store_marker.args[4]),
+                                        attr="bitcast",
+                                        ctx=ast.Load(),
+                                    ),
+                                    args=[
+                                        ast.parse(carrier, mode="eval").body,
+                                    ],
+                                    keywords=[],
+                                )
+                            ],
+                            keywords=[],
+                        )
+                    )
+                    stmt = append
+                    flush = ast.Expr(
+                        value=ast.Call(
+                            func=ast.Name(id=store_helper, ctx=ast.Load()),
+                            args=[
+                                base,
+                                ast.Name(id=values_name, ctx=ast.Load()),
+                            ],
+                            keywords=[],
+                        )
+                    )
+                    after.append(
+                        flush
+                        if guard is None
+                        else ast.If(test=_clone_expr(guard), body=[flush], orelse=[])
+                    )
+                else:
+                    rewritten_body.extend(self._restore_store(store_marker))
+                    continue
+
+            rewritten_body.append(stmt)
+            definitions.update(_single_name_definitions([stmt]))
+
+        loop.body = self.transform_body(rewritten_body)
+        return before, loop, after
+
+    def transform_body(self, body: list[ast.stmt]) -> list[ast.stmt]:
+        result: list[ast.stmt] = []
+        for stmt in body:
+            if isinstance(stmt, ast.For) and isinstance(stmt.target, ast.Name):
+                match = _SYNTHETIC_LANE_RE.fullmatch(stmt.target.id)
+                extent = _range_extent(stmt)
+                if match is not None and extent is not None:
+                    before, loop, after = self._vectorize_loop(
+                        stmt, int(match.group(1)), extent
+                    )
+                    result.extend(before)
+                    result.append(loop)
+                    result.extend(after)
+                    continue
+
+            store_marker = self._store_marker(stmt)
+            if store_marker is not None:
+                result.extend(self._restore_store(store_marker))
+                continue
+            for field in ("body", "orelse", "finalbody"):
+                child = getattr(stmt, field, None)
+                if isinstance(child, list) and all(
+                    isinstance(child_stmt, ast.stmt) for child_stmt in child
+                ):
+                    setattr(stmt, field, self.transform_body(child))
+            result.append(stmt)
+        return result
+
+
+def vectorize_branch_local_persistent_fragments(
+    body: list[ast.stmt],
+    *,
+    proven_disjoint_tensor_pairs: set[frozenset[str]] | None = None,
+    proven_tensor_stride_values: Mapping[tuple[str, int], int] | None = None,
+) -> list[ast.stmt]:
+    """Vectorize marked exact fragments and erase every unhandled marker."""
+    vectorizer = _BranchLocalPersistentVectorizer(
+        body,
+        proven_disjoint_tensor_pairs or set(),
+        proven_tensor_stride_values or {},
+    )
+    transformed = vectorizer.transform_body(body)
+    # Most kernels have no persistent-fragment load markers.  Avoid running an
+    # AST ``NodeTransformer`` over those bodies: FX can preserve an
+    # ``immutable_list`` in constructs such as inline-asm operand lists, while
+    # ``NodeTransformer.generic_visit`` mutates list fields in place.
+    if not any(
+        isinstance(node, ast.Call) and _marker_call(node, _LOAD_MARKER, 6) is not None
+        for stmt in transformed
+        for node in ast.walk(stmt)
+    ):
+        module = ast.Module(body=transformed, type_ignores=[])
+        ast.fix_missing_locations(module)
+        return module.body
+    restored = _RestoreLoadMarkers().visit(
+        ast.Module(body=transformed, type_ignores=[])
+    )
+    assert isinstance(restored, ast.Module)
+    ast.fix_missing_locations(restored)
+    return restored.body

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -18,7 +18,10 @@ import sympy
 import torch
 from torch._dynamo.source import TensorProperty
 from torch._dynamo.source import TensorPropertySource
+from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx.graph import _Namespace
+from torch.utils._sympy.symbol import SymT
+from torch.utils._sympy.symbol import symbol_is_type
 
 from .. import exc
 from .._compat import get_tensor_descriptor_fn_name
@@ -52,6 +55,7 @@ if TYPE_CHECKING:
     from .generate_ast import GenerateAST
     from .indexing_strategy import IndexingStrategy
     from .program_id import ProgramIDs
+    from .tile_dispatch import TileStrategyDispatch
     from helion._compiler.pallas.dma import DmaResources
     from helion._compiler.pallas.ordered_carry import CarryBoundaryTile
     from helion._compiler.pallas.ordered_carry import CarryScratchKey
@@ -64,6 +68,23 @@ if TYPE_CHECKING:
 
 
 tls: _TLS = cast("_TLS", threading.local())
+
+
+def _exact_thread_block_dims(
+    tile_strategy: TileStrategyDispatch,
+) -> tuple[int, int, int] | None:
+    """Return a proven-static launch shape, or ``None`` when inference fails."""
+
+    try:
+        thread_dims = tile_strategy.thread_block_dims()
+        if len(thread_dims) != 3 or any(
+            not isinstance(dim, (int, sympy.Integer)) for dim in thread_dims
+        ):
+            return None
+        result = int(thread_dims[0]), int(thread_dims[1]), int(thread_dims[2])
+        return result if all(dim > 0 for dim in result) else None
+    except Exception:
+        return None
 
 
 class VarInfo(NamedTuple):
@@ -1069,15 +1090,7 @@ class DeviceFunction:
             # linear slot index when ``cache_size`` exceeds the
             # register-fragment threshold (opt-in via
             # ``HELION_FUSER_MODE=smem``).
-            try:
-                thread_dims = self.tile_strategy.thread_block_dims()
-                thread_block_dims: tuple[int, int, int] = (
-                    int(thread_dims[0]),
-                    int(thread_dims[1]),
-                    int(thread_dims[2]),
-                )
-            except Exception:
-                thread_block_dims = (1, 1, 1)
+            exact_thread_block_dims = _exact_thread_block_dims(self.tile_strategy)
             # Best-effort map for the fuser's cache-dtype resolution;
             # ``dtype_str`` raises for dtypes the cute backend has no
             # canonical spelling for (e.g. uint32 barrier flags, which
@@ -1092,10 +1105,9 @@ class DeviceFunction:
                         )
                     except ValueError:
                         continue
-            # Autotuner-selected reload mode per rolled reduction dim
-            # ("auto" / "register" / "gmem"); the fuser keys the sweep
-            # loops back to their block id via the ``roffset_<id>`` /
-            # ``tile_offset_<id>`` loop offset variable.
+            proven_disjoint_tensor_pairs = self.proven_disjoint_tensor_pairs()
+            # Autotuner-selected reload mode per rolled or persistent
+            # reduction dim ("auto" / "register" / "gmem").
             env = CompileEnvironment.current()
             reload_cfg = cast(
                 "list[str]",
@@ -1107,12 +1119,30 @@ class DeviceFunction:
                 )
                 for block_id in env.config_spec.cute_reduction_reloads.valid_block_ids()
             }
-            kernel_body = fuse_two_pass_loads(
+            if exact_thread_block_dims is not None:
+                kernel_body = fuse_two_pass_loads(
+                    kernel_body,
+                    constexpr_values,
+                    thread_block_dims=exact_thread_block_dims,
+                    tensor_dtypes=tensor_dtypes,
+                    reload_modes=reload_modes,
+                    proven_disjoint_tensor_pairs=proven_disjoint_tensor_pairs,
+                    proven_tensor_stride_values=self.proven_tensor_stride_values(),
+                )
+            # Some exact persistent fragments have addresses defined only
+            # inside a runtime branch (for example a loaded state-slot index),
+            # so the normal root-wrapper hoist cannot legally reference them.
+            # Their lowering markers survive the reduction split and load
+            # fuser; place one vector transaction beside the earliest surviving
+            # constexpr sweep and erase every unhandled marker here.
+            from .cute.persistent_branch_vec import (
+                vectorize_branch_local_persistent_fragments,
+            )
+
+            kernel_body = vectorize_branch_local_persistent_fragments(
                 kernel_body,
-                constexpr_values,
-                thread_block_dims=thread_block_dims,
-                tensor_dtypes=tensor_dtypes,
-                reload_modes=reload_modes,
+                proven_disjoint_tensor_pairs=proven_disjoint_tensor_pairs,
+                proven_tensor_stride_values=self.proven_tensor_stride_values(),
             )
             # Hoist warp reductions out of constexpr V-loops to collapse
             # 4 per-V-lane warp reductions into 1 V-fold + 1 warp reduce.
@@ -1136,6 +1166,50 @@ class DeviceFunction:
             from .cute.merge_sibling_v_loops import merge_sibling_v_loops
 
             kernel_body = merge_sibling_v_loops(kernel_body)
+            # A persistent row tile may repeat a row-invariant Q/K norm (and
+            # its warp reduction) once for every compile-time row lane.  Wide
+            # row tiles are useful only if that setup is shared.  Unswitch a
+            # proven-uniform terminal guard and move complete, pure invariant
+            # reduction slices before the row loop.  Runtime storage facts are
+            # required before a load may cross any loop write.
+            from .cute.hoist_lane_invariant_reductions import (
+                hoist_lane_invariant_reductions,
+            )
+
+            float_scalar_names = {
+                argument.name
+                for expression, argument in self._expr_args.items()
+                if isinstance(expression, sympy.Symbol)
+                and (
+                    symbol_is_type(expression, SymT.FLOAT)
+                    or symbol_is_type(expression, SymT.UNBACKED_FLOAT)
+                )
+            } | {
+                argument.name
+                for argument in self.arguments
+                if isinstance(argument, NumericArgument)
+                and isinstance(
+                    HostFunction.current().params.arguments.get(argument.host_str()),
+                    (float, torch.SymFloat),
+                )
+            }
+            kernel_body = hoist_lane_invariant_reductions(
+                kernel_body,
+                tensor_names=set(tensor_dtypes),
+                tensor_dtypes=tensor_dtypes,
+                proven_disjoint_tensor_pairs=proven_disjoint_tensor_pairs,
+                rename_groups=rename_groups,
+                uniform_names={arg.arg for arg in args},
+                float_scalar_names=float_scalar_names,
+                thread_block_dims=exact_thread_block_dims,
+            )
+            if CompileEnvironment.current().settings.fast_math:
+                from .cute.factor_affine_reductions import hoist_factored_reductions
+
+                kernel_body = hoist_factored_reductions(
+                    kernel_body,
+                    fast_math=True,
+                )
             # Fuse adjacent per-lane fp8 decodes in the SIMT matmul V-loop
             # into one ``cvt.rn.f16x2.e4m3x2`` (decode 2 e4m3 bytes per
             # instruction) — halves the decode instruction count on the
@@ -1269,6 +1343,96 @@ class DeviceFunction:
                     f"{self.name}._helion_cute_min_blocks_per_mp = {min_blocks}"
                 )
             )
+        return result
+
+    def proven_disjoint_tensor_pairs(self) -> set[frozenset[str]]:
+        """Return tensor argument pairs with a cache-safe non-aliasing proof.
+
+        Different user/global tensor arguments are not a non-aliasing proof:
+        callers may pass the same tensor, or overlapping views, under multiple
+        names.  A tensor backed by storage absent from the original function
+        inputs cannot overlap an external input or a separately allocated
+        output.  Two external inputs are disjoint only when the current runtime
+        storage spans do not overlap and that predicate is part of the bound
+        kernel cache key.  Origin type alone is insufficient: host-local
+        ``torch.empty``-family outputs commonly carry ``NameOrigin`` too.
+        """
+        from .cute.memory_ops import runtime_tensors_are_proven_disjoint
+
+        env = CompileEnvironment.current()
+        host_function = HostFunction.current()
+        input_storages = {id(tensor.untyped_storage()) for tensor in env.input_sources}
+        origins: dict[str, tuple[str, int, bool, torch.Tensor]] = {}
+        for arg in self.arguments:
+            if not isinstance(arg, TensorArg):
+                continue
+            origin = host_function.tensor_to_origin.get(arg.fake_value)
+            root = origin.root_rw_name() if origin is not None else None
+            if root is not None:
+                storage = id(arg.fake_value.untyped_storage())
+                origins[arg.name] = (
+                    root,
+                    storage,
+                    storage not in input_storages,
+                    arg.fake_value,
+                )
+        return {
+            frozenset((left_name, right_name))
+            for left_name, (
+                left_root,
+                left_storage,
+                left_is_fresh,
+                left_tensor,
+            ) in origins.items()
+            for right_name, (
+                right_root,
+                right_storage,
+                right_is_fresh,
+                right_tensor,
+            ) in origins.items()
+            if left_name < right_name
+            and left_root != right_root
+            and left_storage != right_storage
+            and (
+                left_is_fresh
+                or right_is_fresh
+                or runtime_tensors_are_proven_disjoint(
+                    env,
+                    left_tensor,
+                    right_tensor,
+                )
+            )
+        }
+
+    def proven_tensor_stride_values(self) -> dict[tuple[str, int], int]:
+        """Return tensor strides whose exact value is cache-safe."""
+        env = CompileEnvironment.current()
+        input_metadata_specialized = (
+            "input_tensor_metadata" in env.compiler_fact_specialization_facts
+        )
+        result: dict[tuple[str, int], int] = {}
+        for arg in self.arguments:
+            if not isinstance(arg, TensorArg):
+                continue
+            source = env.tensor_input_source(arg.fake_value)
+            runtime = env.runtime_value_for_tensor(arg.fake_value)
+            if not isinstance(runtime, torch.Tensor) or isinstance(runtime, FakeTensor):
+                continue
+            for dim, fake_stride in enumerate(arg.fake_value.stride()):
+                cache_safe = source is not None and (
+                    input_metadata_specialized
+                    or TensorPropertySource(source, TensorProperty.STRIDE, dim)
+                    in env.specialized_strides
+                )
+                if not cache_safe:
+                    continue
+                try:
+                    traced_stride = env.size_hint(fake_stride)
+                except (RuntimeError, TypeError, ValueError):
+                    continue
+                runtime_stride = runtime.stride(dim)
+                if runtime_stride == traced_stride:
+                    result[arg.name, dim] = traced_stride
         return result
 
     def codegen_function_call(self) -> ast.AST:

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -369,6 +369,10 @@ class ForLoopGraphInfo(NodeArgsGraphInfo):
         # Make the active graph reachable by the strategy so it can pick
         # different lane-loop shapes for the reduce vs consume sweeps.
         # pyrefly: ignore [missing-attribute]
+        previous_active_graph_info = getattr(
+            state.codegen, "_cute_active_graph_info", None
+        )
+        # pyrefly: ignore [missing-attribute]
         state.codegen._cute_active_graph_info = self
         try:
             device_loop = state.device_function.tile_strategy.codegen_device_loop(
@@ -394,7 +398,7 @@ class ForLoopGraphInfo(NodeArgsGraphInfo):
                 )
         finally:
             # pyrefly: ignore [missing-attribute]
-            state.codegen._cute_active_graph_info = None
+            state.codegen._cute_active_graph_info = previous_active_graph_info
 
 
 def control_flow_parent_entries(
@@ -982,6 +986,7 @@ class DeviceIR:
             for graph_info in self.graphs:
                 mark_ftz_safe_exp_nodes(graph_info.graph)
         rdims = [bs for bs in env.block_sizes if bs.reduction]
+        env.config_spec.reduction_block_ids.update(rdim.block_id for rdim in rdims)
         # Eager tile-slot registration (see _register_cute_tile_vec_slots).
         # A present reduction must keep its slot at index 0, so reduction
         # kernels register their tile slots after the reduction-loop pass below.
@@ -1045,6 +1050,69 @@ class DeviceIR:
 
         # Second pass: register reduction loop specs, ensuring that each
         # original graph is only rolled for one reduction dim at a time.
+        #
+        # CuTe's persistent reduction strategy can also split a static
+        # reduction over fewer live threads plus synthetic per-thread lanes.
+        # Those layout choices are independent of whether ReductionRoller can
+        # turn the reduction into an outer ``reduction_loop``.  In particular,
+        # an ``hl.arange``-indexed reduction is deliberately non-rollable but
+        # is still a profitable persistent subwarp reduction.  Register the
+        # orthogonal CuTe knobs for every static reduction block; only the
+        # ``ReductionLoopSpec`` below remains conditional on rollability.
+        if env.backend_name == "cute":
+            from .cute.memory_ops import register_cute_tensor_alias_specializations
+            from .cute.memory_ops import (
+                register_persistent_vec_alignment_specializations,
+            )
+
+            register_persistent_vec_alignment_specializations(env)
+            register_cute_tensor_alias_specializations(env)
+            num_thread_blocks = set(env.config_spec.num_threads.valid_block_ids())
+            vector_blocks = set(env.config_spec.cute_vector_widths.valid_block_ids())
+            lane_layout_blocks = set(
+                env.config_spec.cute_lane_layouts.valid_block_ids()
+            )
+            reload_blocks = set(
+                env.config_spec.cute_reduction_reloads.valid_block_ids()
+            )
+            for rdim, _allow_loop, _used_graphs in rdim_results:
+                # Reduction lowering materializes output-range blocks even
+                # when the range is exactly an already-active tile symbol.
+                # CuTe reuses that tile's execution strategy, so separate
+                # reduction tuning slots would be dead dimensions in the
+                # search space.
+                if env.canonical_block_id(rdim.block_id) != rdim.block_id:
+                    continue
+                if not isinstance(rdim.size, (int, torch.SymInt)):
+                    continue
+                size_hint = rdim.size_hint()
+                if rdim.block_id not in num_thread_blocks:
+                    env.config_spec.num_threads.append(
+                        NumThreadsSpec(
+                            block_id=rdim.block_id,
+                            size_hint=size_hint,
+                        )
+                    )
+                    num_thread_blocks.add(rdim.block_id)
+                if rdim.block_id not in vector_blocks:
+                    env.config_spec.cute_vector_widths.append(
+                        CuteVectorWidthSpec(
+                            block_id=rdim.block_id,
+                            size_hint=size_hint,
+                        )
+                    )
+                    vector_blocks.add(rdim.block_id)
+                if rdim.block_id not in lane_layout_blocks:
+                    env.config_spec.cute_lane_layouts.append(
+                        CuteLaneLayoutSpec(block_id=rdim.block_id)
+                    )
+                    lane_layout_blocks.add(rdim.block_id)
+                if rdim.block_id not in reload_blocks:
+                    env.config_spec.cute_reduction_reloads.append(
+                        CuteReductionReloadSpec(block_id=rdim.block_id)
+                    )
+                    reload_blocks.add(rdim.block_id)
+
         graphs_with_rolled_rdim: set[int] = set()
         for rdim, allow_loop, used_graphs in rdim_results:
             if not allow_loop:
@@ -1058,29 +1126,6 @@ class DeviceIR:
                         size_hint=rdim.size_hint(),
                     )
                 )
-                if env.backend_name == "cute":
-                    env.config_spec.cute_vector_widths.append(
-                        CuteVectorWidthSpec(
-                            block_id=rdim.block_id,
-                            size_hint=rdim.size_hint(),
-                        )
-                    )
-                    env.config_spec.cute_lane_layouts.append(
-                        CuteLaneLayoutSpec(block_id=rdim.block_id)
-                    )
-                    env.config_spec.cute_reduction_reloads.append(
-                        CuteReductionReloadSpec(block_id=rdim.block_id)
-                    )
-                    # Rolled reduction dims get a thread-count knob: fewer
-                    # threads per row (with more elements per thread) is
-                    # often faster for memory-bound row reductions. 0 = auto
-                    # (derive from the loop chunk, the legacy behavior).
-                    env.config_spec.num_threads.append(
-                        NumThreadsSpec(
-                            block_id=rdim.block_id,
-                            size_hint=rdim.size_hint(),
-                        )
-                    )
             graphs_with_rolled_rdim |= used_graphs
 
         # Track which rdims appear as the reduction axis of an indexed
@@ -3071,6 +3116,14 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
 
         for graph in device_ir.graphs:
             rewrite_implicit_random_ops(graph.graph)
+        if (
+            CompileEnvironment.current().backend.name == "cute"
+            and CompileEnvironment.current().settings.fast_math
+        ):
+            from .cute.factor_affine_reductions import factor_affine_reductions
+
+            for graph_info in device_ir.graphs:
+                factor_affine_reductions(graph_info.graph, fast_math=True)
         if CompileEnvironment.current().backend.name == "cute":
             promotions = collect_cute_half_atomic_output_promotions(device_ir.graphs)
             if promotions:

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -1134,6 +1134,10 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                         )
 
                         codegen_fn(state)
+                    if isinstance(self.current_grid_state, DeviceGridState):
+                        self.current_grid_state.hoist_parent_statements = (
+                            self.statements_stack[-1]
+                        )
                     root = root_graph_info.graph
                     if not self._try_codegen_attention_flash_root():
                         grid_state = self.current_grid_state
@@ -1232,7 +1236,20 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                         )
                     )
                     self.device_function.body = split_lane_loop_reductions(
-                        list(self.device_function.body)
+                        list(self.device_function.body),
+                        uniform_names={
+                            *(
+                                argument.name
+                                for argument in self.device_function.arguments
+                            ),
+                            *self._extra_params,
+                        },
+                        proven_disjoint_tensor_pairs=(
+                            self.device_function.proven_disjoint_tensor_pairs()
+                        ),
+                        proven_tensor_stride_values=(
+                            self.device_function.proven_tensor_stride_values()
+                        ),
                     )
                     # Safety net: revert any lane-reduce marker that neither pass
                     # rewrote so no ``_helion_lane_reduce`` call leaks into the
@@ -1245,7 +1262,12 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                     # lane-invariant rescale / chunk-entry stores / final combine
                     # hoisted to run once per chunk (gdn_fwd_h).
                     self.device_function.body = hoist_lane_invariant_chunk_recurrence(
-                        list(self.device_function.body)
+                        list(self.device_function.body),
+                        rename_groups={
+                            name: aliases[0]
+                            for name, aliases in self.device_function._variable_renames.items()
+                        },
+                        running_sums=self.device_function.cute_matmul_running_sums,
                     )
                 self.device_function.dead_code_elimination()
                 if not self.device_function.preamble and not self.device_function.body:
@@ -1447,17 +1469,7 @@ def generate_ast(
             load_transform=load_transform,
             extra_params=extra_params,
         )
-        fast_math_cm: contextlib.AbstractContextManager[None] = contextlib.nullcontext()
-        if env.backend_name == "cute" and env.settings.fast_math:
-            # Route the global ``fast_math`` setting into the inductor
-            # CuteDSL op overrides: every cute.math call in this codegen
-            # gets ``fastmath=True``.
-            from torch._inductor.codegen.cutedsl.cutedsl_op_overrides import (
-                use_cutedsl_fast_math,
-            )
-
-            fast_math_cm = use_cutedsl_fast_math(True)
-        with codegen.device_function, fast_math_cm:
+        with codegen.device_function:
             CompileEnvironment.current().backend.pre_codegen(
                 graphs=codegen.codegen_graphs,
                 config=config,

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -1207,11 +1207,11 @@ class GenerateASTFromInductor(DefaultHandler):
     def rsqrt(self, x: object) -> str:  # type: ignore[override]
         backend_name = CompileEnvironment.current().backend_name
         if backend_name == "cute":
-            from torch._inductor.codegen.cutedsl.cutedsl_op_overrides import (
-                _CUTEDSL_FAST_MATH,
+            suffix = (
+                ", fastmath=True"
+                if CompileEnvironment.current().settings.fast_math
+                else ""
             )
-
-            suffix = ", fastmath=True" if _CUTEDSL_FAST_MATH.get() else ""
             return self._lift(
                 expr_from_string(f"cute.math.rsqrt({{x}}{suffix})", x=self._to_ast(x))
             )

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -707,6 +707,12 @@ class PersistentReductionStrategy(ReductionStrategy):
 
         env = CompileEnvironment.current()
         numel = env.block_sizes[block_index].numel
+        if isinstance(numel, (int, sympy.Integer)):
+            size_hint = int(numel)
+        elif isinstance(numel, sympy.Expr):
+            size_hint = shape_env_size_hint(env.shape_env, numel)
+        else:
+            size_hint = env.size_hint(numel)
         # Skip the mask when RDIM_SIZE == numel (no padding needed).
         # This is true when numel is a power of 2 (Triton doesn't round),
         # or when the backend uses exact RDIM sizes (e.g., Pallas).
@@ -738,13 +744,19 @@ class PersistentReductionStrategy(ReductionStrategy):
                 # ``cute.arch.warp_reduction`` is correct.
                 if _block_has_indexed_reduction(fn, block_index):
                     max_threads = min(max_threads, _CUTE_WARP_REDUCTION_THREADS)
-            if isinstance(numel, (int, sympy.Integer)):
-                size_hint = int(numel)
-            elif isinstance(numel, sympy.Expr):
-                size_hint = shape_env_size_hint(env.shape_env, numel)
-            else:
-                size_hint = env.size_hint(numel)
             self._thread_count = next_power_of_2(min(size_hint, max_threads))
+            if env.backend.name == "cute":
+                # Persistent reductions use the same per-block thread-count
+                # knob as rolled reductions.  A smaller live subgroup keeps
+                # unrelated tile axes from inflating the CTA and lets each
+                # thread retain a short contiguous reduction fragment.
+                requested = env.config_spec.num_threads.config_get(
+                    cast("list[int]", fn.config.config.get("num_threads", []) or []),
+                    block_index,
+                    0,
+                )
+                if isinstance(requested, int) and 0 < requested < self._thread_count:
+                    self._thread_count = requested
         else:
             self._thread_count = 0
         # On cute, the launch block dim is capped at MAX_THREADS_PER_BLOCK.
@@ -768,17 +780,24 @@ class PersistentReductionStrategy(ReductionStrategy):
             )
         self._synthetic_cute_lane_var: str | None = None
         self._synthetic_cute_lane_extent = 1
+        # Persistent reductions expose the same unroll-vec protocol as rolled
+        # reductions when one V-wide vector exactly covers each thread's
+        # synthetic slice.  Restricting the first implementation to one vector
+        # per thread avoids introducing a second loop-carried reduction level;
+        # wider slices keep the established scalar synthetic-lane path.
+        self._cute_reduction_lane_extent = 1
+        self._cute_reduction_vec_width = 1
+        self._cute_reduction_vec_mode = "unroll"
+        self._cute_pending_vec_masks: list[str] = []
+        self._cute_emitted_vec_load = False
+        self._cute_lane_base_index_var: str | None = None
+        self._cute_lane_body: list[ast.AST] | None = None
+        self._cute_lane_vloop: ast.For | None = None
         is_graph_reduction_dim = any(
             isinstance(graph, ReductionLoopGraphInfo) and block_index in graph.block_ids
             for graph in fn.codegen.codegen_graphs
         )
         if self._thread_count > 0:
-            if isinstance(numel, (int, sympy.Integer)):
-                size_hint = int(numel)
-            elif isinstance(numel, sympy.Expr):
-                size_hint = shape_env_size_hint(env.shape_env, numel)
-            else:
-                size_hint = env.size_hint(numel)
             # For a non-graph-reduction dim we always try to recover the
             # full extent through a synthetic lane loop. For a graph
             # reduction dim we only need the synthetic lane loop when
@@ -818,6 +837,25 @@ class PersistentReductionStrategy(ReductionStrategy):
                         dce=False,
                     )
                     self._synthetic_cute_lane_extent = lane_extent
+                    if mask_var is None:
+                        cfg = fn.config.config
+                        vec_width = env.config_spec.cute_vector_widths.config_get(
+                            cast(
+                                "list[int]",
+                                cfg.get("cute_vector_widths", []) or [],
+                            ),
+                            block_index,
+                            1,
+                        )
+                        # One complete vector per live thread.  The memory-op
+                        # gate independently caps each load/store at 16 bytes
+                        # for its dtype.
+                        if (
+                            isinstance(vec_width, int)
+                            and vec_width > 1
+                            and lane_extent == vec_width
+                        ):
+                            self._cute_reduction_vec_width = vec_width
 
     def _reduction_thread_count(self) -> int:
         return self._thread_count
@@ -861,20 +899,60 @@ class PersistentReductionStrategy(ReductionStrategy):
         synthetic_lane_var = self._synthetic_cute_lane_var
         if synthetic_lane_var is not None and current_grid is not None:
             axis = self._get_thread_axis()
-            current_grid.add_lane_loop(
-                block_idx,
-                synthetic_lane_var,
-                self._synthetic_cute_lane_extent,
-            )
+            vec_width = self._cute_reduction_vec_width
+            if vec_width > 1:
+                # With exactly one V-wide chunk per thread, blocked and strided
+                # layouts coincide: thread ``t`` owns ``[t*V, (t+1)*V)``.
+                # Build the same mutable wrapper used by rolled/tile vec loops
+                # so memory lowering can splice one LDG/STG vector around the
+                # constexpr per-element loop.  The dummy one-trip outer loop is
+                # retained only as a container and elided by ``wrap_body``.
+                from .tile_strategy import VecLaneWrapper
+                from .tile_strategy import _create_lane_loop
+
+                base_index_var = self.fn.new_var(
+                    f"reduction_lane_base_{block_idx}", dce=False
+                )
+                self._cute_lane_base_index_var = base_index_var
+                base_expr = (
+                    f"({self._index_init_expr(block_size_var, env.index_type(), block_idx)})"
+                    f" * {vec_width}"
+                )
+                vec_for = _create_lane_loop(synthetic_lane_var, vec_width, [])
+                vec_iter = expr_from_string(f"cutlass.range_constexpr({vec_width})")
+                assert isinstance(vec_iter, ast.expr)
+                vec_for.iter = vec_iter
+                lane_body: list[ast.AST] = [
+                    statement_from_string(f"{base_index_var} = {base_expr}"),
+                    vec_for,
+                ]
+                outer_for = _create_lane_loop(synthetic_lane_var, 1, lane_body)
+                self._cute_lane_body = lane_body
+                self._cute_lane_vloop = vec_for
+                current_grid.add_lane_loop(block_idx, synthetic_lane_var, vec_width)
+                current_grid.vec_lane_wrappers[synthetic_lane_var] = VecLaneWrapper(
+                    outer_for=outer_for,
+                    vloop=vec_for,
+                    vec_lane_var=synthetic_lane_var,
+                    base_index_var=base_index_var,
+                    elide_outer_loop=True,
+                )
+                index_expr = f"{base_index_var} + cutlass.Int32({synthetic_lane_var})"
+            else:
+                current_grid.add_lane_loop(
+                    block_idx,
+                    synthetic_lane_var,
+                    self._synthetic_cute_lane_extent,
+                )
+                index_expr = (
+                    f"({self._index_init_expr(block_size_var, env.index_type(), block_idx)})"
+                    f" + cutlass.Int32({synthetic_lane_var}) * {self._thread_count}"
+                )
             current_grid.thread_axis_sizes[axis] = max(
                 current_grid.thread_axis_sizes.get(axis, 1),
                 self._thread_count,
             )
             current_grid.block_thread_axes[block_idx] = axis
-            index_expr = (
-                f"({self._index_init_expr(block_size_var, env.index_type(), block_idx)})"
-                f" + cutlass.Int32({synthetic_lane_var}) * {self._thread_count}"
-            )
             current_grid.lane_setup_statements.append(
                 statement_from_string(f"{index_var} = {index_expr}")
             )

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -78,6 +78,26 @@ def _lane_loop_iter(extent: int) -> ast.AST:
     return expr_from_string(f"range({extent})")
 
 
+def _static_lane_loop_extent(loop: ast.For) -> int | None:
+    iterator = loop.iter
+    if (
+        not isinstance(iterator, ast.Call)
+        or len(iterator.args) != 1
+        or iterator.keywords
+    ):
+        return None
+    function = ast.unparse(iterator.func)
+    extent = iterator.args[0]
+    if (
+        function not in ("range", "cutlass.range_constexpr")
+        or not isinstance(extent, ast.Constant)
+        or not isinstance(extent.value, int)
+        or extent.value <= 1
+    ):
+        return None
+    return extent.value
+
+
 def _create_lane_loop(lane_var: str, extent: int, body: list[ast.AST]) -> ast.For:
     loop = create(
         ast.For,
@@ -89,6 +109,32 @@ def _create_lane_loop(lane_var: str, extent: int, body: list[ast.AST]) -> ast.Fo
     )
     setattr(loop, HELION_LANE_LOOP_VAR_ATTR, lane_var)
     return loop
+
+
+def _clone_lane_loop_with_body(loop: ast.For, body: list[ast.AST]) -> ast.For:
+    """Clone a synthetic lane loop while preserving its iterator form.
+
+    Most lane loops use ordinary ``range``.  A persistent reduction whose
+    complete per-thread slice is one vector instead uses
+    ``cutlass.range_constexpr(V)`` so the load/store hoist machinery can form
+    one native vector transaction.  Reduction splitting must retain that
+    constexpr iterator rather than silently rebuilding it as ``range``.
+    """
+    assert isinstance(loop.target, ast.Name)
+    target = create(ast.Name, id=loop.target.id, ctx=ast.Store())
+    iterator = ast.parse(ast.unparse(loop.iter), mode="eval").body
+    cloned = create(
+        ast.For,
+        target=target,
+        iter=iterator,
+        body=body,
+        orelse=[],
+        type_comment=None,
+    )
+    lane_var = getattr(loop, HELION_LANE_LOOP_VAR_ATTR, None)
+    if isinstance(lane_var, str):
+        setattr(cloned, HELION_LANE_LOOP_VAR_ATTR, lane_var)
+    return cloned
 
 
 # Marker call emitted by reduction strategies when a reduction over a
@@ -106,6 +152,23 @@ def _create_lane_loop(lane_var: str, extent: int, body: list[ast.AST]) -> ast.Fo
 # The marker never reaches the emitted kernel — the post-pass strips every
 # marker it processes.
 _HELION_LANE_REDUCE_MARKER = "_helion_lane_reduce"
+_CUTE_UNIFORM_GLOBAL_NAMES = frozenset(
+    {
+        "abs",
+        "bool",
+        "cutlass",
+        "cute",
+        "float",
+        "int",
+        "len",
+        "math",
+        "max",
+        "min",
+        "operator",
+        "range",
+    }
+)
+_CUTE_THREAD_VARYING_INTRINSICS = ("thread_idx", "lane_idx", "warp_idx")
 
 
 def _lane_reduce_marker_expr(
@@ -441,7 +504,15 @@ def _backward_slice(body: list[ast.AST], roots: set[str]) -> tuple[list[int], se
     return selected, written
 
 
-def split_lane_loop_reductions(body: list[ast.AST]) -> list[ast.AST]:
+def split_lane_loop_reductions(
+    body: list[ast.AST],
+    *,
+    uniform_names: set[str] | None = None,
+    proven_disjoint_tensor_pairs: set[frozenset[str]] | None = None,
+    proven_tensor_stride_values: dict[tuple[str, int], int] | None = None,
+    thread_axis_names: dict[str, frozenset[int]] | None = None,
+    scalar_definitions: dict[str, ast.AST] | None = None,
+) -> list[ast.AST]:
     """Rewrite single-pass lane loops that contain ``_helion_lane_reduce``
     markers into the two-pass accumulate / finalize / consume structure.
 
@@ -449,9 +520,29 @@ def split_lane_loop_reductions(body: list[ast.AST]) -> list[ast.AST]:
     Lane loops without markers are returned unchanged (their inner statements
     are still recursed into so nested markers are processed).
     """
+    if not any(_find_lane_reduce_call(stmt) is not None for stmt in body):
+        return body
+
+    proven_uniform = set(_CUTE_UNIFORM_GLOBAL_NAMES)
+    if uniform_names is not None:
+        proven_uniform.update(uniform_names)
+    proven_thread_axes = dict(thread_axis_names or {})
+    proven_scalar_definitions = dict(scalar_definitions or {})
     new_body: list[ast.AST] = []
     for stmt in body:
-        new_body.extend(_split_stmt_lane_reductions(stmt))
+        new_body.extend(
+            _split_stmt_lane_reductions(
+                stmt,
+                proven_uniform,
+                proven_disjoint_tensor_pairs or set(),
+                proven_tensor_stride_values or {},
+                proven_thread_axes,
+                proven_scalar_definitions,
+            )
+        )
+        _update_proven_uniform_names(stmt, proven_uniform)
+        _update_thread_axis_names(stmt, proven_thread_axes)
+        _update_scalar_definitions(stmt, proven_scalar_definitions)
     return new_body
 
 
@@ -494,13 +585,31 @@ def restore_unprocessed_lane_reduce_markers(
     return [_restore_stmt_lane_reduce_markers(stmt) for stmt in body]
 
 
-def _split_stmt_lane_reductions(stmt: ast.AST) -> list[ast.AST]:
+def _split_stmt_lane_reductions(
+    stmt: ast.AST,
+    uniform_names: set[str],
+    proven_disjoint_tensor_pairs: set[frozenset[str]],
+    proven_tensor_stride_values: dict[tuple[str, int], int],
+    thread_axis_names: dict[str, frozenset[int]],
+    scalar_definitions: dict[str, ast.AST],
+) -> list[ast.AST]:
     # Recurse into any statement-list-bearing fields first so nested lane
     # loops are rewritten before the enclosing one.
     for field in ("body", "orelse", "finalbody"):
         old = getattr(stmt, field, None)
         if isinstance(old, list) and all(isinstance(s, ast.stmt) for s in old):
-            setattr(stmt, field, split_lane_loop_reductions(old))
+            setattr(
+                stmt,
+                field,
+                split_lane_loop_reductions(
+                    old,
+                    uniform_names=set(uniform_names),
+                    proven_disjoint_tensor_pairs=proven_disjoint_tensor_pairs,
+                    proven_tensor_stride_values=proven_tensor_stride_values,
+                    thread_axis_names=dict(thread_axis_names),
+                    scalar_definitions=dict(scalar_definitions),
+                ),
+            )
     lane_var = getattr(stmt, HELION_LANE_LOOP_VAR_ATTR, None)
     if (
         lane_var is None
@@ -509,10 +618,27 @@ def _split_stmt_lane_reductions(stmt: ast.AST) -> list[ast.AST]:
         or stmt.target.id != lane_var
     ):
         return [stmt]
-    return _split_one_lane_loop(stmt, lane_var)
+    return _split_one_lane_loop(
+        stmt,
+        lane_var,
+        uniform_names,
+        proven_disjoint_tensor_pairs,
+        proven_tensor_stride_values,
+        thread_axis_names,
+        scalar_definitions,
+    )
 
 
-def _split_one_lane_loop(loop: ast.For, lane_var: str) -> list[ast.AST]:
+def _split_one_lane_loop(
+    loop: ast.For,
+    lane_var: str,
+    uniform_names: set[str],
+    proven_disjoint_tensor_pairs: set[frozenset[str]],
+    proven_tensor_stride_values: dict[tuple[str, int], int],
+    thread_axis_names: dict[str, frozenset[int]],
+    scalar_definitions: dict[str, ast.AST],
+) -> list[ast.AST]:
+    from .. import exc
     from .ast_read_writes import ReadWrites
 
     body: list[ast.AST] = list(loop.body)
@@ -522,9 +648,46 @@ def _split_one_lane_loop(loop: ast.For, lane_var: str) -> list[ast.AST]:
         if parsed is not None:
             markers.append((idx, parsed))
     if not markers:
+        # A dynamic guard that does not depend on the synthetic lane may hide
+        # reduction markers in one of its branches.  Move that guard outside
+        # the lane loop so each branch owns an ordinary lane loop that can be
+        # split below.  This occurs in packed recurrent kernels which guard a
+        # state slot before performing several reductions over a free arange.
+        lifted = _lift_lane_invariant_if(loop, lane_var, uniform_names)
+        if lifted is not None:
+            return split_lane_loop_reductions(
+                lifted,
+                uniform_names=set(uniform_names),
+                proven_disjoint_tensor_pairs=proven_disjoint_tensor_pairs,
+                proven_tensor_stride_values=proven_tensor_stride_values,
+                thread_axis_names=dict(thread_axis_names),
+                scalar_definitions=dict(scalar_definitions),
+            )
+        if any(_find_lane_reduce_call(node) is not None for node in ast.walk(loop)):
+            from .. import exc
+
+            raise exc.BackendUnsupported(
+                "cute",
+                "lane reduction under a guard whose thread uniformity cannot be proven",
+            )
         return [loop]
 
     marker_indices = {i for i, _ in markers}
+
+    if _lane_split_reorders_aliasing_memory(
+        body,
+        markers,
+        proven_disjoint_tensor_pairs,
+        lane_var,
+        _static_lane_loop_extent(loop),
+        proven_tensor_stride_values,
+    ):
+        from .. import exc
+
+        raise exc.BackendUnsupported(
+            "cute",
+            "synthetic-lane reduction would reorder a potentially aliasing write",
+        )
 
     # A matmul whose *output* is reduced over a lane-distributed axis (e.g.
     # matmul_layernorm's ``acc.sum(-1)`` over the synthetic-lane N output) cannot
@@ -563,11 +726,38 @@ def _split_one_lane_loop(loop: ast.For, lane_var: str) -> list[ast.AST]:
     # Phase 1: the backward slice that produces all reduction inputs.
     phase1_indices, _phase1_written = _backward_slice(body, input_roots)
 
+    # A generated serial loop can carry a value through SSA names that are
+    # restored only by the final rename pass.  At this point the loop may read
+    # the marker input while ``ReadWrites`` reports only its temporary output
+    # name, causing the backward slice above to select the initializer and skip
+    # the update loop.  Splitting that shape would reduce the initializer (often
+    # zero) instead of the completed accumulator.  Keep the original per-lane
+    # order whenever an unselected serial loop between the chosen producer and
+    # marker reads the marker input.
+    phase1_index_set = set(phase1_indices)
+    for marker_index, marker in markers:
+        if any(
+            index not in phase1_index_set
+            and isinstance(stmt, (ast.For, ast.While))
+            and marker.input_name in ReadWrites.from_ast(stmt).reads
+            for index, stmt in enumerate(body[:marker_index])
+        ):
+            return [_restore_per_lane_markers(loop, markers)]
+
     # Sequentially-dependent reductions (one marker's input depends on another
-    # marker's result, e.g. online softmax's sum-of-exp needing the max first)
-    # would require a multi-pass split. The single-pass phase-1/finalize/phase-2
-    # structure can't express that, so fall back to per-lane behavior.
+    # marker's result) require one accumulate/finalize pass per dependency
+    # level.  The common single-pass path below remains preferable when all
+    # markers are independent because it walks the lane extent only once.
     if set(phase1_indices) & marker_indices:
+        dependent = _split_dependent_lane_reductions(
+            loop,
+            lane_var,
+            markers,
+            thread_axis_names=thread_axis_names,
+            scalar_definitions=scalar_definitions,
+        )
+        if dependent is not None:
+            return dependent
         return [_restore_per_lane_markers(loop, markers)]
 
     # The phase-1 (accumulate) and phase-2 (consume) passes both re-run the
@@ -579,8 +769,6 @@ def _split_one_lane_loop(loop: ast.For, lane_var: str) -> list[ast.AST]:
     # would be numerically wrong).
     if any(_contains_unduplicatable_op(body[i]) for i in phase1_indices):
         return [_restore_per_lane_markers(loop, markers)]
-
-    extent = _lane_loop_extent(loop)
 
     prefix: list[ast.AST] = []  # acc init statements (outside the lane loops)
     accumulate_body: list[ast.AST] = [body[i] for i in phase1_indices]
@@ -611,28 +799,418 @@ def _split_one_lane_loop(loop: ast.For, lane_var: str) -> list[ast.AST]:
     # if-with-store, an in-place write). Pure lane-varying producers that fed
     # only the (now-removed) reduction markers are dropped.
     lane_varying_names = _lane_varying_names(phase2_body, lane_var)
+    marker_dependencies = [
+        (marker, _forward_live_names(body, {marker.result_var}))
+        for _, marker in markers
+    ]
+    thread_axes_before, scalar_defs_before = _statement_provenance_before(
+        body,
+        thread_axis_names,
+        scalar_definitions,
+    )
 
     def is_lane_varying(stmt: ast.AST) -> bool:
-        reads = set(ReadWrites.from_ast(stmt).reads)
-        return lane_var in reads or bool(reads & lane_varying_names)
+        rw = ReadWrites.from_ast(stmt)
+        reads = set(rw.reads)
+        writes = set(rw.writes)
+        return (
+            lane_var in reads
+            or bool(reads & lane_varying_names)
+            or bool(writes & lane_varying_names)
+        )
 
     keep_indices = _live_phase2_indices(phase2_body)
     lane_invariant_tail: list[ast.AST] = []
     lane_varying_tail: list[ast.AST] = []
     for i, s in enumerate(phase2_body):
+        owner_exprs = _lane_reduction_owner_exprs_for_statement(
+            s,
+            markers,
+            marker_dependencies,
+            thread_axes_before.get(id(s), thread_axis_names),
+            scalar_defs_before.get(id(s), {}),
+        )
         if is_lane_varying(s):
             if i in keep_indices:
-                lane_varying_tail.append(s)
+                lane_varying_tail.append(
+                    _guard_stmt_with_owner(s, owner_exprs) if owner_exprs else s
+                )
         else:
-            lane_invariant_tail.append(s)
+            if owner_exprs:
+                predicate = " and ".join(
+                    f"({owner_expr})" for owner_expr in owner_exprs
+                )
+                lane_invariant_tail.append(_guard_stmt_with_owner(s, [predicate]))
+            else:
+                lane_invariant_tail.append(s)
 
     result: list[ast.AST] = []
     result.extend(prefix)
-    result.append(_create_lane_loop(lane_var, extent, accumulate_body))
+    result.append(_clone_lane_loop_with_body(loop, accumulate_body))
     result.extend(finalize)
     result.extend(lane_invariant_tail)
     if lane_varying_tail:
-        result.append(_create_lane_loop(lane_var, extent, lane_varying_tail))
+        result.append(_clone_lane_loop_with_body(loop, lane_varying_tail))
+    return result
+
+
+def _lift_lane_invariant_if(
+    loop: ast.For,
+    lane_var: str,
+    uniform_names: set[str],
+) -> list[ast.AST] | None:
+    """Lift one lane-invariant guard that hides reduction markers.
+
+    Synthetic reduction lanes wrap the complete grid body.  Consequently a
+    uniform runtime guard such as ``if state_index < 0`` can sit between the
+    lane loop and its reduction markers, while :func:`_split_one_lane_loop`
+    intentionally only rewrites direct marker assignments.  Lift the guard
+    when its complete condition slice is independent of both the sequential
+    lane and CUDA thread coordinates.  Each branch then owns a lane loop and
+    can be processed by the normal reduction splitter.
+
+    This is deliberately narrow: exactly one top-level guarded tail, no
+    statements after it, and no side effects in the condition slice.
+    """
+    from .ast_read_writes import ReadWrites
+
+    body: list[ast.AST] = [*loop.body]
+    candidates = [
+        (idx, stmt)
+        for idx, stmt in enumerate(body)
+        if isinstance(stmt, ast.If)
+        and any(_find_lane_reduce_call(child) is not None for child in ast.walk(stmt))
+    ]
+    if len(candidates) != 1:
+        return None
+    if_index, branch = candidates[0]
+    if if_index != len(body) - 1:
+        return None
+
+    prefix: list[ast.AST] = body[:if_index]
+    condition_reads = set(ReadWrites.from_ast(branch.test).reads)
+    condition_indices, condition_writes = _backward_slice(prefix, condition_reads)
+    condition_nodes = [prefix[idx] for idx in condition_indices]
+    external_reads = set(condition_reads)
+    for stmt in condition_nodes:
+        external_reads.update(ReadWrites.from_ast(stmt).reads)
+    external_reads.difference_update(condition_writes)
+    # Every dependency from outside the condition slice must be a kernel
+    # argument, generated constexpr, module global, or an enclosing assignment
+    # already proven independent of CUDA thread coordinates.
+    if not all(_is_proven_uniform_name(name, uniform_names) for name in external_reads):
+        return None
+    condition_source = "\n".join(
+        [ast.unparse(branch.test), *(ast.unparse(stmt) for stmt in condition_nodes)]
+    )
+    if lane_var in condition_source:
+        return None
+    if any(name in condition_source for name in _CUTE_THREAD_VARYING_INTRINSICS):
+        return None
+    if any(_has_side_effect(stmt) for stmt in condition_nodes):
+        return None
+
+    condition_index_set = set(condition_indices)
+    lane_prefix = [
+        _clone_stmt(stmt)
+        for idx, stmt in enumerate(prefix)
+        if idx not in condition_index_set
+    ]
+
+    def branch_loop(statements: list[ast.AST]) -> list[ast.stmt]:
+        branch_body = [
+            *(_clone_stmt(stmt) for stmt in lane_prefix),
+            *statements,
+        ]
+        if not branch_body:
+            return [ast.Pass()]
+        return [
+            cast(
+                "ast.stmt",
+                _clone_lane_loop_with_body(loop, branch_body),
+            )
+        ]
+
+    lifted_if = create(
+        ast.If,
+        test=_clone_expr(branch.test),
+        body=branch_loop([_clone_stmt(stmt) for stmt in branch.body]),
+        orelse=branch_loop([_clone_stmt(stmt) for stmt in branch.orelse]),
+    )
+    return [*(_clone_stmt(stmt) for stmt in condition_nodes), lifted_if]
+
+
+def _is_proven_uniform_name(name: str, uniform_names: set[str]) -> bool:
+    return name in uniform_names or name.startswith(("_BLOCK_SIZE_", "_RDIM_SIZE_"))
+
+
+def _update_proven_uniform_names(stmt: ast.AST, uniform_names: set[str]) -> None:
+    """Track simple assignments proven uniform across the CUDA thread block."""
+    from .ast_read_writes import ReadWrites
+
+    rw = ReadWrites.from_ast(stmt)
+    writes = set(rw.writes)
+    if not writes:
+        return
+    source = ast.unparse(stmt)
+    if not isinstance(stmt, ast.Assign) or any(
+        name in source for name in _CUTE_THREAD_VARYING_INTRINSICS
+    ):
+        uniform_names.difference_update(writes)
+        return
+    reads = set(rw.reads)
+    if all(_is_proven_uniform_name(name, uniform_names) for name in reads):
+        uniform_names.update(writes)
+    else:
+        uniform_names.difference_update(writes)
+
+
+def _thread_axes_read_by(
+    node: ast.AST,
+    thread_axis_names: dict[str, frozenset[int]],
+) -> set[int]:
+    """Physical thread axes that can affect an expression or statement."""
+    axes: set[int] = set()
+
+    class ThreadAxisVisitor(ast.NodeVisitor):
+        def visit_Name(self, node: ast.Name) -> None:
+            if isinstance(node.ctx, ast.Load):
+                axes.update(thread_axis_names.get(node.id, ()))
+
+        def visit_Call(self, node: ast.Call) -> None:
+            if isinstance(node.func, ast.Attribute) and node.func.attr == "lane_idx":
+                # ``lane_idx`` is a linear warp coordinate, not CUDA axis 0.
+                # In a multidimensional CTA it can depend on every physical
+                # thread axis, and it repeats across warps.  This provenance is
+                # intentionally a conservative superset so a lane-based value
+                # or predicate cannot be mistaken for axis-0-only ownership.
+                axes.update((0, 1, 2))
+            self.generic_visit(node)
+
+        def visit_Subscript(self, node: ast.Subscript) -> None:
+            value = node.value
+            if (
+                isinstance(value, ast.Call)
+                and isinstance(value.func, ast.Attribute)
+                and value.func.attr == "thread_idx"
+                and isinstance(node.slice, ast.Constant)
+                and isinstance(node.slice.value, int)
+            ):
+                axes.add(node.slice.value)
+            self.generic_visit(node)
+
+    ThreadAxisVisitor().visit(node)
+    return axes
+
+
+def _update_thread_axis_names(
+    stmt: ast.AST,
+    thread_axis_names: dict[str, frozenset[int]],
+) -> None:
+    """Track physical-thread provenance through generated scalar assignments.
+
+    The lane-reduction post-pass runs after code generation, when logical block
+    provenance has otherwise been erased.  Keeping this small dataflow map lets
+    the pass distinguish a real sibling output coordinate from a redundant
+    launch coordinate before it emits a memory write.
+    """
+    from .ast_read_writes import ReadWrites
+
+    rw = ReadWrites.from_ast(stmt)
+    writes = set(rw.writes)
+    if not writes:
+        return
+    axes = _thread_axes_read_by(stmt, thread_axis_names)
+    marker = _is_lane_reduce_marker_assign(stmt)
+    if marker is not None:
+        reduce_axis = _lane_reduce_axis(marker)
+        if reduce_axis is not None:
+            axes.discard(reduce_axis)
+    frozen_axes = frozenset(axes)
+    for name in writes:
+        thread_axis_names[name] = frozen_axes
+
+
+def _update_scalar_definitions(
+    stmt: ast.AST,
+    scalar_definitions: dict[str, ast.AST],
+) -> None:
+    """Track simple generated scalar assignments for predicate proofs."""
+    from .ast_read_writes import ReadWrites
+
+    writes = set(ReadWrites.from_ast(stmt).writes)
+    invalidated = set(writes)
+    changed = True
+    while changed:
+        changed = False
+        for name, expression in list(scalar_definitions.items()):
+            if (
+                name in invalidated
+                or set(ReadWrites.from_ast(expression).reads) & invalidated
+            ):
+                scalar_definitions.pop(name)
+                if name not in invalidated:
+                    invalidated.add(name)
+                    changed = True
+    if (
+        isinstance(stmt, ast.Assign)
+        and len(stmt.targets) == 1
+        and isinstance(stmt.targets[0], ast.Name)
+    ):
+        scalar_definitions[stmt.targets[0].id] = stmt.value
+
+
+def _statement_provenance_before(
+    body: list[ast.AST],
+    thread_axis_names: dict[str, frozenset[int]],
+    scalar_definitions: dict[str, ast.AST],
+) -> tuple[
+    dict[int, dict[str, frozenset[int]]],
+    dict[int, dict[str, ast.AST]],
+]:
+    """Snapshot physical-thread and scalar provenance before each statement."""
+    thread_axes_before: dict[int, dict[str, frozenset[int]]] = {}
+    scalar_defs_before: dict[int, dict[str, ast.AST]] = {}
+    local_thread_axes = dict(thread_axis_names)
+    local_scalar_defs = dict(scalar_definitions)
+    for stmt in body:
+        thread_axes_before[id(stmt)] = dict(local_thread_axes)
+        scalar_defs_before[id(stmt)] = dict(local_scalar_defs)
+        _update_thread_axis_names(stmt, local_thread_axes)
+        _update_scalar_definitions(stmt, local_scalar_defs)
+    return thread_axes_before, scalar_defs_before
+
+
+def _lane_reduction_owner_exprs_for_statement(
+    stmt: ast.AST,
+    markers: list[tuple[int, _LaneReduceMarker]],
+    marker_dependencies: list[tuple[_LaneReduceMarker, set[str]]],
+    thread_axis_names: dict[str, frozenset[int]],
+    scalar_definitions: dict[str, ast.AST],
+) -> list[str]:
+    """Return proven owner predicates for one reduction-consume statement.
+
+    Calling ``_store_thread_axes`` even when no predicate is ultimately needed
+    is intentional: it rejects unguardable memory writes and unknown side
+    effects instead of letting a reduction-broadcast consumer race.
+    """
+    from .ast_read_writes import ReadWrites
+
+    store_axes = _store_thread_axes(stmt, thread_axis_names, scalar_definitions)
+    owner_exprs = _redundant_thread_axis_owner_exprs(markers, store_axes)
+    if store_axes is None:
+        return owner_exprs
+    reads = set(ReadWrites.from_ast(stmt).reads)
+    for marker, dependencies in marker_dependencies:
+        owner_expr = _lane_reduce_owner_expr(marker, store_axes)
+        if owner_expr is not None and reads & dependencies:
+            owner_exprs.append(owner_expr)
+    return list(dict.fromkeys(owner_exprs))
+
+
+def _split_dependent_lane_reductions(
+    loop: ast.For,
+    lane_var: str,
+    markers: list[tuple[int, _LaneReduceMarker]],
+    *,
+    thread_axis_names: dict[str, frozenset[int]],
+    scalar_definitions: dict[str, ast.AST],
+) -> list[ast.AST] | None:
+    """Split an ordered chain of lane reductions into multiple passes.
+
+    Each marker is accumulated and finalized before the next marker's input is
+    recomputed.  This handles normalization/update/project chains such as
+    ``sum(k*k) -> normalized_k -> sum(state*k) -> ...`` while keeping the
+    existing one-pass rewrite for independent reductions.
+    """
+    from .ast_read_writes import ReadWrites
+
+    body: list[ast.AST] = [*loop.body]
+    marker_indices = {idx for idx, _ in markers}
+    marker_results = {marker.result_var for _, marker in markers}
+    finalized: set[str] = set()
+    result: list[ast.AST] = []
+    marker_dependencies = [
+        (marker, _forward_live_names(body, {marker.result_var}))
+        for _, marker in markers
+    ]
+    thread_axes_before, scalar_defs_before = _statement_provenance_before(
+        body,
+        thread_axis_names,
+        scalar_definitions,
+    )
+
+    for marker_index, marker in markers:
+        available_body: list[ast.AST] = [
+            stmt
+            for idx, stmt in enumerate(body[:marker_index])
+            if idx not in marker_indices
+        ]
+        stage_indices, _ = _backward_slice(available_body, {marker.input_name})
+        stage = [available_body[idx] for idx in stage_indices]
+        stage_reads = {
+            name for stmt in stage for name in ReadWrites.from_ast(stmt).reads
+        }
+        if stage_reads & (marker_results - finalized):
+            return None
+        if any(_contains_unduplicatable_op(stmt) for stmt in stage):
+            return None
+        if any(_has_side_effect(stmt) for stmt in stage):
+            return None
+
+        acc_var = f"{marker.result_var}_lane_acc"
+        result.append(statement_from_string(f"{acc_var} = {marker.identity_expr}"))
+        acc_body = [_clone_stmt(stmt) for stmt in stage]
+        ctor = _dtype_ctor_from_identity(marker.identity_expr)
+        combine_val = (
+            f"{ctor}({marker.input_name})" if ctor is not None else marker.input_name
+        )
+        acc_body.append(
+            statement_from_string(
+                f"{acc_var} = "
+                f"{_combine_expr(marker.reduction_type, acc_var, combine_val)}"
+            )
+        )
+        result.append(_clone_lane_loop_with_body(loop, acc_body))
+        result.extend(_finalize_lane_reduce_marker(marker, acc_var))
+        finalized.add(marker.result_var)
+
+    # Re-run the lane-invariant tail once with every reduction finalized, and
+    # only the dependency closure of observable lane-varying side effects in a
+    # final lane pass.  The invariant tail must not be pruned to memory side
+    # effects: generated SSA assignments can be loop-carried outputs whose
+    # physical names are restored by the later rename pass (for example the
+    # ``acc_cnt``/``acc_mean``/``acc_m2`` updates in Welford).
+    consume_candidates: list[ast.AST] = [
+        stmt for idx, stmt in enumerate(body) if idx not in marker_indices
+    ]
+    keep_indices = _live_phase2_indices(consume_candidates)
+    lane_varying = _lane_varying_names(consume_candidates, lane_var)
+
+    def reads_lane(stmt: ast.AST) -> bool:
+        reads = set(ReadWrites.from_ast(stmt).reads)
+        return lane_var in reads or bool(reads & lane_varying)
+
+    invariant: list[ast.AST] = []
+    varying: list[ast.AST] = []
+    for idx, stmt in enumerate(consume_candidates):
+        lane_varying_stmt = reads_lane(stmt)
+        if lane_varying_stmt and idx not in keep_indices:
+            continue
+        owner_exprs = _lane_reduction_owner_exprs_for_statement(
+            stmt,
+            markers,
+            marker_dependencies,
+            thread_axes_before.get(id(stmt), thread_axis_names),
+            scalar_defs_before.get(id(stmt), {}),
+        )
+        cloned = _clone_stmt(stmt)
+        if owner_exprs:
+            cloned = _guard_stmt_with_owner(cloned, owner_exprs)
+        (varying if lane_varying_stmt else invariant).append(cloned)
+    result.extend(invariant)
+    if varying:
+        result.append(_clone_lane_loop_with_body(loop, varying))
     return result
 
 
@@ -1008,7 +1586,7 @@ def _split_lane_loop_with_register_stash(
 
     result: list[ast.AST] = []
     result.extend(decls)
-    result.append(_create_lane_loop(lane_var, extent, phase0_body))
+    result.append(_clone_lane_loop_with_body(loop, phase0_body))
 
     # Process each marker in source order (they are sequentially dependent: a
     # later marker's input may read an earlier marker's finalized scalar).
@@ -1036,7 +1614,7 @@ def _split_lane_loop_with_register_stash(
                 f"{acc_var} = {_combine_expr(m.reduction_type, acc_var, combine_val)}"
             )
         )
-        result.append(_create_lane_loop(lane_var, extent, acc_body))
+        result.append(_clone_lane_loop_with_body(loop, acc_body))
         result.extend(_finalize_lane_reduce_marker(m, acc_var))
 
     # Final consume pass: everything in the tail except the marker assignments,
@@ -1053,7 +1631,7 @@ def _split_lane_loop_with_register_stash(
         consume_body.extend(_clone_stmt(s) for s in recompute_kept)
         consume_body.extend(read_stash_stmts())
         consume_body.extend(_clone_stmt(s) for s in consume_kept)
-        result.append(_create_lane_loop(lane_var, extent, consume_body))
+        result.append(_clone_lane_loop_with_body(loop, consume_body))
     return result
 
 
@@ -1110,7 +1688,9 @@ def _markers_feed_cross_lane_carry(
 
 
 def _has_extra_cross_lane_carry(
-    body: list[ast.AST], lane_var: str, marker_indices: set[int]
+    body: list[ast.AST],
+    lane_var: str,
+    marker_indices: set[int],
 ) -> bool:
     """Return True when ``body`` contains a loop-carried accumulator across the
     lanes that is INDEPENDENT of the reduction markers.
@@ -1130,13 +1710,13 @@ def _has_extra_cross_lane_carry(
     """
     from .ast_read_writes import ReadWrites
 
-    written_so_far: set[str] = set()
+    definitely_written_so_far: set[str] = set()
     aliases: dict[str, str] = {}  # copy_var -> original carried name
     live_in: set[str] = set()
     for stmt in body:
-        rw = ReadWrites.from_ast(stmt)
-        for name in rw.reads:
-            if name != lane_var and name not in written_so_far:
+        effects = _ordered_statement_reads_writes(stmt)
+        for name in effects.reads_before_write:
+            if name != lane_var and name not in definitely_written_so_far:
                 live_in.add(name)
         if (
             isinstance(stmt, ast.Assign)
@@ -1145,7 +1725,7 @@ def _has_extra_cross_lane_carry(
             and isinstance(stmt.value, ast.Name)
         ):
             aliases[stmt.targets[0].id] = stmt.value.id
-        written_so_far |= set(rw.writes)
+        definitely_written_so_far.update(effects.definite_writes)
 
     def root(name: str) -> str:
         seen: set[str] = set()
@@ -1197,6 +1777,803 @@ def _has_extra_cross_lane_carry(
     return False
 
 
+class _OrderedReadWrites(NamedTuple):
+    reads_before_write: set[str]
+    may_writes: set[str]
+    definite_writes: set[str]
+
+
+def _ordered_block_reads_writes(body: list[ast.stmt]) -> _OrderedReadWrites:
+    reads_before_write: set[str] = set()
+    may_writes: set[str] = set()
+    definitely_written_so_far: set[str] = set()
+    for stmt in body:
+        effects = _ordered_statement_reads_writes(stmt)
+        reads_before_write.update(
+            effects.reads_before_write - definitely_written_so_far
+        )
+        may_writes.update(effects.may_writes)
+        definitely_written_so_far.update(effects.definite_writes)
+    return _OrderedReadWrites(
+        reads_before_write,
+        may_writes,
+        definitely_written_so_far,
+    )
+
+
+def _literal_int_expr(node: ast.AST) -> int | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, int):
+        return node.value
+    if isinstance(node, ast.UnaryOp):
+        value = _literal_int_expr(node.operand)
+        if value is None:
+            return None
+        if isinstance(node.op, ast.USub):
+            return -value
+        if isinstance(node.op, ast.UAdd):
+            return value
+    if isinstance(node, ast.Call) and len(node.args) == 1 and not node.keywords:
+        is_builtin_int = isinstance(node.func, ast.Name) and node.func.id == "int"
+        is_cutlass_int = (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "cutlass"
+            and node.func.attr in ("Int32", "Int64")
+        )
+        if is_builtin_int or is_cutlass_int:
+            return _literal_int_expr(node.args[0])
+    return None
+
+
+def _for_is_provably_nonempty(stmt: ast.For) -> bool:
+    if any(
+        isinstance(node, (ast.Break, ast.Continue, ast.Return, ast.Raise))
+        for node in ast.walk(stmt)
+    ):
+        return False
+    iterator = stmt.iter
+    if not (
+        isinstance(iterator, ast.Call)
+        and isinstance(iterator.func, ast.Name)
+        and iterator.func.id == "range"
+        and not iterator.keywords
+        and 1 <= len(iterator.args) <= 3
+    ):
+        return False
+    values = [_literal_int_expr(arg) for arg in iterator.args]
+    if any(value is None for value in values):
+        return False
+    integers = cast("list[int]", values)
+    try:
+        return len(range(*integers)) > 0
+    except ValueError:
+        return False
+
+
+def _ordered_statement_reads_writes(stmt: ast.AST) -> _OrderedReadWrites:
+    """Return ordered reads plus may-write and definitely-write sets.
+
+    :class:`ReadWrites` intentionally summarizes a compound statement as an
+    unordered set.  That is too conservative for cross-*outer*-lane carry
+    detection: locals assigned near the top of a generated serial loop and
+    read later in that same loop look like live-ins, causing a valid reduction
+    marker to be replaced by its per-lane value.
+
+    A conditional write, however, cannot suppress a later read unless every
+    branch definitely writes the name.  Likewise, writes in a loop only become
+    definite when its generated ``range`` is statically non-empty.  Keeping
+    may-writes separate preserves both properties.
+    """
+    from .ast_read_writes import ReadWrites
+
+    if isinstance(stmt, ast.If):
+        test_rw = ReadWrites.from_ast(stmt.test)
+        body = _ordered_block_reads_writes(stmt.body)
+        orelse = _ordered_block_reads_writes(stmt.orelse)
+        return _OrderedReadWrites(
+            set(test_rw.reads) | body.reads_before_write | orelse.reads_before_write,
+            set(test_rw.writes) | body.may_writes | orelse.may_writes,
+            set(test_rw.writes) | (body.definite_writes & orelse.definite_writes),
+        )
+
+    if not isinstance(stmt, ast.For):
+        rw = ReadWrites.from_ast(stmt)
+        writes = set(rw.writes)
+        # Other compound statements (while/try/with/match) may skip or branch
+        # around writes. Treat their writes as possible only; generated plain
+        # assignments and expression statements execute unconditionally.
+        definite_writes = (
+            set()
+            if any(
+                isinstance(stmt, kind)
+                for kind in (ast.While, ast.Try, ast.With, ast.AsyncWith, ast.Match)
+            )
+            else writes
+        )
+        return _OrderedReadWrites(set(rw.reads), writes, definite_writes)
+
+    iter_rw = ReadWrites.from_ast(stmt.iter)
+    target_rw = ReadWrites.from_ast(stmt.target)
+    target_writes = set(target_rw.writes)
+    body = _ordered_block_reads_writes(stmt.body)
+    orelse = _ordered_block_reads_writes(stmt.orelse)
+    reads_before_write = set(iter_rw.reads)
+    reads_before_write.update(body.reads_before_write - target_writes)
+    # A ``for ... else`` can execute its else suite without one body iteration,
+    # so no body/target write is available to suppress these reads.
+    reads_before_write.update(orelse.reads_before_write)
+    may_writes = (
+        set(iter_rw.writes) | target_writes | body.may_writes | orelse.may_writes
+    )
+    definite_writes = set(iter_rw.writes)
+    if _for_is_provably_nonempty(stmt):
+        definite_writes.update(target_writes)
+        definite_writes.update(body.definite_writes)
+    return _OrderedReadWrites(reads_before_write, may_writes, definite_writes)
+
+
+def _lane_reduce_owner_expr(
+    marker: _LaneReduceMarker,
+    store_axes: _StoreThreadAxes | None = None,
+) -> str | None:
+    """Predicate selecting one writer for a broadcast reduction result."""
+    reduce_axis = _lane_reduce_axis(marker)
+    if store_axes is not None and reduce_axis is not None:
+        if reduce_axis in store_axes.address:
+            return None
+        if reduce_axis in store_axes.unique_predicate:
+            return None
+        if reduce_axis in store_axes.predicate or reduce_axis in store_axes.value:
+            raise exc.BackendUnsupported(
+                "cute",
+                "cannot infer unique ownership for a thread-varying store",
+            )
+    if marker.group_span > 1 and marker.group_lane_expr:
+        # ``group_pre`` is the product of sibling coordinates below the
+        # reduction axis.  The first ``group_pre`` lanes in each group are the
+        # reduction-coordinate-zero owners, one for each sibling element.
+        return (
+            f"(({marker.group_lane_expr}) % {marker.group_span}) < {marker.group_pre}"
+        )
+    if marker.threads_in_group > 1:
+        return f"(cutlass.Int32(cute.arch.lane_idx()) % {marker.threads_in_group}) == 0"
+    return None
+
+
+def _lane_reduce_axis(marker: _LaneReduceMarker) -> int | None:
+    if marker.group_span > 1 and marker.group_lane_expr:
+        strides = _linear_thread_axis_strides(marker.group_lane_expr)
+        if strides is None:
+            return None
+        matches = [
+            axis for axis, stride in strides.items() if stride == marker.group_pre
+        ]
+        return matches[0] if len(matches) == 1 else None
+    if marker.threads_in_group > 1:
+        return 0
+    return None
+
+
+def _linear_thread_axis_strides(expr: str) -> dict[int, int] | None:
+    """Recover ``thread_idx`` coefficients from a flattened lane expression."""
+    try:
+        root = ast.parse(expr, mode="eval").body
+    except SyntaxError:
+        return None
+
+    def merge(
+        left: tuple[dict[int, int], int],
+        right: tuple[dict[int, int], int],
+        sign: int = 1,
+    ) -> tuple[dict[int, int], int]:
+        coefficients = dict(left[0])
+        for axis, coefficient in right[0].items():
+            coefficients[axis] = coefficients.get(axis, 0) + sign * coefficient
+        return coefficients, left[1] + sign * right[1]
+
+    def scale(
+        value: tuple[dict[int, int], int], factor: int
+    ) -> tuple[dict[int, int], int]:
+        return (
+            {axis: coefficient * factor for axis, coefficient in value[0].items()},
+            value[1] * factor,
+        )
+
+    def visit(node: ast.AST) -> tuple[dict[int, int], int] | None:
+        if isinstance(node, ast.Constant) and isinstance(node.value, int):
+            return {}, node.value
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+            value = visit(node.operand)
+            return None if value is None else scale(value, -1)
+        if isinstance(node, ast.Call) and len(node.args) == 1 and not node.keywords:
+            # Generated lane expressions wrap both coordinates and constants in
+            # the configured index dtype constructor.
+            return visit(node.args[0])
+        if isinstance(node, ast.Subscript):
+            value = node.value
+            if (
+                isinstance(value, ast.Call)
+                and isinstance(value.func, ast.Attribute)
+                and value.func.attr == "thread_idx"
+                and isinstance(node.slice, ast.Constant)
+                and isinstance(node.slice.value, int)
+            ):
+                return {node.slice.value: 1}, 0
+            return None
+        if isinstance(node, ast.BinOp):
+            left = visit(node.left)
+            right = visit(node.right)
+            if left is None or right is None:
+                return None
+            if isinstance(node.op, ast.Add):
+                return merge(left, right)
+            if isinstance(node.op, ast.Sub):
+                return merge(left, right, -1)
+            if isinstance(node.op, ast.Mult):
+                if not left[0]:
+                    return scale(right, left[1])
+                if not right[0]:
+                    return scale(left, right[1])
+        return None
+
+    result = visit(root)
+    if result is None or result[1] != 0:
+        return None
+    return result[0]
+
+
+class _StoreThreadAxes(NamedTuple):
+    value: set[int]
+    address: set[int]
+    predicate: set[int]
+    unique_predicate: set[int]
+    zero_safe_predicate: set[int]
+
+
+def _contains_sync_threads(stmt: ast.AST) -> bool:
+    return any(
+        isinstance(node, ast.Call)
+        and (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "sync_threads"
+            or isinstance(node.func, ast.Name)
+            and node.func.id == "sync_threads"
+        )
+        for node in ast.walk(stmt)
+    )
+
+
+def _memory_write_calls(stmt: ast.AST) -> list[ast.Call]:
+    helper_stores = {
+        "_cute_store_u16_vec",
+        "_cute_store_u32_vec",
+        "_helion_persistent_branch_vec_store",
+    }
+    helper_atomics = {"_cute_atomic_max_float32", "_cute_atomic_min_float32"}
+    result: list[ast.Call] = []
+    for node in ast.walk(stmt):
+        if not isinstance(node, ast.Call):
+            continue
+        if (
+            isinstance(node.func, ast.Attribute)
+            and (
+                node.func.attr in ("store", "__setitem__")
+                or node.func.attr.startswith("atomic_")
+            )
+            or isinstance(node.func, ast.Name)
+            and (
+                node.func.id in helper_stores
+                or node.func.id in helper_atomics
+                or node.func.id.startswith("atomic_")
+            )
+        ):
+            result.append(node)
+    return result
+
+
+def _is_persistent_branch_vec_store(call: ast.Call) -> bool:
+    return (
+        isinstance(call.func, ast.Name)
+        and call.func.id == "_helion_persistent_branch_vec_store"
+        and len(call.args) == 6
+        and not call.keywords
+    )
+
+
+def _atomic_pointer_and_value(call: ast.Call) -> tuple[ast.AST, ast.AST] | None:
+    if isinstance(call.func, ast.Name) and (
+        call.func.id.startswith("atomic_")
+        or call.func.id in ("_cute_atomic_max_float32", "_cute_atomic_min_float32")
+    ):
+        return (call.args[0], call.args[1]) if len(call.args) >= 2 else None
+    if not (
+        isinstance(call.func, ast.Attribute) and call.func.attr.startswith("atomic_")
+    ):
+        return None
+    # ``cute.arch.atomic_add(ptr, value)`` carries its pointer as the first
+    # argument; pointer-method atomics carry it in the callee receiver.
+    if ast.unparse(call.func.value) == "cute.arch":
+        return (call.args[0], call.args[1]) if len(call.args) >= 2 else None
+    return (call.func.value, call.args[0]) if call.args else None
+
+
+def _is_isolated_store_statement(stmt: ast.AST, store: ast.Call) -> bool:
+    """Whether wrapping *stmt* predicates only one otherwise isolated store."""
+    if any(isinstance(node, ast.NamedExpr) for node in ast.walk(stmt)):
+        return False
+    for node in ast.walk(stmt):
+        if not isinstance(node, ast.stmt):
+            continue
+        if isinstance(node, (ast.If, ast.Pass)):
+            continue
+        if isinstance(node, ast.Expr) and node.value is store:
+            continue
+        return False
+    return True
+
+
+def _direct_thread_coordinate(node: ast.AST) -> int | None:
+    """Return an axis for a direct thread coordinate, allowing scalar casts."""
+    if isinstance(node, ast.Call) and len(node.args) == 1 and not node.keywords:
+        is_builtin_int = isinstance(node.func, ast.Name) and node.func.id == "int"
+        is_cutlass_int = (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "cutlass"
+            and node.func.attr in ("Int32", "Int64")
+        )
+        if is_builtin_int or is_cutlass_int:
+            return _direct_thread_coordinate(node.args[0])
+    if not isinstance(node, ast.Subscript):
+        return None
+    value = node.value
+    if not (
+        isinstance(value, ast.Call)
+        and isinstance(value.func, ast.Attribute)
+        and value.func.attr == "thread_idx"
+        and isinstance(node.slice, ast.Constant)
+        and isinstance(node.slice.value, int)
+    ):
+        return None
+    return node.slice.value
+
+
+def _uniquely_predicated_thread_axes(predicate: ast.AST) -> set[int]:
+    """Axes for which *predicate* fixes one exact physical thread coordinate."""
+    if isinstance(predicate, ast.BoolOp) and isinstance(predicate.op, ast.And):
+        result: set[int] = set()
+        for value in predicate.values:
+            result.update(_uniquely_predicated_thread_axes(value))
+        return result
+    if not (
+        isinstance(predicate, ast.Compare)
+        and len(predicate.ops) == 1
+        and isinstance(predicate.ops[0], ast.Eq)
+        and len(predicate.comparators) == 1
+    ):
+        return set()
+    lhs_axis = _direct_thread_coordinate(predicate.left)
+    rhs_axis = _direct_thread_coordinate(predicate.comparators[0])
+    lhs_literal = _literal_int_expr(predicate.left)
+    rhs_literal = _literal_int_expr(predicate.comparators[0])
+    if lhs_axis is not None and rhs_literal is not None:
+        return {lhs_axis}
+    if rhs_axis is not None and lhs_literal is not None:
+        return {rhs_axis}
+    return set()
+
+
+def _resolve_scalar_definition(
+    node: ast.AST,
+    scalar_definitions: dict[str, ast.AST],
+    seen: set[str] | None = None,
+) -> ast.AST:
+    """Resolve generated scalar aliases without expanding arbitrary syntax."""
+    if not isinstance(node, ast.Name) or node.id not in scalar_definitions:
+        return node
+    if seen is None:
+        seen = set()
+    if node.id in seen:
+        return node
+    return _resolve_scalar_definition(
+        scalar_definitions[node.id],
+        scalar_definitions,
+        {*seen, node.id},
+    )
+
+
+def _thread_axis_linear_coefficient(
+    node: ast.AST,
+    axis: int,
+    thread_axis_names: dict[str, frozenset[int]],
+    scalar_definitions: dict[str, ast.AST],
+    seen: set[str] | None = None,
+) -> int | None:
+    """Return the integer coefficient of one thread axis, when affine."""
+    if axis not in _thread_axes_read_by(node, thread_axis_names):
+        return 0
+    if isinstance(node, ast.Name):
+        if node.id not in scalar_definitions:
+            return None
+        if seen is None:
+            seen = set()
+        if node.id in seen:
+            return None
+        return _thread_axis_linear_coefficient(
+            scalar_definitions[node.id],
+            axis,
+            thread_axis_names,
+            scalar_definitions,
+            {*seen, node.id},
+        )
+    direct_axis = _direct_thread_coordinate(node)
+    if direct_axis is not None:
+        return int(direct_axis == axis)
+    if isinstance(node, ast.Call) and len(node.args) == 1 and not node.keywords:
+        is_builtin_int = isinstance(node.func, ast.Name) and node.func.id == "int"
+        is_cutlass_int = (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "cutlass"
+            and node.func.attr in ("Int32", "Int64")
+        )
+        if is_builtin_int or is_cutlass_int:
+            return _thread_axis_linear_coefficient(
+                node.args[0],
+                axis,
+                thread_axis_names,
+                scalar_definitions,
+                seen,
+            )
+    if isinstance(node, ast.UnaryOp):
+        coefficient = _thread_axis_linear_coefficient(
+            node.operand,
+            axis,
+            thread_axis_names,
+            scalar_definitions,
+            seen,
+        )
+        if coefficient is None:
+            return None
+        if isinstance(node.op, ast.UAdd):
+            return coefficient
+        if isinstance(node.op, ast.USub):
+            return -coefficient
+    if isinstance(node, ast.BinOp):
+        left = _thread_axis_linear_coefficient(
+            node.left,
+            axis,
+            thread_axis_names,
+            scalar_definitions,
+            seen,
+        )
+        right = _thread_axis_linear_coefficient(
+            node.right,
+            axis,
+            thread_axis_names,
+            scalar_definitions,
+            seen,
+        )
+        if left is None or right is None:
+            return None
+        if isinstance(node.op, ast.Add):
+            return left + right
+        if isinstance(node.op, ast.Sub):
+            return left - right
+        if isinstance(node.op, ast.Mult):
+            left_literal = _literal_int_expr(node.left)
+            right_literal = _literal_int_expr(node.right)
+            if left_literal is not None:
+                return left_literal * right
+            if right_literal is not None:
+                return right_literal * left
+    return None
+
+
+def _is_generated_block_extent(
+    node: ast.AST,
+    scalar_definitions: dict[str, ast.AST],
+) -> bool:
+    """Whether *node* is a generated, statically positive block extent."""
+    node = _resolve_scalar_definition(node, scalar_definitions)
+    while isinstance(node, ast.Call) and len(node.args) == 1 and not node.keywords:
+        is_builtin_int = isinstance(node.func, ast.Name) and node.func.id == "int"
+        is_cutlass_int = (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "cutlass"
+            and node.func.attr in ("Int32", "Int64")
+        )
+        if not (is_builtin_int or is_cutlass_int):
+            return False
+        node = _resolve_scalar_definition(node.args[0], scalar_definitions)
+    return isinstance(node, ast.Name) and node.id.startswith("_BLOCK_SIZE_")
+
+
+def _predicate_accepts_zero_thread_axis(
+    predicate: ast.AST,
+    axis: int,
+    thread_axis_names: dict[str, frozenset[int]],
+    scalar_definitions: dict[str, ast.AST],
+) -> bool:
+    """Prove a generated bound remains true after selecting axis lane zero.
+
+    A ``<``/``<=`` bound whose left side has a positive affine coefficient for
+    the nonnegative CUDA thread coordinate can only become easier to satisfy
+    when that coordinate is replaced by zero. Other predicate forms fail
+    closed rather than risk adding an owner condition that makes them empty.
+    """
+    if axis not in _thread_axes_read_by(predicate, thread_axis_names):
+        return True
+    resolved = _resolve_scalar_definition(predicate, scalar_definitions)
+    if resolved is not predicate:
+        return _predicate_accepts_zero_thread_axis(
+            resolved,
+            axis,
+            thread_axis_names,
+            scalar_definitions,
+        )
+    if isinstance(predicate, ast.BoolOp) and isinstance(predicate.op, ast.And):
+        return all(
+            _predicate_accepts_zero_thread_axis(
+                value,
+                axis,
+                thread_axis_names,
+                scalar_definitions,
+            )
+            for value in predicate.values
+        )
+    if not (
+        isinstance(predicate, ast.Compare)
+        and len(predicate.ops) == 1
+        and isinstance(predicate.ops[0], (ast.Lt, ast.LtE))
+        and len(predicate.comparators) == 1
+    ):
+        return False
+    lhs = _resolve_scalar_definition(predicate.left, scalar_definitions)
+    rhs = _resolve_scalar_definition(predicate.comparators[0], scalar_definitions)
+    return (
+        axis not in _thread_axes_read_by(rhs, thread_axis_names)
+        and _is_generated_block_extent(rhs, scalar_definitions)
+        and (
+            coefficient := _thread_axis_linear_coefficient(
+                lhs,
+                axis,
+                thread_axis_names,
+                scalar_definitions,
+            )
+        )
+        is not None
+        and coefficient > 0
+    )
+
+
+def _store_enclosing_predicates(stmt: ast.AST, store: ast.Call) -> list[ast.AST]:
+    """Control predicates on the unique path from *stmt* to *store*."""
+
+    def find(node: ast.AST, predicates: list[ast.AST]) -> list[ast.AST] | None:
+        if node is store:
+            return predicates
+        if isinstance(node, ast.If):
+            for child in node.body:
+                found = find(child, [*predicates, node.test])
+                if found is not None:
+                    return found
+            for child in node.orelse:
+                # The else path is guarded by the negation. It can still carry
+                # axis provenance, but an equality in the positive test does
+                # not prove that the else selects a unique lane.
+                found = find(
+                    child,
+                    [*predicates, create(ast.UnaryOp, op=ast.Not(), operand=node.test)],
+                )
+                if found is not None:
+                    return found
+            return None
+        for child in ast.iter_child_nodes(node):
+            found = find(child, predicates)
+            if found is not None:
+                return found
+        return None
+
+    return find(stmt, []) or []
+
+
+def _store_thread_axes(
+    stmt: ast.AST,
+    thread_axis_names: dict[str, frozenset[int]],
+    scalar_definitions: dict[str, ast.AST],
+) -> _StoreThreadAxes | None:
+    """Validate one guardable store and return its thread-axis provenance."""
+    memory_calls = _memory_write_calls(stmt)
+    atomic_parts = (
+        _atomic_pointer_and_value(memory_calls[0])
+        if len(memory_calls) == 1
+        and _is_isolated_store_statement(stmt, memory_calls[0])
+        else None
+    )
+    if atomic_parts is not None:
+        if _contains_sync_threads(stmt):
+            raise exc.BackendUnsupported(
+                "cute", "cannot predicate a statement containing sync_threads"
+            )
+        store = memory_calls[0]
+        pointer, value = atomic_parts
+    else:
+        store = _validated_owner_store(stmt)
+        if store is None:
+            return None
+        if _is_persistent_branch_vec_store(store):
+            pointer = store.args[3]
+            value = store.args[4]
+        else:
+            store_func = cast("ast.Attribute", store.func)
+            pointer = store_func.value
+            value = store.args[0]
+    predicates = _store_enclosing_predicates(stmt, store)
+    if _is_persistent_branch_vec_store(store):
+        marker_mask = store.args[5]
+        if not (isinstance(marker_mask, ast.Constant) and marker_mask.value is None):
+            predicates.append(marker_mask)
+    value_axes = _thread_axes_read_by(value, thread_axis_names)
+    predicate_axes = [
+        _thread_axes_read_by(predicate, thread_axis_names) for predicate in predicates
+    ]
+    all_predicate_axes = set().union(*predicate_axes)
+    return _StoreThreadAxes(
+        value_axes,
+        _thread_axes_read_by(pointer, thread_axis_names),
+        all_predicate_axes,
+        set().union(
+            *(_uniquely_predicated_thread_axes(predicate) for predicate in predicates)
+        ),
+        {
+            axis
+            for axis in all_predicate_axes
+            if all(
+                axis not in axes
+                or _predicate_accepts_zero_thread_axis(
+                    predicate,
+                    axis,
+                    thread_axis_names,
+                    scalar_definitions,
+                )
+                for predicate, axes in zip(predicates, predicate_axes, strict=True)
+            )
+        },
+    )
+
+
+def _validated_owner_store(stmt: ast.AST) -> ast.Call | None:
+    """Return the only isolated store, rejecting unsafe ownership rewrites."""
+    if _contains_sync_threads(stmt):
+        raise exc.BackendUnsupported(
+            "cute", "cannot predicate a statement containing sync_threads"
+        )
+    # A call used as a statement discards its result, so it exists for an
+    # effect.  Unknown callees must not pass through as if they were pure: the
+    # finalized reduction is broadcast to every reduction thread, and an
+    # unguarded custom writer would therefore race.  Recognized memory calls
+    # continue through the stricter unique-store validation below.
+    memory_calls = _memory_write_calls(stmt)
+    memory_call_ids = {id(call) for call in memory_calls}
+    if any(
+        isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Call)
+        and id(node.value) not in memory_call_ids
+        for node in ast.walk(stmt)
+    ):
+        raise exc.BackendUnsupported(
+            "cute", "cannot infer whether a standalone call has side effects"
+        )
+    if not _has_observable_memory_write(stmt):
+        return None
+    stores = [
+        node
+        for node in memory_calls
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "store"
+            and len(node.args) == 1
+            or _is_persistent_branch_vec_store(node)
+        )
+    ]
+    if len(memory_calls) != 1 or len(stores) != 1:
+        raise exc.BackendUnsupported(
+            "cute", "cannot infer unique ownership for this memory write"
+        )
+    store = stores[0]
+    if not _is_isolated_store_statement(stmt, store):
+        raise exc.BackendUnsupported(
+            "cute", "cannot predicate a compound statement containing a store"
+        )
+    return store
+
+
+def _redundant_thread_axis_owner_exprs(
+    markers: list[tuple[int, _LaneReduceMarker]],
+    store_axes: _StoreThreadAxes | None,
+) -> list[str]:
+    """Select one writer along launch axes duplicated by a lane reduction.
+
+    A scan feeding a reduction can expose the same logical free coordinate via
+    two physical axes: one chosen by the scan/store layout and one introduced
+    by the reduction layout.  The grouped reduction correctly preserves every
+    sibling coordinate, but a store whose value, address, and enclosing control
+    flow use none of those coordinates is otherwise emitted by every redundant
+    thread. Gate only an axis proven absent from the complete statement. If the
+    stored value varies on an unaddressed axis, reject instead of silently
+    choosing one conflicting writer.
+    """
+    redundant_axes: set[int] = set()
+    for _, marker in markers:
+        if marker.group_span <= 1 or not marker.group_lane_expr:
+            continue
+        strides = _linear_thread_axis_strides(marker.group_lane_expr)
+        if strides is None:
+            continue
+        reduce_axis = _lane_reduce_axis(marker)
+        if reduce_axis is None:
+            continue
+        for axis in sorted(strides):
+            if axis != reduce_axis:
+                redundant_axes.add(axis)
+    return _thread_axis_owner_exprs(redundant_axes, store_axes)
+
+
+def _thread_axis_owner_exprs(
+    redundant_axes: set[int],
+    store_axes: _StoreThreadAxes | None,
+) -> list[str]:
+    """Choose one writer along physical axes absent from a logical store."""
+    if store_axes is None:
+        return []
+    predicates: list[str] = []
+    for axis in sorted(redundant_axes):
+        if axis in store_axes.address or axis in store_axes.unique_predicate:
+            continue
+        if axis in store_axes.value:
+            raise exc.BackendUnsupported(
+                "cute",
+                "lane reduction store aliases a value-varying thread axis",
+            )
+        if axis in store_axes.predicate and axis not in store_axes.zero_safe_predicate:
+            raise exc.BackendUnsupported(
+                "cute", "cannot infer unique ownership from a thread predicate"
+            )
+        predicates.append(f"cutlass.Int32(cute.arch.thread_idx()[{axis}]) == 0")
+    return predicates
+
+
+def _guard_stmt_with_owner(stmt: ast.AST, predicates: list[str]) -> ast.AST:
+    if not predicates:
+        return stmt
+    store = _validated_owner_store(stmt)
+    if store is None:
+        raise exc.BackendUnsupported("cute", "owner predicate requires one store")
+    predicate = " and ".join(f"({expr})" for expr in dict.fromkeys(predicates))
+    if _is_persistent_branch_vec_store(store):
+        mask = store.args[5]
+        mask_source = (
+            None
+            if isinstance(mask, ast.Constant) and mask.value is None
+            else ast.unparse(mask)
+        )
+        guarded = _clone_stmt(stmt)
+        assert isinstance(guarded, ast.Expr)
+        guarded_store = cast("ast.Call", guarded.value)
+        guarded_mask = expr_from_string(
+            predicate if mask_source is None else f"({mask_source}) and ({predicate})"
+        )
+        assert isinstance(guarded_mask, ast.expr)
+        guarded_store.args[5] = guarded_mask
+        return guarded
+    return statement_from_string(
+        f"if {predicate}:\n"
+        + "\n".join(f"    {line}" for line in ast.unparse(stmt).splitlines())
+    )
+
+
 def _restore_per_lane_markers(
     loop: ast.For, markers: list[tuple[int, _LaneReduceMarker]]
 ) -> ast.For:
@@ -1229,6 +2606,126 @@ def _contains_unduplicatable_op(stmt: ast.AST) -> bool:
     return any(call in src for call in _UNDUPLICATABLE_CALLS)
 
 
+def _lane_split_reorders_aliasing_memory(
+    body: list[ast.AST],
+    markers: list[tuple[int, _LaneReduceMarker]],
+    proven_disjoint_tensor_pairs: set[frozenset[str]],
+    lane_var: str,
+    lane_extent: int | None,
+    proven_tensor_stride_values: dict[tuple[str, int], int],
+) -> bool:
+    """Whether splitting the repeated lane loop can reorder an aliasing write.
+
+    A multi-pass lane split omits stores from its accumulation passes.  Writes
+    on either side of a producer load are barriers: a lexically later write
+    executes before the next iteration's load.  The narrow exception is a later
+    exact load/store pair with the same injective lane mapping.  Distinct
+    generated tensor names do not establish disjointness because two user
+    arguments may be the same tensor or overlapping views.
+    """
+    from .ast_read_writes import ReadWrites
+    from .cute.fuse_two_pass_loads import _contains_arch_attribute
+    from .cute.fuse_two_pass_loads import _is_store_call
+    from .cute.fuse_two_pass_loads import _store_tensor_roots
+    from .cute.fuse_two_pass_loads import _tensor_arg_roots
+    from .cute.persistent_branch_vec import _definition_snapshots
+    from .cute.persistent_branch_vec import _lane_accesses_are_iteration_independent
+    from .cute.persistent_branch_vec import _memory_load_calls
+
+    tensor_names = {
+        node.value.id
+        for stmt in body
+        for node in ast.walk(stmt)
+        if isinstance(node, ast.Attribute)
+        and node.attr == "iterator"
+        and isinstance(node.value, ast.Name)
+    }
+
+    def roots_may_alias(
+        left: frozenset[str] | None,
+        right: frozenset[str] | None,
+    ) -> bool:
+        if left is None or right is None:
+            return True
+        return any(
+            left_name == right_name
+            or frozenset((left_name, right_name)) not in proven_disjoint_tensor_pairs
+            for left_name in left
+            for right_name in right
+        )
+
+    writes: list[tuple[int, ast.Call, frozenset[str] | None]] = []
+    for write_index, stmt in enumerate(body):
+        for call in (
+            node
+            for node in ast.walk(stmt)
+            if isinstance(node, ast.Call) and _is_store_call(node)
+        ):
+            writes.append((write_index, call, _store_tensor_roots(call, tensor_names)))
+
+    definition_snapshots = _definition_snapshots(cast("list[ast.stmt]", body))
+    definitely_written: set[str] = set()
+    live_in: set[str] = set()
+    may_writes: set[str] = set()
+    for statement in body:
+        effects = ReadWrites.from_ast(statement)
+        live_in.update(set(effects.reads) - definitely_written - {lane_var})
+        may_writes.update(effects.writes)
+        if isinstance(statement, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+            definitely_written.update(effects.writes)
+    loop_carried_names = live_in & may_writes
+
+    for marker_index, marker in markers:
+        stage_indices, _ = _backward_slice(body[:marker_index], {marker.input_name})
+        for load_index in stage_indices:
+            for load_call in _memory_load_calls(body[load_index]):
+                load_marker = (
+                    isinstance(load_call.func, ast.Name)
+                    and load_call.func.id == "_helion_persistent_branch_vec_load"
+                    and len(load_call.args) == 6
+                )
+                if load_marker:
+                    pointer = load_call.args[4]
+                else:
+                    func = load_call.func
+                    assert isinstance(func, ast.Attribute)
+                    pointer = (
+                        load_call.args[0]
+                        if load_call.args and _contains_arch_attribute(func.value)
+                        else func.value
+                    )
+                load_roots = _tensor_arg_roots(pointer, tensor_names)
+                for write_index, store_call, write_roots in writes:
+                    if not roots_may_alias(write_roots, load_roots):
+                        continue
+                    unstable_address_names = set(loop_carried_names)
+                    if write_index > load_index:
+                        for crossed_statement in body[load_index + 1 : write_index + 1]:
+                            unstable_address_names.update(
+                                ReadWrites.from_ast(crossed_statement).writes
+                            )
+                    # A write before this producer load is an intra-iteration
+                    # dependence and cannot move. A later exact store may cross
+                    # the loop backedge only when both accesses have the same
+                    # injective lane mapping.
+                    if (
+                        write_index > load_index
+                        and _lane_accesses_are_iteration_independent(
+                            load_call,
+                            store_call,
+                            lane_var=lane_var,
+                            lane_extent=lane_extent,
+                            load_definitions=definition_snapshots[load_index],
+                            store_definitions=definition_snapshots[write_index],
+                            proven_tensor_stride_values=proven_tensor_stride_values,
+                            loop_carried_names=unstable_address_names,
+                        )
+                    ):
+                        continue
+                    return True
+    return False
+
+
 def _has_side_effect(stmt: ast.AST) -> bool:
     """Return True when ``stmt`` produces an observable side effect (a store,
     an in-place / atomic write, or any non-plain-assignment statement such as
@@ -1240,6 +2737,15 @@ def _has_side_effect(stmt: ast.AST) -> bool:
     # Conservatively treat structured / expression statements as
     # side-effecting (store calls live inside ``if`` blocks / bare exprs).
     return True
+
+
+def _has_observable_memory_write(stmt: ast.AST) -> bool:
+    """True for generated tensor stores/atomics, including guarded stores."""
+    from .ast_read_writes import ReadWrites
+
+    if ReadWrites.from_ast(stmt).inplace_writes:
+        return True
+    return bool(_memory_write_calls(stmt))
 
 
 def _live_phase2_indices(body: list[ast.AST]) -> set[int]:
@@ -1283,22 +2789,6 @@ def _lane_varying_names(body: list[ast.AST], lane_var: str) -> set[str]:
                         changed = True
     varying.discard(lane_var)
     return varying
-
-
-def _lane_body_live_in(body: list[ast.AST], lane_var: str) -> set[str]:
-    """Names read in ``body`` before they are written (live-in), excluding the
-    lane var.  A loop-carried accumulator phi is live-in to the lane body."""
-    from .ast_read_writes import ReadWrites
-
-    written: set[str] = set()
-    live_in: set[str] = set()
-    for stmt in body:
-        rw = ReadWrites.from_ast(stmt)
-        for name in rw.reads:
-            if name != lane_var and name not in written:
-                live_in.add(name)
-        written |= set(rw.writes)
-    return live_in
 
 
 def _is_serial_for(stmt: ast.AST) -> bool:
@@ -1406,7 +2896,6 @@ def _interchange_one_lane_loop(loop: ast.For, lane_var: str) -> list[ast.AST]:
             mb_index = idx
     if mb_index is None:
         return [loop]
-
     mb_loop = cast("ast.For", body[mb_index])
     lane_prefix = body[:mb_index]
     lane_suffix = body[mb_index + 1 :]
@@ -1491,9 +2980,8 @@ def _interchange_one_lane_loop(loop: ast.For, lane_var: str) -> list[ast.AST]:
     mb_head_a = [_clone_stmt(s) for s in keep_mb_a if not reads_lane(s)]
     mb_varying_a = [_clone_stmt(s) for s in keep_mb_a if reads_lane(s)]
 
-    extent = _lane_loop_extent(loop)
-    inner_lane_loop_a = _create_lane_loop(
-        lane_var, extent, [*prefix_varying_a, *mb_varying_a]
+    inner_lane_loop_a = _clone_lane_loop_with_body(
+        loop, [*prefix_varying_a, *mb_varying_a]
     )
     mb_loop_a = create(
         ast.For,
@@ -1525,13 +3013,15 @@ def _interchange_one_lane_loop(loop: ast.For, lane_var: str) -> list[ast.AST]:
 #
 # A chunked recurrence such as gdn_fwd_h carries an accumulator ``b_h`` across a
 # SERIAL chunk loop and, inside each chunk, contracts a matmul over the
-# within-chunk position ``c`` (lowered as an inner lane loop).  ``matmul_fallback``
-# emits the running-sum ``dot_acc`` form for this matmul (because the per-chunk
-# rescale is lane-invariant), producing inside the lane loop:
+# within-chunk position ``c`` (lowered as an inner lane loop).  The scalar
+# matmul fallback emits a running sum because the per-chunk rescale is
+# lane-invariant.  Depending on how the source spelled the update, its relevant
+# dataflow inside the lane loop is either direct or separated by temporaries:
 #
-#       dot_acc_base = <lane-invariant rescale of b_h>      # e.g. b_h * decay
-#       dot_acc = dot_acc + <product(c)>                    # accumulate over c
-#       b_h = dot_acc_base + dot_acc                        # WRONG: per-lane reassign
+#       base = <lane-invariant rescale of b_h>       # e.g. b_h * decay
+#       dot_acc = dot_acc + <product(c)>             # accumulate over c
+#       reduced = <cross-thread reduction>(dot_acc)
+#       b_h = base + reduced                          # WRONG: per-lane reassign
 #
 # with ``dot_acc = <identity>`` reset OUTSIDE the chunk loop.  Reassigning ``b_h``
 # every lane iteration corrupts the recurrence (and any lane-invariant op that
@@ -1542,71 +3032,382 @@ def _interchange_one_lane_loop(loop: ast.For, lane_var: str) -> list[ast.AST]:
 #   for chunk:
 #       dot_acc = <identity>                  # reset per chunk
 #       <lane-invariant chunk-entry stores using b_h>
-#       dot_acc_base = <rescale of frozen b_h>
+#       base = <rescale of frozen b_h>
 #       for lane:
 #           <producers; dot_acc = dot_acc + product(c)>
-#       b_h = dot_acc_base + dot_acc          # once per chunk
+#       reduced = <cross-thread reduction>(dot_acc)
+#       b_h = base + reduced                  # once per chunk
 # ---------------------------------------------------------------------------
 
 
-def _find_dot_acc_recurrence(
-    lane_loop: ast.For, lane_var: str
-) -> tuple[str, str, str] | None:
-    """If ``lane_loop`` ends with the chunked-recurrence ``dot_acc`` triple,
-    return ``(acc_var, dot_acc_base_var, dot_acc_var)``; else ``None``.
+@dataclasses.dataclass(frozen=True)
+class _ChunkRecurrence:
+    """Dataflow description of one lane-folded, chunk-carried matmul."""
 
-    The triple (emitted by ``_emit_cute_matmul``'s lane-invariant ``dot_acc``
-    path) is, as the LAST three statements of the lane-loop body:
+    dot_acc_var: str
+    lane_idx: int
+    lane_loop: ast.For
+    lane_var: str
+    sum_idx: int
+    base_indices: tuple[int, ...]
+    finalize_indices: tuple[int, ...]
+    final_idx: int
+    state_name: str
 
-        dot_acc_base = <expr>             # lane-invariant rescale of acc
-        dot_acc = dot_acc + <product>    # running sum over the lane axis
-        acc = dot_acc_base + dot_acc     # final combine
-    """
-    body = lane_loop.body
-    if len(body) < 3:
-        return None
-    base_stmt, sum_stmt, final_stmt = body[-3], body[-2], body[-1]
 
-    def assign_name(stmt: ast.AST) -> str | None:
-        if (
-            isinstance(stmt, ast.Assign)
-            and len(stmt.targets) == 1
-            and isinstance(stmt.targets[0], ast.Name)
-        ):
-            return stmt.targets[0].id
-        return None
-
-    base_var = assign_name(base_stmt)
-    dot_acc_var = assign_name(sum_stmt)
-    acc_var = assign_name(final_stmt)
-    if base_var is None or dot_acc_var is None or acc_var is None:
-        return None
-    if not (base_var.startswith("dot_acc_base") and dot_acc_var.startswith("dot_acc")):
-        return None
-    # ``dot_acc = dot_acc + product``: a running self-sum over the lane axis.
-    assert isinstance(sum_stmt, ast.Assign)
-    if not (
-        isinstance(sum_stmt.value, ast.BinOp)
-        and isinstance(sum_stmt.value.op, ast.Add)
-        and isinstance(sum_stmt.value.left, ast.Name)
-        and sum_stmt.value.left.id == dot_acc_var
+def _plain_assignment_name(stmt: ast.AST) -> str | None:
+    if (
+        isinstance(stmt, ast.Assign)
+        and len(stmt.targets) == 1
+        and isinstance(stmt.targets[0], ast.Name)
     ):
+        return stmt.targets[0].id
+    return None
+
+
+_PURE_RELOCATABLE_NAMES = frozenset(
+    {
+        "abs",
+        "bool",
+        "float",
+        "int",
+        "len",
+        "max",
+        "min",
+    }
+)
+_PURE_OPERATOR_CALLS = frozenset(
+    {
+        "add",
+        "and_",
+        "eq",
+        "floordiv",
+        "ge",
+        "getitem",
+        "gt",
+        "invert",
+        "le",
+        "lshift",
+        "lt",
+        "mod",
+        "mul",
+        "ne",
+        "neg",
+        "not_",
+        "or_",
+        "pos",
+        "pow",
+        "rshift",
+        "sub",
+        "truediv",
+        "xor",
+    }
+)
+_CHUNK_REDUCTION_HELPERS = frozenset(
+    {
+        "_cute_grouped_reduce_shared_tree",
+        "_cute_grouped_reduce_shared_two_stage",
+        "_cute_grouped_reduce_warp",
+    }
+)
+
+
+def _qualified_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _qualified_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix is not None else None
+    return None
+
+
+def _is_proven_relocatable_call(
+    call: ast.Call,
+    *,
+    allow_load: bool,
+    allow_reduction: bool = False,
+) -> bool:
+    """Whether evaluating ``call`` is known not to have observable effects."""
+    if isinstance(call.func, ast.Attribute):
+        if call.func.attr == "load":
+            return allow_load
+        if call.func.attr == "bitcast":
+            return True
+    name = _qualified_name(call.func)
+    if name is None:
+        return False
+    if name in _PURE_RELOCATABLE_NAMES:
+        return True
+    if name.startswith("cutlass."):
+        member = name.rsplit(".", 1)[-1]
+        return bool(member) and member[0].isupper()
+    if name.startswith(("math.", "cute.math.")):
+        return True
+    if name.startswith("operator."):
+        return name.rsplit(".", 1)[-1] in _PURE_OPERATOR_CALLS
+    if name in {
+        "cute.arch.block_idx",
+        "cute.arch.lane_idx",
+        "cute.arch.thread_idx",
+        "cute.arch.warp_idx",
+    }:
+        return True
+    if name == "cute.arch.load":
+        return allow_load
+    return allow_reduction and (
+        name in _CHUNK_REDUCTION_HELPERS or name.startswith("cute.arch.warp_reduction")
+    )
+
+
+def _is_proven_relocatable_assignment(
+    stmt: ast.AST,
+    *,
+    allow_load: bool,
+    allow_reduction: bool = False,
+) -> bool:
+    """Whether a simple assignment may safely change lane-loop scope."""
+    if _plain_assignment_name(stmt) is None:
+        return False
+    return all(
+        _is_proven_relocatable_call(
+            node,
+            allow_load=allow_load,
+            allow_reduction=allow_reduction,
+        )
+        for node in ast.walk(stmt)
+        if isinstance(node, ast.Call)
+    )
+
+
+def _validated_idempotent_store(stmt: ast.AST) -> ast.Call | None:
+    """Return a single ordinary store whose surrounding expressions are pure.
+
+    Atomics, helper writes, compound effects, synchronization, and calls with
+    unknown purity are deliberately rejected: changing any of those from once
+    per synthetic lane to once per chunk is not semantics-preserving.
+    """
+    store = _validated_owner_store(stmt)
+    if store is None:
         return None
-    # ``acc = dot_acc_base + dot_acc``: the final per-chunk combine.
-    assert isinstance(final_stmt, ast.Assign)
-    final_reads = {n.id for n in ast.walk(final_stmt.value) if isinstance(n, ast.Name)}
-    if final_reads != {base_var, dot_acc_var}:
+    if any(
+        node is not store
+        and isinstance(node, ast.Call)
+        and not _is_proven_relocatable_call(node, allow_load=False)
+        for node in ast.walk(stmt)
+    ):
+        raise exc.BackendUnsupported(
+            "cute", "chunk recurrence store contains a call with unknown purity"
+        )
+    return store
+
+
+def _store_iterator_roots(store: ast.Call) -> set[str]:
+    """Generated tensor iterator names that determine a store's allocation."""
+    if not isinstance(store.func, ast.Attribute):
+        return set()
+    return {
+        node.value.id
+        for node in ast.walk(store.func.value)
+        if isinstance(node, ast.Attribute)
+        and node.attr == "iterator"
+        and isinstance(node.value, ast.Name)
+    }
+
+
+def _self_addend(stmt: ast.AST, target: str) -> ast.AST | None:
+    """Return the non-self operand of ``target = target + value``."""
+    if not isinstance(stmt, ast.Assign) or not isinstance(stmt.value, ast.BinOp):
         return None
-    # The rescale (``dot_acc_base``) must be lane-INVARIANT: it must not read the
-    # lane var nor any value derived from it within the lane body.
-    lane_body: list[ast.AST] = list(body)
-    lane_varying = _lane_varying_names(lane_body, lane_var)
+    if not isinstance(stmt.value.op, ast.Add):
+        return None
+    if isinstance(stmt.value.left, ast.Name) and stmt.value.left.id == target:
+        return stmt.value.right
+    if isinstance(stmt.value.right, ast.Name) and stmt.value.right.id == target:
+        return stmt.value.left
+    return None
+
+
+def _additive_operands(expr: ast.AST) -> tuple[ast.AST, ast.AST] | None:
+    """Find the add below any generated one-argument dtype conversions."""
+    while isinstance(expr, ast.Call) and len(expr.args) == 1 and not expr.keywords:
+        expr = expr.args[0]
+    if isinstance(expr, ast.BinOp) and isinstance(expr.op, ast.Add):
+        return expr.left, expr.right
+    return None
+
+
+def _canonical_name(name: str, rename_groups: dict[str, str]) -> str:
+    return rename_groups.get(name, name)
+
+
+def _dependency_names(body: list[ast.AST], roots: set[str]) -> set[str]:
+    """Return every name in the backward slice producing ``roots``."""
     from .ast_read_writes import ReadWrites
 
-    base_reads = set(ReadWrites.from_ast(base_stmt).reads)
-    if lane_var in base_reads or (base_reads & lane_varying):
+    indices, _ = _backward_slice(body, roots)
+    names = set(roots)
+    for idx in indices:
+        rw = ReadWrites.from_ast(body[idx])
+        names.update(rw.reads)
+        names.update(rw.writes)
+    return names
+
+
+def _find_dot_acc_recurrence(
+    lane_loop: ast.For,
+    lane_var: str,
+    rename_groups: dict[str, str],
+    running_sums: set[str] | None,
+) -> _ChunkRecurrence | None:
+    """Find a lane-folded matmul that updates a chunk-carried accumulator.
+
+    Matmul and DCE temporary names are deliberately not part of the contract.
+    The recognizable structure is a scalar self-add over lane-varying input,
+    followed by an additive combine of its finalized value with a
+    lane-invariant value derived from the chunk-entry state.  The combine's
+    result must alias that state according to the compiler's SSA rename groups.
+
+    The dot-derived side may contain arbitrary plain-assignment setup and a
+    cross-thread reduction.  This covers both ``dot(..., acc=state)`` and the
+    equivalent ``state = state * decay; state = state + dot(...)`` spelling.
+    """
+    from .ast_read_writes import ReadWrites
+
+    body: list[ast.AST] = list(lane_loop.body)
+    matches: list[_ChunkRecurrence] = []
+    for sum_idx, sum_stmt in enumerate(body):
+        dot_acc_var = _plain_assignment_name(sum_stmt)
+        if dot_acc_var is None:
+            continue
+        if running_sums is not None and dot_acc_var not in running_sums:
+            continue
+        product = _self_addend(sum_stmt, dot_acc_var)
+        if product is None:
+            continue
+
+        # The update must actually fold values across this synthetic lane.
+        prefix_varying = _lane_varying_names(body[: sum_idx + 1], lane_var)
+        product_reads = set(ReadWrites.from_ast(product).reads)
+        if lane_var not in product_reads and not (product_reads & prefix_varying):
+            continue
+
+        dot_derived = {dot_acc_var}
+        for final_idx in range(sum_idx + 1, len(body)):
+            candidate = body[final_idx]
+            candidate_name = _plain_assignment_name(candidate)
+            if candidate_name is not None and isinstance(candidate, ast.Assign):
+                operands = _additive_operands(candidate.value)
+                if operands is not None:
+                    left_reads = set(ReadWrites.from_ast(operands[0]).reads)
+                    right_reads = set(ReadWrites.from_ast(operands[1]).reads)
+                    left_is_dot = bool(left_reads & dot_derived)
+                    right_is_dot = bool(right_reads & dot_derived)
+                    if left_is_dot != right_is_dot:
+                        dot_roots = left_reads if left_is_dot else right_reads
+                        base_roots = right_reads if left_is_dot else left_reads
+                        base_indices, _ = _backward_slice(
+                            body[:sum_idx], set(base_roots)
+                        )
+                        base_dependencies = _dependency_names(
+                            body[:sum_idx], set(base_roots)
+                        )
+                        base_external_varying = base_dependencies & (
+                            {lane_var} | prefix_varying
+                        )
+                        state_name = _canonical_name(candidate_name, rename_groups)
+                        carries_state = any(
+                            _canonical_name(name, rename_groups) == state_name
+                            for name in base_dependencies
+                        )
+                        base_is_invariant = all(
+                            lane_var not in set(ReadWrites.from_ast(body[idx]).reads)
+                            and not (
+                                set(ReadWrites.from_ast(body[idx]).reads)
+                                & prefix_varying
+                            )
+                            for idx in base_indices
+                        )
+                        base_is_pure = all(
+                            _is_proven_relocatable_assignment(
+                                body[idx], allow_load=True
+                            )
+                            for idx in base_indices
+                        )
+
+                        finalizer_body = body[sum_idx + 1 : final_idx]
+                        finalize_indices_rel, _ = _backward_slice(
+                            finalizer_body, set(dot_roots)
+                        )
+                        finalize_indices = tuple(
+                            sum_idx + 1 + idx for idx in finalize_indices_rel
+                        )
+                        finalize_dependencies = _dependency_names(
+                            finalizer_body, set(dot_roots)
+                        )
+                        finalize_external_varying = (
+                            finalize_dependencies - {dot_acc_var}
+                        ) & ({lane_var} | prefix_varying)
+                        finalizer_is_pure = all(
+                            _is_proven_relocatable_assignment(
+                                body[idx],
+                                allow_load=False,
+                                allow_reduction=True,
+                            )
+                            for idx in finalize_indices
+                        )
+                        reaches_running_sum = dot_acc_var in finalize_dependencies
+
+                        recognized_recurrence = bool(
+                            base_roots and carries_state and reaches_running_sum
+                        )
+                        if recognized_recurrence and (
+                            base_external_varying
+                            or not base_is_invariant
+                            or finalize_external_varying
+                        ):
+                            raise exc.BackendUnsupported(
+                                "cute",
+                                "chunk recurrence is not lane-invariant",
+                            )
+                        if recognized_recurrence and (
+                            not base_is_pure
+                            or not finalizer_is_pure
+                            or not _is_proven_relocatable_assignment(
+                                candidate, allow_load=False
+                            )
+                        ):
+                            raise exc.BackendUnsupported(
+                                "cute",
+                                "chunk recurrence contains a call with unknown purity",
+                            )
+                        if recognized_recurrence:
+                            matches.append(
+                                _ChunkRecurrence(
+                                    dot_acc_var=dot_acc_var,
+                                    lane_idx=-1,
+                                    lane_loop=lane_loop,
+                                    lane_var=lane_var,
+                                    sum_idx=sum_idx,
+                                    base_indices=tuple(base_indices),
+                                    finalize_indices=finalize_indices,
+                                    final_idx=final_idx,
+                                    state_name=state_name,
+                                )
+                            )
+
+            rw = ReadWrites.from_ast(candidate)
+            if set(rw.reads) & dot_derived:
+                dot_derived.update(rw.writes)
+
+    # Multiple candidates would require coordinated resets and post-lane
+    # finalizers.  Fail closed instead of guessing which matmul owns the carry.
+    if len(matches) > 1:
+        raise exc.BackendUnsupported(
+            "cute", "chunk recurrence has multiple candidate state updates"
+        )
+    if not matches:
         return None
-    return acc_var, base_var, dot_acc_var
+    return matches[0]
 
 
 def _single_lane_loop_in_body(
@@ -1644,128 +3445,331 @@ def _find_reset_assign(body: list[ast.AST], var: str) -> int | None:
     return None
 
 
+def _collect_statement_provenance(
+    body: list[ast.AST],
+) -> tuple[
+    dict[int, dict[str, frozenset[int]]],
+    dict[int, dict[str, ast.AST]],
+]:
+    """Capture thread-axis and scalar-definition facts before every statement."""
+    thread_axes_before: dict[int, dict[str, frozenset[int]]] = {}
+    scalar_defs_before: dict[int, dict[str, ast.AST]] = {}
+
+    def visit_block(
+        statements: list[ast.AST],
+        inherited_axes: dict[str, frozenset[int]],
+        inherited_defs: dict[str, ast.AST],
+    ) -> None:
+        local_axes = dict(inherited_axes)
+        local_defs = dict(inherited_defs)
+        for statement in statements:
+            thread_axes_before[id(statement)] = dict(local_axes)
+            scalar_defs_before[id(statement)] = dict(local_defs)
+            for field in ("body", "orelse", "finalbody"):
+                child = getattr(statement, field, None)
+                if isinstance(child, list) and all(
+                    isinstance(child_stmt, ast.stmt) for child_stmt in child
+                ):
+                    visit_block(child, local_axes, local_defs)
+            _update_thread_axis_names(statement, local_axes)
+            _update_scalar_definitions(statement, local_defs)
+
+    visit_block(body, {}, {})
+    return thread_axes_before, scalar_defs_before
+
+
+def _call_keyword_int(call: ast.Call, name: str) -> int | None:
+    for keyword in call.keywords:
+        if keyword.arg == name:
+            return _literal_int_expr(keyword.value)
+    return None
+
+
+def _chunk_recurrence_reduction_axes(
+    info: _ChunkRecurrence,
+    scalar_defs_before: dict[int, dict[str, ast.AST]],
+) -> set[int]:
+    """Physical thread axes folded by the moved cross-thread finalizer."""
+    axes: set[int] = set()
+    for idx in info.finalize_indices:
+        statement = info.lane_loop.body[idx]
+        definitions = scalar_defs_before.get(id(statement), {})
+        for call in (
+            node for node in ast.walk(statement) if isinstance(node, ast.Call)
+        ):
+            name = _qualified_name(call.func)
+            if name in _CHUNK_REDUCTION_HELPERS:
+                if len(call.args) < 4:
+                    raise exc.BackendUnsupported(
+                        "cute", "cannot infer chunk recurrence reduction ownership"
+                    )
+                pre = _call_keyword_int(call, "pre")
+                lane_expr = _resolve_scalar_definition(call.args[3], definitions)
+                strides = _linear_thread_axis_strides(ast.unparse(lane_expr))
+                matches = (
+                    []
+                    if pre is None or strides is None
+                    else [axis for axis, stride in strides.items() if stride == pre]
+                )
+                if len(matches) != 1:
+                    raise exc.BackendUnsupported(
+                        "cute", "cannot infer chunk recurrence reduction ownership"
+                    )
+                axes.add(matches[0])
+            elif name is not None and name.startswith("cute.arch.warp_reduction"):
+                axes.add(0)
+    return axes
+
+
 def hoist_lane_invariant_chunk_recurrence(
     body: list[ast.AST],
+    *,
+    rename_groups: dict[str, str] | None = None,
+    running_sums: set[str] | None = None,
 ) -> list[ast.AST]:
     """Restructure ``for chunk: for lane: <dot_acc recurrence>`` nests so the
     lane-invariant rescale, chunk-entry stores, and final accumulator combine
     run once per chunk (see the module comment above).
 
     Tightly gated: only fires on a serial chunk loop whose single inner lane
-    loop ends with the ``dot_acc`` triple and whose ``dot_acc`` reset sits in
-    the same statement list before the chunk loop.
+    loop has the verified dataflow described by :func:`_find_dot_acc_recurrence`
+    and whose running-sum reset sits in the same statement list before it.
     """
+    if running_sums is not None and not running_sums:
+        return body
+
+    thread_axes_before, scalar_defs_before = _collect_statement_provenance(body)
+    return _hoist_lane_invariant_chunk_recurrence(
+        body,
+        rename_groups or {},
+        running_sums,
+        thread_axes_before,
+        scalar_defs_before,
+    )
+
+
+def _hoist_lane_invariant_chunk_recurrence(
+    body: list[ast.AST],
+    aliases: dict[str, str],
+    running_sums: set[str] | None,
+    thread_axes_before: dict[int, dict[str, frozenset[int]]],
+    scalar_defs_before: dict[int, dict[str, ast.AST]],
+) -> list[ast.AST]:
+    from .ast_read_writes import ReadWrites
+
     new_body: list[ast.AST] = []
     for stmt in body:
         # Recurse into nested statement-bearing fields first.
         for field in ("body", "orelse", "finalbody"):
             old = getattr(stmt, field, None)
             if isinstance(old, list) and all(isinstance(s, ast.stmt) for s in old):
-                setattr(stmt, field, hoist_lane_invariant_chunk_recurrence(old))
+                setattr(
+                    stmt,
+                    field,
+                    _hoist_lane_invariant_chunk_recurrence(
+                        old,
+                        aliases,
+                        running_sums,
+                        thread_axes_before,
+                        scalar_defs_before,
+                    ),
+                )
 
-        info = _detect_chunk_recurrence(stmt)
+        info = _detect_chunk_recurrence(stmt, aliases, running_sums)
         if info is None:
             new_body.append(stmt)
             continue
-        dot_acc_var = info[0]
-        reset_idx = _find_reset_assign(new_body, dot_acc_var)
+        reset_idx = _find_reset_assign(new_body, info.dot_acc_var)
         if reset_idx is None:
-            # No relocatable reset found: bail out (leave nest unchanged).
-            new_body.append(stmt)
-            continue
-        reset_stmt = new_body.pop(reset_idx)
+            raise exc.BackendUnsupported(
+                "cute", "chunk recurrence has no relocatable accumulator reset"
+            )
+        reset_stmt = new_body[reset_idx]
+        if not _is_proven_relocatable_assignment(reset_stmt, allow_load=False):
+            raise exc.BackendUnsupported(
+                "cute", "chunk recurrence reset has effects or unknown call purity"
+            )
+        chunk_writes = {
+            _canonical_name(name, aliases) for name in ReadWrites.from_ast(stmt).writes
+        }
+        reset_reads = {
+            _canonical_name(name, aliases)
+            for name in ReadWrites.from_ast(reset_stmt).reads
+        }
+        if reset_reads & chunk_writes:
+            raise exc.BackendUnsupported(
+                "cute", "chunk recurrence reset depends on chunk-carried state"
+            )
+        if any(
+            info.dot_acc_var
+            in {
+                *ReadWrites.from_ast(intervening).reads,
+                *ReadWrites.from_ast(intervening).writes,
+            }
+            for intervening in new_body[reset_idx + 1 :]
+        ):
+            raise exc.BackendUnsupported(
+                "cute", "chunk recurrence reset has an intervening consumer"
+            )
+        if any(
+            {
+                _canonical_name(name, aliases)
+                for name in ReadWrites.from_ast(intervening).writes
+            }
+            & reset_reads
+            for intervening in new_body[reset_idx + 1 :]
+        ):
+            raise exc.BackendUnsupported(
+                "cute", "chunk recurrence reset dependency is overwritten"
+            )
+        new_body.pop(reset_idx)
         assert isinstance(stmt, ast.For)
-        new_body.append(_rewrite_chunk_recurrence(stmt, info, reset_stmt))
+        new_body.append(
+            _rewrite_chunk_recurrence(
+                stmt,
+                info,
+                reset_stmt,
+                aliases,
+                thread_axes_before,
+                scalar_defs_before,
+            )
+        )
     return new_body
 
 
 def _detect_chunk_recurrence(
     stmt: ast.AST,
-) -> tuple[str, int, ast.For, str, str, str, str] | None:
-    """Return ``(dot_acc_var, lane_idx, lane_loop, lane_var, acc_var, base_var,
-    dot_acc_var)`` when ``stmt`` is a serial chunk loop carrying the ``dot_acc``
-    recurrence, else ``None``."""
+    rename_groups: dict[str, str],
+    running_sums: set[str] | None,
+) -> _ChunkRecurrence | None:
+    """Describe a serial chunk loop carrying one lane-folded recurrence."""
     if not _is_serial_for(stmt) or not isinstance(stmt, ast.For):
         return None
     found = _single_lane_loop_in_body(list(stmt.body))
     if found is None:
         return None
     lane_idx, lane_loop, lane_var = found
-    triple = _find_dot_acc_recurrence(lane_loop, lane_var)
-    if triple is None:
+    recurrence = _find_dot_acc_recurrence(
+        lane_loop,
+        lane_var,
+        rename_groups,
+        running_sums,
+    )
+    if recurrence is None:
         return None
-    acc_var, base_var, dot_acc_var = triple
-    return dot_acc_var, lane_idx, lane_loop, lane_var, acc_var, base_var, dot_acc_var
+    return dataclasses.replace(recurrence, lane_idx=lane_idx)
 
 
 def _rewrite_chunk_recurrence(
     stmt: ast.For,
-    info: tuple[str, int, ast.For, str, str, str, str],
+    info: _ChunkRecurrence,
     reset_stmt: ast.AST,
+    rename_groups: dict[str, str],
+    thread_axes_before: dict[int, dict[str, frozenset[int]]],
+    scalar_defs_before: dict[int, dict[str, ast.AST]],
 ) -> ast.For:
     """Build the restructured chunk loop (see module comment)."""
     from .ast_read_writes import ReadWrites
 
-    _dot_acc, lane_idx, lane_loop, lane_var, acc_var, _base_var, _dot_acc2 = info
+    lane_idx = info.lane_idx
+    lane_loop = info.lane_loop
+    lane_var = info.lane_var
     chunk_body: list[ast.AST] = list(stmt.body)
     lane_body: list[ast.AST] = list(lane_loop.body)
-    base_stmt = lane_body[-3]
-    sum_stmt = lane_body[-2]
-    final_stmt = lane_body[-1]
-    producers: list[ast.AST] = lane_body[:-3]
-
-    lane_varying = _lane_varying_names(lane_body, lane_var)
+    lane_varying = _lane_varying_names(lane_body[: info.sum_idx + 1], lane_var)
 
     def reads_lane(s: ast.AST) -> bool:
         reads = set(ReadWrites.from_ast(s).reads)
         return lane_var in reads or bool(reads & lane_varying)
 
-    # The "accumulator family": the names that all hold the chunk-ENTRY
-    # accumulator value.  Helion may capture the loop-carried phi through a chain
-    # of plain copy-aliases (``b_h_copy = b_h``; ``b_h_copy_0 = b_h_copy``) and
-    # the rescale / chunk-entry store read those copies, not ``acc_var`` (which
-    # is the chunk-EXIT result).  Build the copy-alias closure over the chunk
-    # prefix and the lane producers, seeded from the loop-carried phi: a name
-    # that is live-in to the lane body (read before written) and feeds the
-    # lane-invariant rescale ``base_stmt``.
-    chunk_prefix = chunk_body[:lane_idx]
-    copy_src: dict[str, str] = {}
-    for s in (*chunk_prefix, *producers):
-        if (
-            isinstance(s, ast.Assign)
-            and len(s.targets) == 1
-            and isinstance(s.targets[0], ast.Name)
-            and isinstance(s.value, ast.Name)
-        ):
-            copy_src[s.targets[0].id] = s.value.id
-
-    def copy_root(name: str) -> str:
-        seen: set[str] = set()
-        while name in copy_src and name not in seen:
-            seen.add(name)
-            name = copy_src[name]
-        return name
-
-    base_slice_indices, _ = _backward_slice(
-        producers, set(ReadWrites.from_ast(base_stmt).reads)
-    )
-    base_slice_reads = set(ReadWrites.from_ast(base_stmt).reads)
-    for i in base_slice_indices:
-        base_slice_reads |= set(ReadWrites.from_ast(producers[i]).reads)
-    lane_live_in = _lane_body_live_in(producers, lane_var)
-    phi_roots = {
-        copy_root(name) for name in base_slice_reads if copy_root(name) in lane_live_in
+    # The base slice was proven lane-invariant by the detector.  It freezes the
+    # chunk-entry state and computes its optional per-chunk rescale.
+    hoist_set = set(info.base_indices)
+    reduction_axes = _chunk_recurrence_reduction_axes(info, scalar_defs_before)
+    guarded_statements: dict[int, ast.AST] = {}
+    all_lane_writes = {
+        name
+        for lane_stmt in lane_body
+        for name in ReadWrites.from_ast(lane_stmt).writes
     }
-    acc_family = set(phi_roots)
-    for name in (*copy_src.keys(),):
-        if copy_root(name) in phi_roots:
-            acc_family.add(name)
+    lane_effects = _ordered_block_reads_writes(cast("list[ast.stmt]", lane_body))
+    canonical_live_ins = {
+        _canonical_name(name, rename_groups)
+        for name in lane_effects.reads_before_write
+        if name != lane_var
+    }
+    canonical_lane_writes = {
+        _canonical_name(name, rename_groups) for name in lane_effects.may_writes
+    }
+    loop_carried_names = canonical_live_ins & canonical_lane_writes
+    allowed_recurrence_carries = {
+        info.state_name,
+        _canonical_name(info.dot_acc_var, rename_groups),
+    }
 
-    # Backward slice feeding the lane-invariant rescale ``base_stmt``: those
-    # producers are lane-invariant and hoist before the lane loop with it.
-    base_seed = set(ReadWrites.from_ast(base_stmt).reads)
-    hoist_indices, _ = _backward_slice(producers, base_seed)
-    hoist_set = set(hoist_indices)
+    def reject_unrelated_carries(index: int, moved_stmt: ast.AST) -> None:
+        dependencies = _dependency_names(
+            lane_body[:index], set(ReadWrites.from_ast(moved_stmt).reads)
+        )
+        dependencies.update(ReadWrites.from_ast(moved_stmt).writes)
+        if {_canonical_name(name, rename_groups) for name in dependencies} & (
+            loop_carried_names - allowed_recurrence_carries
+        ):
+            raise exc.BackendUnsupported(
+                "cute", "chunk recurrence cannot relocate another loop carry"
+            )
+
+    def guard_idempotent_store(
+        index: int,
+        store_stmt: ast.AST,
+        *,
+        thread_axes: dict[str, frozenset[int]] | None = None,
+        scalar_definitions: dict[str, ast.AST] | None = None,
+    ) -> None:
+        store = _validated_idempotent_store(store_stmt)
+        if store is None:
+            raise exc.BackendUnsupported(
+                "cute", "chunk recurrence can only relocate an ordinary store"
+            )
+        reject_unrelated_carries(index, store_stmt)
+        store_func = cast("ast.Attribute", store.func)
+        address_and_predicate_reads = set(ReadWrites.from_ast(store_func.value).reads)
+        for predicate in _store_enclosing_predicates(store_stmt, store):
+            address_and_predicate_reads.update(ReadWrites.from_ast(predicate).reads)
+        address_and_predicate_dependencies = _dependency_names(
+            lane_body[:index], address_and_predicate_reads
+        )
+        if {
+            _canonical_name(name, rename_groups)
+            for name in address_and_predicate_dependencies
+        } & allowed_recurrence_carries:
+            raise exc.BackendUnsupported(
+                "cute",
+                "chunk recurrence store address or predicate is not idempotent",
+            )
+        store_axes = _store_thread_axes(
+            store_stmt,
+            (
+                thread_axes
+                if thread_axes is not None
+                else thread_axes_before.get(id(store_stmt), {})
+            ),
+            (
+                scalar_definitions
+                if scalar_definitions is not None
+                else scalar_defs_before.get(id(store_stmt), {})
+            ),
+        )
+        if store_axes is None:
+            raise exc.BackendUnsupported(
+                "cute", "cannot infer chunk recurrence store ownership"
+            )
+        owner_exprs = _thread_axis_owner_exprs(reduction_axes, store_axes)
+        guarded_statements[index] = (
+            _guard_stmt_with_owner(store_stmt, owner_exprs)
+            if owner_exprs
+            else store_stmt
+        )
 
     # Lane-invariant side-effecting statements whose backward slice reaches the
     # (frozen) chunk-ENTRY accumulator (the store of ``b_h``) must hoist before
@@ -1773,41 +3777,223 @@ def _rewrite_chunk_recurrence(
     # producers along.  A store that does NOT read the accumulator stays in the
     # lane loop (it is a genuinely per-lane side effect).
     entry_indices: list[int] = []
-    for idx, prod in enumerate(producers):
-        if idx in hoist_set or reads_lane(prod) or not _has_side_effect(prod):
+    for idx, prod in enumerate(lane_body[: info.sum_idx]):
+        if idx in hoist_set or reads_lane(prod):
             continue
         slice_indices, _ = _backward_slice(
-            producers[:idx], set(ReadWrites.from_ast(prod).reads)
+            lane_body[:idx], set(ReadWrites.from_ast(prod).reads)
         )
+        slice_names = _dependency_names(
+            lane_body[:idx], set(ReadWrites.from_ast(prod).reads)
+        )
+        if not any(
+            _canonical_name(name, rename_groups) == info.state_name
+            for name in slice_names
+        ):
+            continue
+        store = _validated_idempotent_store(prod)
+        if store is None:
+            if not _is_proven_relocatable_assignment(prod, allow_load=True):
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "chunk recurrence state consumer has unknown side effects",
+                )
+            continue
+        # The store + its complete, lane-invariant, side-effect-free producer
+        # slice all hoist.  A live-in modified elsewhere in the lane would make
+        # the repeated stores observably different and is therefore not
+        # idempotent.
+        if any(
+            reads_lane(lane_body[i])
+            or not _is_proven_relocatable_assignment(lane_body[i], allow_load=False)
+            for i in slice_indices
+        ):
+            raise exc.BackendUnsupported(
+                "cute", "chunk recurrence store does not have a pure complete slice"
+            )
+        relocated_before_store = hoist_set | set(entry_indices) | set(slice_indices)
+        if any(
+            earlier_idx not in relocated_before_store
+            and not _is_proven_relocatable_assignment(
+                lane_body[earlier_idx], allow_load=False
+            )
+            for earlier_idx in range(idx)
+        ):
+            raise exc.BackendUnsupported(
+                "cute", "chunk recurrence cannot move a store across a prior effect"
+            )
+        entry_store_roots = _store_iterator_roots(store)
+        for later_idx in range(idx + 1, info.sum_idx):
+            if later_idx in relocated_before_store:
+                continue
+            later_stmt = lane_body[later_idx]
+            try:
+                later_store = _validated_idempotent_store(later_stmt)
+            except exc.BackendUnsupported as error:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "chunk recurrence cannot collapse a store before a later effect",
+                ) from error
+            if later_store is not None:
+                later_roots = _store_iterator_roots(later_store)
+                if (
+                    entry_store_roots
+                    and later_roots
+                    and later_roots.isdisjoint(entry_store_roots)
+                ):
+                    continue
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "chunk recurrence cannot collapse stores to the same allocation",
+                )
+            if not _is_proven_relocatable_assignment(
+                later_stmt,
+                allow_load=True,
+                allow_reduction=True,
+            ):
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "chunk recurrence cannot collapse a store before a later effect",
+                )
+        slice_writes = {
+            name
+            for slice_index in slice_indices
+            for name in ReadWrites.from_ast(lane_body[slice_index]).writes
+        }
         slice_reads = set(ReadWrites.from_ast(prod).reads)
-        for i in slice_indices:
-            slice_reads |= set(ReadWrites.from_ast(producers[i]).reads)
-        if not (acc_family & slice_reads):
-            continue
-        # The store + its lane-invariant producer slice all hoist.
-        if any(reads_lane(producers[i]) for i in slice_indices):
-            continue
+        for slice_index in slice_indices:
+            slice_reads.update(ReadWrites.from_ast(lane_body[slice_index]).reads)
+        if any(
+            name in all_lane_writes
+            and name not in slice_writes
+            and _canonical_name(name, rename_groups) != info.state_name
+            for name in slice_reads
+        ):
+            raise exc.BackendUnsupported(
+                "cute", "chunk recurrence store is not proven idempotent"
+            )
+        guard_idempotent_store(idx, prod)
         entry_indices.append(idx)
         hoist_set.update(slice_indices)
 
     hoist_pre = sorted(hoist_set | set(entry_indices))
-    pre_lane = [producers[i] for i in hoist_pre]
+    for idx in hoist_pre:
+        reject_unrelated_carries(idx, lane_body[idx])
+    pre_lane = [guarded_statements.get(i, lane_body[i]) for i in hoist_pre]
+
+    # Moving the state update out of the repeated lane requires moving its
+    # complete lexical suffix with it.  Otherwise a suffix consumer executes
+    # before the newly finalized state exists.  Relocate only lane-invariant,
+    # provably pure assignments and isolated idempotent stores; fail closed for
+    # atomics, synchronization, compound effects, or calls of unknown purity.
+    required_post_indices = {*info.finalize_indices, info.final_idx}
+    post_lane_indices = set(range(info.sum_idx + 1, len(lane_body)))
+    extra_post_indices = post_lane_indices - required_post_indices
+    extra_post_reads = {
+        name
+        for idx in extra_post_indices
+        for name in ReadWrites.from_ast(lane_body[idx]).reads
+    }
+    suffix_dependency_indices, _ = _backward_slice(
+        lane_body[: info.sum_idx + 1], extra_post_reads
+    )
+    for idx in suffix_dependency_indices:
+        if idx in hoist_set or idx == info.sum_idx:
+            continue
+        dependency = lane_body[idx]
+        if reads_lane(dependency) or not _is_proven_relocatable_assignment(
+            dependency, allow_load=False
+        ):
+            raise exc.BackendUnsupported(
+                "cute", "chunk recurrence suffix does not have a pure complete slice"
+            )
+    post_varying = set(lane_varying)
+    first_post = info.sum_idx + 1
+    effective_post_axes = dict(
+        thread_axes_before.get(id(lane_body[first_post]), {})
+        if first_post < len(lane_body)
+        else {}
+    )
+    effective_post_defs = dict(
+        scalar_defs_before.get(id(lane_body[first_post]), {})
+        if first_post < len(lane_body)
+        else {}
+    )
+    for idx in sorted(post_lane_indices):
+        post_stmt = lane_body[idx]
+        post_rw = ReadWrites.from_ast(post_stmt)
+        reject_unrelated_carries(idx, post_stmt)
+        if idx in required_post_indices:
+            # The detector proved these statements turn the lane fold into a
+            # lane-invariant final value.  Do not let their original dataflow
+            # taint later consumers that are relocated with them.
+            post_varying.difference_update(post_rw.writes)
+            _update_thread_axis_names(post_stmt, effective_post_axes)
+            _update_scalar_definitions(post_stmt, effective_post_defs)
+            if any(
+                _qualified_name(node.func) in _CHUNK_REDUCTION_HELPERS
+                or (
+                    (_qualified_name(node.func) or "").startswith(
+                        "cute.arch.warp_reduction"
+                    )
+                )
+                for node in ast.walk(post_stmt)
+                if isinstance(node, ast.Call)
+            ):
+                for name in post_rw.writes:
+                    effective_post_axes[name] = frozenset(
+                        set(effective_post_axes.get(name, ())) - reduction_axes
+                    )
+            continue
+        statement_is_lane_varying = lane_var in post_rw.reads or bool(
+            set(post_rw.reads) & post_varying
+        )
+        if statement_is_lane_varying or any(
+            _canonical_name(name, rename_groups) == info.state_name
+            for name in post_rw.writes
+        ):
+            raise exc.BackendUnsupported(
+                "cute", "chunk recurrence has a lane-varying state suffix"
+            )
+        store = _validated_idempotent_store(post_stmt)
+        if store is not None:
+            if idx < info.final_idx:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "chunk recurrence cannot relocate a store before the finalized state",
+                )
+            guard_idempotent_store(
+                idx,
+                post_stmt,
+                thread_axes=effective_post_axes,
+                scalar_definitions=effective_post_defs,
+            )
+        elif not _is_proven_relocatable_assignment(post_stmt, allow_load=False):
+            raise exc.BackendUnsupported(
+                "cute", "chunk recurrence suffix is not proven pure"
+            )
+        post_varying.difference_update(post_rw.writes)
+        _update_thread_axis_names(post_stmt, effective_post_axes)
+        _update_scalar_definitions(post_stmt, effective_post_defs)
+
     lane_kept = [
-        producers[i]
-        for i in range(len(producers))
-        if i not in hoist_set and i not in set(entry_indices)
+        lane_body[i]
+        for i in range(len(lane_body))
+        if i not in hoist_set
+        and i not in set(entry_indices)
+        and i not in post_lane_indices
     ]
 
-    new_lane_loop = _create_lane_loop(
-        lane_var, _lane_loop_extent(lane_loop), [*lane_kept, sum_stmt]
-    )
+    new_lane_loop = _clone_lane_loop_with_body(lane_loop, lane_kept)
+    post_lane = [
+        guarded_statements.get(i, lane_body[i]) for i in sorted(post_lane_indices)
+    ]
     new_chunk_body: list[ast.AST] = [
-        *chunk_body[:lane_idx],
         reset_stmt,
+        *chunk_body[:lane_idx],
         *pre_lane,
-        base_stmt,
         new_lane_loop,
-        final_stmt,
+        *post_lane,
         *chunk_body[lane_idx + 1 :],
     ]
     return create(
@@ -1942,6 +4128,11 @@ class VecLaneWrapper:
     vloop: ast.For
     vec_lane_var: str
     base_index_var: str
+    # Persistent reductions whose complete per-thread slice is one vector do
+    # not need a separate outer scalar-lane loop.  Keep ``outer_for`` as the
+    # mutable container used by the load/store hoist protocol, but splice its
+    # body directly into the enclosing scope when this flag is set.
+    elide_outer_loop: bool = False
 
 
 @dataclasses.dataclass
@@ -1951,6 +4142,10 @@ class DeviceGridState(DeviceLoopOrGridState):
     lane_setup_statements: list[ast.AST] = dataclasses.field(default_factory=list)
     outer_prefix: list[ast.AST] = dataclasses.field(default_factory=list)
     outer_suffix: list[ast.AST] = dataclasses.field(default_factory=list)
+    # Statement list that will receive ``wrap_body(...)``.  Definitions
+    # already emitted there dominate every synthetic lane wrapper; lists
+    # pushed after it are branch/loop bodies that the wrapper will enclose.
+    hoist_parent_statements: list[ast.AST] | None = None
     # lane_var -> pre-built vec partition (see VecLaneWrapper).  Only grid
     # lane loops whose block has ``cute_vector_widths[block] > 1`` (and a
     # divisible elements-per-thread) get an entry.
@@ -1961,7 +4156,12 @@ class DeviceGridState(DeviceLoopOrGridState):
     def has_lane_loops(self) -> bool:
         return bool(self.lane_loops)
 
-    def add_lane_loop(self, block_id: int, lane_var: str, extent: int) -> None:
+    def add_lane_loop(
+        self,
+        block_id: int,
+        lane_var: str,
+        extent: int,
+    ) -> None:
         self.lane_loops.append((lane_var, extent))
         self.lane_loop_blocks.add(block_id)
 
@@ -1995,8 +4195,62 @@ class DeviceGridState(DeviceLoopOrGridState):
                 kept_setup.append(stmt)
                 needed |= set(rw.reads)
         kept_setup.reverse()
-        wrapped: list[ast.AST] = [*kept_setup, *body]
+        # Place each setup at the shallowest lane scope that defines every
+        # lane/base variable it reads.  Historically all setup statements were
+        # placed in the innermost lane loop.  That is semantically correct for
+        # scalar loops, but strands an outer-axis index definition *inside* an
+        # inner persistent vec loop while that vec loop's hoisted load needs the
+        # index outside its constexpr V loop.  Explicit scope placement keeps
+        # outer tile coordinates available to nested reduction vec hoists and
+        # avoids redundantly recomputing them for every inner lane.
+        setup_by_lane: dict[str, list[ast.AST]] = {
+            lane_var: [] for lane_var, _extent in self.lane_loops
+        }
+        fallback_setup: list[ast.AST] = []
+        lane_scope_names: dict[str, set[str]] = {}
+        for lane_var, _extent in self.lane_loops:
+            names = {lane_var}
+            wrapper = self.vec_lane_wrappers.get(lane_var)
+            if wrapper is not None:
+                names.update((wrapper.vec_lane_var, wrapper.base_index_var))
+            lane_scope_names[lane_var] = names
+        setup_name_scopes: dict[str, int] = {}
+        for stmt in kept_setup:
+            rw = ReadWrites.from_ast(stmt)
+            reads = set(rw.reads)
+            matching_depths = [
+                depth
+                for depth, (lane_var, _extent) in enumerate(self.lane_loops)
+                if reads & lane_scope_names[lane_var]
+            ]
+            matching_depths.extend(
+                setup_name_scopes[name] for name in reads if name in setup_name_scopes
+            )
+            if matching_depths:
+                # A statement depending on multiple lane coordinates belongs
+                # to the deepest of those nested scopes.
+                depth = max(matching_depths)
+                lane_var = self.lane_loops[depth][0]
+                setup_by_lane[lane_var].append(stmt)
+                for name in rw.writes:
+                    setup_name_scopes[name] = depth
+            else:
+                # Preserve the old innermost placement for an unfamiliar
+                # setup form rather than speculatively widening its scope.
+                # Record that placement as well: a later setup statement that
+                # reads this value must remain at least as deep, even if it
+                # also reads an outer lane coordinate.
+                if self.lane_loops:
+                    depth = len(self.lane_loops) - 1
+                    setup_by_lane[self.lane_loops[depth][0]].append(stmt)
+                    for name in rw.writes:
+                        setup_name_scopes[name] = depth
+                else:
+                    fallback_setup.append(stmt)
+
+        wrapped: list[ast.AST] = [*fallback_setup, *body]
         for lane_var, extent in reversed(self.lane_loops):
+            wrapped = [*setup_by_lane[lane_var], *wrapped]
             wrapper = self.vec_lane_wrappers.get(lane_var)
             if wrapper is not None:
                 # The per-element index var reads ``base_index_var`` +
@@ -2007,7 +4261,11 @@ class DeviceGridState(DeviceLoopOrGridState):
                 ):
                     continue
                 wrapper.vloop.body = wrapped  # type: ignore[assignment]
-                wrapped = [wrapper.outer_for]
+                wrapped = (
+                    list(wrapper.outer_for.body)
+                    if wrapper.elide_outer_loop
+                    else [wrapper.outer_for]
+                )
                 continue
             if lane_var not in needed:
                 continue

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -995,6 +995,10 @@ class ConfigSpec:
         self.max_reduction_threads = backend.max_reduction_threads()
         self.max_reduction_loop = backend.max_reduction_loop()
         self.reduction_loop_force_threshold = self.max_reduction_threads
+        # Every reduction block, including static/non-rollable persistent
+        # dimensions that have no ReductionLoopSpec.  DeviceIR fills this
+        # before configs are normalized.
+        self.reduction_block_ids: set[int] = set()
         self.cute_indexed_reduction_block_ids: set[int] = set()
         self.user_defined_tunables = (
             {} if user_defined_tunables is None else dict(user_defined_tunables)
@@ -2408,6 +2412,29 @@ class ConfigSpec:
                 name, config.get(name, ()), flatten=flatten
             )
 
+        if self.backend_name == "cute":
+            # A persistent reduction with exactly one vector fragment per
+            # thread has only one physical assignment, so blocked/strided are
+            # identical.  Canonicalize the inactive choice to avoid duplicate
+            # autotuner candidates.  Looped reductions retain both layouts.
+            lane_layouts = config.get("cute_lane_layouts")
+            reduction_loops = cast(
+                "list[int | None]", config.get("reduction_loops", []) or []
+            )
+            if isinstance(lane_layouts, list):
+                canonical_layouts = list(lane_layouts)
+                for index, layout_spec in enumerate(self.cute_lane_layouts):
+                    block_id = layout_spec.block_id
+                    if (
+                        block_id in self.reduction_block_ids
+                        and self.reduction_loops.config_get(
+                            reduction_loops, block_id, None
+                        )
+                        is None
+                    ):
+                        canonical_layouts[index] = "blocked"
+                config["cute_lane_layouts"] = canonical_layouts
+
         # Clamp inner block sizes that are bounded by an outer block
         # (e.g. ``hl.tile(outer.begin, outer.end)``): at this point the
         # outer's concrete block size for this config is known, and the
@@ -2531,18 +2558,21 @@ class ConfigSpec:
             nt_list = cast("list[int]", config.get("num_threads", []) or [])
             bs_list = cast("list[int]", config.get("block_sizes", []) or [])
             # ``num_threads`` also carries per-rolled-rdim slots (the
-            # reduction's own thread count); only NON-reduction tile axes
-            # consume the budget the reduction competes for.  Tile slots
-            # are registered in ``block_sizes`` order, so pairing the i-th
-            # num_threads slot with block_sizes[i] stays valid for them.
-            reduction_block_ids = {spec.block_id for spec in self.reduction_loops}
+            # reduction's own thread count), plus static persistent-rdim slots
+            # that have no ``reduction_loops`` entry.  Only NON-reduction tile
+            # axes consume the budget the reduction competes for.  Resolve all
+            # values by block id because the two sequences need not share an
+            # order.
+            reduction_block_ids = self.reduction_block_ids | {
+                spec.block_id for spec in self.reduction_loops
+            }
             other_threads = 1
-            for i, nt_spec in enumerate(self.num_threads):
+            for nt_spec in self.num_threads:
                 if nt_spec.block_id in reduction_block_ids:
                     continue
-                nt = nt_list[i] if i < len(nt_list) else 0
+                nt = self.num_threads.config_get(nt_list, nt_spec.block_id, 0)
                 if not isinstance(nt, int) or nt <= 0:
-                    bs = bs_list[i] if i < len(bs_list) else 1
+                    bs = self.block_sizes.config_get(bs_list, nt_spec.block_id, 1)
                     nt = bs if isinstance(bs, int) and bs > 1 else 1
                 if nt > 1:
                     other_threads *= nt
@@ -4008,15 +4038,15 @@ _CUTE_REDUCTION_RELOAD_CHOICES: tuple[str, ...] = ("auto", "register", "gmem")
 
 
 class CuteReductionReloadSpec(_BlockIdItem):
-    """Where a multi-sweep rolled reduction keeps the values it re-reads.
+    """Where a multi-sweep reduction keeps the values it re-reads.
 
-    LayerNorm/RMSNorm-style kernels sweep the same input several times
-    (reduce, then consume).  ``"register"`` caches the first sweep's loads
-    in a per-thread register fragment (fastest when the per-thread slice
-    is small; spills to local memory when it is not).  ``"gmem"`` re-loads
-    from global memory on later sweeps (the row is usually still resident
-    in L2, and no registers are burned).  ``"auto"`` (default) keeps the
-    legacy size heuristic in ``fuse_two_pass_loads``.
+    Rolled or persistent LayerNorm/RMSNorm-style kernels sweep the same input
+    several times (reduce, then consume).  ``"register"`` caches the earliest
+    sweep's loads in a per-thread register fragment (fastest when the
+    per-thread slice is small; spills to local memory when it is not).
+    ``"gmem"`` re-loads from global memory on later sweeps (the row is usually
+    still resident in L2, and no registers are burned).  ``"auto"`` (default)
+    keeps the legacy size heuristic in ``fuse_two_pass_loads``.
     """
 
     def __init__(self, *, block_id: int) -> None:

--- a/test/test_barrier.py
+++ b/test/test_barrier.py
@@ -265,7 +265,10 @@ class TestBarrier(RefEagerTestBase, TestCase):
 
         fake_env = SimpleNamespace(
             block_sizes=[_FakeRDim()],
-            config_spec=SimpleNamespace(reduction_loops=[]),
+            config_spec=SimpleNamespace(
+                reduction_block_ids=set(),
+                reduction_loops=[],
+            ),
             backend_name="triton",
         )
 

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -6974,6 +6974,7 @@ class TestCuteBackend(TestCase):
             args,
             block_sizes=[1],
             reduction_loop=8192,
+            cute_reduction_reloads=["register"],
         )
         (x,) = args
         expected = x / x.sum(-1, keepdim=True)
@@ -6994,6 +6995,7 @@ class TestCuteBackend(TestCase):
             block_sizes=[1],
             reduction_loop=8192,
             cute_vector_widths=[4],
+            cute_reduction_reloads=["register"],
         )
         (x,) = args
         expected = (x.float() / x.float().sum(-1, keepdim=True)).to(x.dtype)

--- a/test/test_cute_factor_affine_reductions.py
+++ b/test/test_cute_factor_affine_reductions.py
@@ -1,0 +1,1220 @@
+"""Tests for fast-math affine sum-reduction factoring."""
+
+from __future__ import annotations
+
+import ast
+from typing import cast
+
+import torch
+
+from helion._compiler.ast_extension import ExtendedAST
+from helion._compiler.ast_extension import convert
+from helion._compiler.ast_read_writes import HELION_LANE_LOOP_VAR_ATTR
+from helion._compiler.cute.factor_affine_reductions import factor_affine_reductions
+from helion._compiler.cute.factor_affine_reductions import hoist_factored_reductions
+from helion._compiler.cute.factor_affine_reductions import (
+    hoist_packed_factored_reductions,
+)
+from helion._compiler.cute.factor_affine_reductions import pack_fp32_constexpr_loops
+from helion.language import _tracing_ops
+from helion.language import view_ops
+
+
+def _add_node(
+    graph: torch.fx.Graph,
+    target: object,
+    args: tuple[object, ...],
+    value: torch.Tensor,
+) -> torch.fx.Node:
+    # pyrefly: ignore [bad-argument-type]
+    node = graph.call_function(target, args)
+    node.meta["val"] = value
+    return node
+
+
+def _affine_sum_graph(
+    *, dtype: torch.dtype = torch.float32, mask_value: float | None = None
+) -> tuple[torch.fx.Graph, torch.fx.Node]:
+    graph = torch.fx.Graph()
+    base = graph.placeholder("base")
+    scalar = graph.placeholder("scalar")
+    direction = graph.placeholder("direction")
+    weight = graph.placeholder("weight")
+    base.meta["val"] = torch.empty(4, 8, dtype=dtype)
+    scalar.meta["val"] = torch.empty(4, dtype=dtype)
+    direction.meta["val"] = torch.empty(8, dtype=dtype)
+    weight.meta["val"] = torch.empty(8, dtype=dtype)
+
+    scalar_view = _add_node(
+        graph,
+        view_ops.subscript,
+        (scalar, [slice(None), None]),
+        torch.empty(4, 1, dtype=dtype),
+    )
+    direction_view = _add_node(
+        graph,
+        view_ops.subscript,
+        (direction, [None, slice(None)]),
+        torch.empty(1, 8, dtype=dtype),
+    )
+    affine = _add_node(
+        graph,
+        torch.ops.aten.mul.Tensor,
+        (scalar_view, direction_view),
+        torch.empty(4, 8, dtype=dtype),
+    )
+    update = _add_node(
+        graph,
+        torch.ops.aten.add.Tensor,
+        (base, affine),
+        torch.empty(4, 8, dtype=dtype),
+    )
+    weight_view = _add_node(
+        graph,
+        view_ops.subscript,
+        (weight, [None, slice(None)]),
+        torch.empty(1, 8, dtype=dtype),
+    )
+    product = _add_node(
+        graph,
+        torch.ops.aten.mul.Tensor,
+        (update, weight_view),
+        torch.empty(4, 8, dtype=dtype),
+    )
+    reduction_input = product
+    if mask_value is not None:
+        reduction_input = _add_node(
+            graph,
+            _tracing_ops._mask_to,
+            (product, mask_value),
+            torch.empty(4, 8, dtype=dtype),
+        )
+    reduction = _add_node(
+        graph,
+        torch.ops.aten.sum.dim_IntList,
+        (reduction_input, [-1]),
+        torch.empty(4, dtype=dtype),
+    )
+    graph.output(reduction)
+    return graph, reduction
+
+
+def test_factors_affine_sum_when_fast_math_is_enabled() -> None:
+    graph, original_reduction = _affine_sum_graph()
+
+    assert factor_affine_reductions(graph, fast_math=True) == 1
+
+    output = next(node for node in graph.nodes if node.op == "output")
+    factored = output.args[0]
+    assert isinstance(factored, torch.fx.Node)
+    assert factored.target is torch.ops.aten.add.Tensor
+    assert original_reduction not in graph.nodes
+    reductions = [
+        node
+        for node in graph.nodes
+        if node.op == "call_function" and node.target is torch.ops.aten.sum.dim_IntList
+    ]
+    assert len(reductions) == 3
+    assert all(tuple(node.meta["val"].shape) == (4,) for node in reductions)
+    assert any(node.name == "_helion_factored_base_sum" for node in reductions)
+    assert any(node.name == "_helion_factored_dot_sum" for node in reductions)
+
+
+def test_does_not_factor_without_fast_math() -> None:
+    graph, original_reduction = _affine_sum_graph()
+
+    assert factor_affine_reductions(graph, fast_math=False) == 0
+
+    assert original_reduction in graph.nodes
+
+
+def test_requires_direct_prelowering_sum_input() -> None:
+    graph, original_reduction = _affine_sum_graph(mask_value=0)
+
+    assert factor_affine_reductions(graph, fast_math=True) == 0
+
+    assert original_reduction in graph.nodes
+
+
+def test_requires_fp32_arithmetic() -> None:
+    graph, original_reduction = _affine_sum_graph(dtype=torch.float16)
+
+    assert factor_affine_reductions(graph, fast_math=True) == 0
+
+    assert original_reduction in graph.nodes
+
+
+def test_rejects_sum_dtype_override() -> None:
+    graph, original_reduction = _affine_sum_graph()
+    original_reduction.kwargs = {"dtype": torch.float64}
+    original_reduction.meta["val"] = torch.empty(4, dtype=torch.float64)
+
+    assert factor_affine_reductions(graph, fast_math=True) == 0
+
+    assert original_reduction in graph.nodes
+
+
+def test_scalar_sum_does_not_crash_dimension_normalization() -> None:
+    graph = torch.fx.Graph()
+    source = graph.placeholder("source")
+    source.meta["val"] = torch.empty((), dtype=torch.float32)
+    reduction = _add_node(
+        graph,
+        torch.ops.aten.sum.dim_IntList,
+        (source, [0]),
+        torch.empty((), dtype=torch.float32),
+    )
+    graph.output(reduction)
+
+    assert factor_affine_reductions(graph, fast_math=True) == 0
+
+
+def test_requires_direction_invariant_over_retained_dims() -> None:
+    graph, original_reduction = _affine_sum_graph()
+    affine = next(
+        node
+        for node in graph.nodes
+        if node.op == "call_function" and node.target is torch.ops.aten.add.Tensor
+    ).args[1]
+    assert isinstance(affine, torch.fx.Node)
+    direction_view = affine.args[1]
+    assert isinstance(direction_view, torch.fx.Node)
+    direction_view.args = (direction_view.args[0], [slice(None), slice(None)])
+
+    assert factor_affine_reductions(graph, fast_math=True) == 0
+
+    assert original_reduction in graph.nodes
+
+
+def _tagged_lane_loop(source: str) -> list[ast.stmt]:
+    body = ast.parse(source).body
+    loop = next(
+        node
+        for statement in body
+        for node in ast.walk(statement)
+        if isinstance(node, ast.For)
+    )
+    setattr(loop, HELION_LANE_LOOP_VAR_ATTR, "row_lane")
+    return body
+
+
+def test_hoists_factored_row_invariant_reduction() -> None:
+    body = _tagged_lane_loop(
+        """
+k_cache = cute.make_rmem_tensor(8, cutlass.Float32)
+q_cache = cute.make_rmem_tensor(8, cutlass.Float32)
+if valid:
+    for row_lane in range(16):
+        row = row_base + row_lane
+        dot_acc = cutlass.Float32(0)
+        for k_lane in cutlass.range_constexpr(8):
+            k = cutlass.Float32(k_cache[k_lane])
+            q = cutlass.Float32(q_cache[k_lane])
+            product = k * q
+            dot_acc = dot_acc + cutlass.Float32(product)
+        _helion_factored_dot_sum = cutlass.Float32(
+            cute.arch.warp_reduction_sum(dot_acc, threads_in_group=16)
+        )
+        output = base[row_lane] + scalar[row_lane] * _helion_factored_dot_sum
+"""
+    )
+
+    rewritten = hoist_factored_reductions(body, fast_math=True)
+    code = ast.unparse(ast.Module(body=rewritten, type_ignores=[]))
+
+    assert code.index("_factored_acc_0") < code.index("for row_lane in range(16)")
+    assert code.count("warp_reduction_sum") == 1
+    assert "k_cache[_factored_lane_0]" in code
+    assert "q_cache[_factored_lane_0]" in code
+    assert "scalar[row_lane] * _helion_factored_dot_sum" in code
+
+
+def test_does_not_hoist_row_dependent_reduction() -> None:
+    body = _tagged_lane_loop(
+        """
+for row_lane in range(16):
+    dot_acc = cutlass.Float32(0)
+    for k_lane in cutlass.range_constexpr(8):
+        product = k_cache[k_lane] * row_lane
+        dot_acc = dot_acc + cutlass.Float32(product)
+    _helion_factored_dot_sum = cutlass.Float32(
+        cute.arch.warp_reduction_sum(dot_acc, threads_in_group=16)
+    )
+    output = scalar[row_lane] * _helion_factored_dot_sum
+"""
+    )
+
+    code_before = ast.unparse(ast.Module(body=body, type_ignores=[]))
+    rewritten = hoist_factored_reductions(body, fast_math=True)
+    code_after = ast.unparse(ast.Module(body=rewritten, type_ignores=[]))
+
+    assert code_after == code_before
+
+
+def test_does_not_hoist_factored_reduction_without_fast_math() -> None:
+    body = _tagged_lane_loop(
+        """
+for row_lane in range(16):
+    dot_acc = cutlass.Float32(0)
+    for k_lane in cutlass.range_constexpr(8):
+        product = k_cache[k_lane] * q_cache[k_lane]
+        dot_acc = dot_acc + cutlass.Float32(product)
+    _helion_factored_dot_sum = cutlass.Float32(
+        cute.arch.warp_reduction_sum(dot_acc)
+    )
+    output = scalar[row_lane] * _helion_factored_dot_sum
+"""
+    )
+
+    code_before = ast.unparse(ast.Module(body=body, type_ignores=[]))
+    rewritten = hoist_factored_reductions(body, fast_math=False)
+    code_after = ast.unparse(ast.Module(body=rewritten, type_ignores=[]))
+
+    assert code_after == code_before
+
+
+def test_does_not_hoist_unmarked_invariant_reduction() -> None:
+    body = _tagged_lane_loop(
+        """
+for row_lane in range(16):
+    dot_acc = cutlass.Float32(0)
+    for k_lane in cutlass.range_constexpr(8):
+        product = k_cache[k_lane] * q_cache[k_lane]
+        dot_acc = dot_acc + cutlass.Float32(product)
+    ordinary_dot = cutlass.Float32(cute.arch.warp_reduction_sum(dot_acc))
+    output = scalar[row_lane] * ordinary_dot
+"""
+    )
+
+    code_before = ast.unparse(ast.Module(body=body, type_ignores=[]))
+    rewritten = hoist_factored_reductions(body, fast_math=True)
+    code_after = ast.unparse(ast.Module(body=rewritten, type_ignores=[]))
+
+    assert code_after == code_before
+
+
+def test_fuses_adjacent_reductions_with_same_lane_cache() -> None:
+    body = _tagged_lane_loop(
+        """
+cache = cute.make_rmem_tensor(8, cutlass.Float32)
+for row_lane in range(16):
+    first_acc = cutlass.Float32(0)
+    for k_lane in cutlass.range_constexpr(8):
+        value = state[row_lane, k_lane]
+        cache[k_lane] = value
+        common = value * 2.0
+        first_term = common * key[k_lane]
+        first_acc = first_acc + cutlass.Float32(first_term)
+    first = cutlass.Float32(cute.arch.warp_reduction_sum(first_acc))
+    second_acc = cutlass.Float32(0)
+    for other_lane in cutlass.range_constexpr(8):
+        value = cache[other_lane]
+        common = value * 2.0
+        second_term = common * query[other_lane]
+        second_acc = second_acc + cutlass.Float32(second_term)
+    _helion_factored_base_sum = cutlass.Float32(
+        cute.arch.warp_reduction_sum(second_acc)
+    )
+    output = first + _helion_factored_base_sum
+"""
+    )
+
+    rewritten = hoist_factored_reductions(body, fast_math=True)
+    code = ast.unparse(ast.Module(body=rewritten, type_ignores=[]))
+    row_loop = next(
+        node
+        for node in ast.walk(ast.Module(body=rewritten, type_ignores=[]))
+        if isinstance(node, ast.For)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "row_lane"
+    )
+
+    assert code.count("cutlass.range_constexpr(8)") == 1
+    assert "cache[k_lane] = value" in ast.unparse(row_loop)
+    assert "value = cache[k_lane]" not in ast.unparse(row_loop)
+    assert ast.unparse(row_loop).count("common = value * 2.0") == 1
+    assert ast.unparse(row_loop).index("first_acc = first_acc") < ast.unparse(
+        row_loop
+    ).index("second_acc = second_acc")
+
+
+def _assert_factored_ast_unchanged(source: str) -> None:
+    body = _tagged_lane_loop(source)
+    before = ast.unparse(ast.Module(body=body, type_ignores=[]))
+
+    rewritten = hoist_factored_reductions(body, fast_math=True)
+
+    assert ast.unparse(ast.Module(body=rewritten, type_ignores=[])) == before
+
+
+def test_rejected_fusion_does_not_mutate_second_lane_name() -> None:
+    _assert_factored_ast_unchanged(
+        """
+cache = cute.make_rmem_tensor(8, cutlass.Float32)
+for row_lane in range(16):
+    first_acc = cutlass.Float32(0)
+    for k_lane in cutlass.range_constexpr(8):
+        value = source[k_lane]
+        cache[k_lane] = value
+        first_acc = first_acc + cutlass.Float32(value)
+    first = cutlass.Float32(cute.arch.warp_reduction_sum(first_acc))
+    second_acc = cutlass.Float32(0)
+    for other_lane in cutlass.range_constexpr(8):
+        value = cache[other_lane + 1]
+        second_acc = second_acc + cutlass.Float32(value)
+    _helion_factored_base_sum = cutlass.Float32(
+        cute.arch.warp_reduction_sum(second_acc)
+    )
+"""
+    )
+
+
+def test_does_not_fuse_when_second_initializer_crosses_a_read() -> None:
+    _assert_factored_ast_unchanged(
+        """
+cache = cute.make_rmem_tensor(8, cutlass.Float32)
+second_acc = cutlass.Float32(7)
+for row_lane in range(16):
+    first_acc = cutlass.Float32(0)
+    for lane in cutlass.range_constexpr(8):
+        prior = second_acc
+        value = source[lane] + prior
+        cache[lane] = value
+        first_acc = first_acc + cutlass.Float32(value)
+    first = cutlass.Float32(cute.arch.warp_reduction_sum(first_acc))
+    second_acc = cutlass.Float32(0)
+    for lane in cutlass.range_constexpr(8):
+        value = cache[lane]
+        second_acc = second_acc + cutlass.Float32(value)
+    _helion_factored_base_sum = cutlass.Float32(
+        cute.arch.warp_reduction_sum(second_acc)
+    )
+"""
+    )
+
+
+def test_does_not_fuse_cross_loop_scalar_dataflow() -> None:
+    _assert_factored_ast_unchanged(
+        """
+cache = cute.make_rmem_tensor(8, cutlass.Float32)
+for row_lane in range(16):
+    first_acc = cutlass.Float32(0)
+    for lane in cutlass.range_constexpr(8):
+        shared = source[lane]
+        cache[lane] = shared
+        first_acc = first_acc + cutlass.Float32(shared)
+    first = cutlass.Float32(cute.arch.warp_reduction_sum(first_acc))
+    second_acc = cutlass.Float32(0)
+    for lane in cutlass.range_constexpr(8):
+        term = shared * weight[lane]
+        second_acc = second_acc + cutlass.Float32(term)
+    _helion_factored_base_sum = cutlass.Float32(
+        cute.arch.warp_reduction_sum(second_acc)
+    )
+"""
+    )
+
+
+def test_does_not_fuse_second_loop_across_first_reduction_dependency() -> None:
+    _assert_factored_ast_unchanged(
+        """
+cache = cute.make_rmem_tensor(8, cutlass.Float32)
+for row_lane in range(16):
+    first_acc = cutlass.Float32(0)
+    for lane in cutlass.range_constexpr(8):
+        value = source[lane]
+        cache[lane] = value
+        first_acc = first_acc + cutlass.Float32(value)
+    first = cutlass.Float32(cute.arch.warp_reduction_sum(first_acc))
+    second_acc = cutlass.Float32(0)
+    for lane in cutlass.range_constexpr(8):
+        term = cache[lane] * first
+        second_acc = second_acc + cutlass.Float32(term)
+    _helion_factored_base_sum = cutlass.Float32(
+        cute.arch.warp_reduction_sum(second_acc)
+    )
+"""
+    )
+
+
+def test_does_not_fuse_second_loop_overwriting_first_reduction() -> None:
+    _assert_factored_ast_unchanged(
+        """
+cache = cute.make_rmem_tensor(8, cutlass.Float32)
+for row_lane in range(16):
+    first_acc = cutlass.Float32(0)
+    for lane in cutlass.range_constexpr(8):
+        value = source[lane]
+        cache[lane] = value
+        first_acc = first_acc + cutlass.Float32(value)
+    first = cutlass.Float32(cute.arch.warp_reduction_sum(first_acc))
+    second_acc = cutlass.Float32(0)
+    for lane in cutlass.range_constexpr(8):
+        value = cache[lane]
+        first = replacement[lane]
+        second_acc = second_acc + cutlass.Float32(value)
+    _helion_factored_base_sum = cutlass.Float32(
+        cute.arch.warp_reduction_sum(second_acc)
+    )
+"""
+    )
+
+
+def test_does_not_fuse_cache_read_after_write_or_noninjective_stores() -> None:
+    for store_index in ("lane", "0"):
+        _assert_factored_ast_unchanged(
+            f"""
+cache = cute.make_rmem_tensor(8, cutlass.Float32)
+for row_lane in range(16):
+    first_acc = cutlass.Float32(0)
+    for lane in cutlass.range_constexpr(8):
+        value = cache[lane]
+        cache[{store_index}] = source[lane]
+        first_acc = first_acc + cutlass.Float32(value)
+    first = cutlass.Float32(cute.arch.warp_reduction_sum(first_acc))
+    second_acc = cutlass.Float32(0)
+    for lane in cutlass.range_constexpr(8):
+        value = cache[lane]
+        second_acc = second_acc + cutlass.Float32(value)
+    _helion_factored_base_sum = cutlass.Float32(
+        cute.arch.warp_reduction_sum(second_acc)
+    )
+"""
+        )
+
+
+def test_does_not_fuse_aliased_register_fragment() -> None:
+    _assert_factored_ast_unchanged(
+        """
+cache = cute.make_rmem_tensor(8, cutlass.Float32)
+alias = cache
+for row_lane in range(16):
+    first_acc = cutlass.Float32(0)
+    for lane in cutlass.range_constexpr(8):
+        value = source[lane]
+        cache[lane] = value
+        first_acc = first_acc + cutlass.Float32(value)
+    first = cutlass.Float32(cute.arch.warp_reduction_sum(first_acc))
+    second_acc = cutlass.Float32(0)
+    for lane in cutlass.range_constexpr(8):
+        value = alias[lane]
+        second_acc = second_acc + cutlass.Float32(value)
+    _helion_factored_base_sum = cutlass.Float32(
+        cute.arch.warp_reduction_sum(second_acc)
+    )
+"""
+    )
+
+
+def test_does_not_hoist_unused_effect_or_forward_dependency() -> None:
+    for prefix in ("junk = observe()", "a = q\n        q = q_cache[k_lane]"):
+        _assert_factored_ast_unchanged(
+            f"""
+k_cache = cute.make_rmem_tensor(8, cutlass.Float32)
+q_cache = cute.make_rmem_tensor(8, cutlass.Float32)
+for row_lane in range(16):
+    dot_acc = cutlass.Float32(0)
+    for k_lane in cutlass.range_constexpr(8):
+        {prefix}
+        k = k_cache[k_lane]
+        product = k * q
+        dot_acc = dot_acc + cutlass.Float32(product)
+    _helion_factored_dot_sum = cutlass.Float32(
+        cute.arch.warp_reduction_sum(dot_acc)
+    )
+    output = scalar[row_lane] * _helion_factored_dot_sum
+"""
+        )
+
+
+def test_does_not_hoist_dynamic_warp_width_or_escaping_accumulator() -> None:
+    for suffix in (
+        "output = dot_acc",
+        "output = scalar[row_lane] * _helion_factored_dot_sum",
+    ):
+        source = f"""
+k_cache = cute.make_rmem_tensor(8, cutlass.Float32)
+q_cache = cute.make_rmem_tensor(8, cutlass.Float32)
+for row_lane in range(16):
+    dot_acc = cutlass.Float32(0)
+    for k_lane in cutlass.range_constexpr(8):
+        product = k_cache[k_lane] * q_cache[k_lane]
+        dot_acc = dot_acc + cutlass.Float32(product)
+    _helion_factored_dot_sum = cutlass.Float32(
+        cute.arch.warp_reduction_sum(dot_acc, threads_in_group=row_lane)
+    )
+    {suffix}
+consume(dot_acc)
+"""
+        _assert_factored_ast_unchanged(source)
+
+
+def test_does_not_hoist_untracked_arch_load() -> None:
+    _assert_factored_ast_unchanged(
+        """
+for row_lane in range(16):
+    dot_acc = cutlass.Float32(0)
+    for k_lane in cutlass.range_constexpr(8):
+        value = cute.arch.load(pointer + k_lane, cutlass.Float32)
+        dot_acc = dot_acc + cutlass.Float32(value)
+    _helion_factored_dot_sum = cutlass.Float32(
+        cute.arch.warp_reduction_sum(dot_acc)
+    )
+    output = scalar[row_lane] * _helion_factored_dot_sum
+"""
+    )
+
+
+def _packed_code(
+    source: str,
+    *,
+    fast_math: bool = True,
+    target_device_capability: tuple[int, int] | None = (10, 0),
+    float_scalar_names: set[str] | frozenset[str] = frozenset(),
+) -> str:
+    body = ast.parse(source).body
+    rewritten = pack_fp32_constexpr_loops(
+        body,
+        fast_math=fast_math,
+        target_device_capability=target_device_capability,
+        float_scalar_names=float_scalar_names,
+    )
+    return ast.unparse(ast.Module(body=rewritten, type_ignores=[]))
+
+
+_PACKED_ROW_REDUCTION = """
+left = cute.make_rmem_tensor(8, cutlass.Float32)
+right = cute.make_rmem_tensor(8, cutlass.Float32)
+for row_lane in cutlass.range_constexpr(16):
+    row_value = row_base + row_lane
+    dot_lo = cutlass.Float32(0)
+    dot_hi = cutlass.Float32(0)
+    for pair_lane in cutlass.range_constexpr(4):
+        dead_index = pair_lane * 2
+        dead_value = dead_index + offset
+        left_lo = cutlass.Float32(left[pair_lane * 2])
+        left_hi = cutlass.Float32(left[pair_lane * 2 + 1])
+        right_lo = cutlass.Float32(right[pair_lane * 2])
+        right_hi = cutlass.Float32(right[pair_lane * 2 + 1])
+        dot_lo, dot_hi = cute.arch.fma_packed_f32x2(
+            (cutlass.Float32(left_lo), cutlass.Float32(left_hi)),
+            (cutlass.Float32(right_lo * scale), cutlass.Float32(right_hi * scale)),
+            (cutlass.Float32(dot_lo), cutlass.Float32(dot_hi)),
+        )
+    dot_lane = cutlass.Float32(dot_lo) + cutlass.Float32(dot_hi)
+    dot = cutlass.Float32(
+        cute.arch.warp_reduction_sum(dot_lane, threads_in_group=16)
+    )
+    output = row_value + dot
+"""
+
+
+def _hoisted_packed_code(
+    source: str = _PACKED_ROW_REDUCTION,
+    *,
+    fast_math: bool = True,
+    marked: bool = True,
+    rename_groups: dict[str, str] | None = None,
+    extended: bool = False,
+) -> tuple[str, list[ast.stmt]]:
+    parsed = ast.parse(source)
+    module = cast("ast.Module", convert(parsed)) if extended else parsed
+    row_loop = next(
+        node
+        for statement in module.body
+        for node in ast.walk(statement)
+        if isinstance(node, ast.For)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "row_lane"
+    )
+    if marked:
+        setattr(row_loop, HELION_LANE_LOOP_VAR_ATTR, "row_lane")
+    rewritten = hoist_packed_factored_reductions(
+        module.body,
+        fast_math=fast_math,
+        rename_groups=rename_groups,
+    )
+    return ast.unparse(ast.Module(body=rewritten, type_ignores=[])), rewritten
+
+
+def test_hoists_post_pack_row_invariant_reduction_dependency_slice() -> None:
+    code, rewritten = _hoisted_packed_code(extended=True)
+    row_loop = next(
+        statement
+        for statement in rewritten
+        if isinstance(statement, ast.For)
+        and isinstance(statement.target, ast.Name)
+        and statement.target.id == "row_lane"
+    )
+
+    assert code.index("dot_lo = cutlass.Float32(0)") < code.index(
+        "for row_lane in cutlass.range_constexpr(16)"
+    )
+    assert code.count("cute.arch.fma_packed_f32x2") == 1
+    assert "dead_index" not in code
+    assert "dead_value" not in code
+    assert "output = row_value + dot" in ast.unparse(row_loop)
+    assert getattr(row_loop, HELION_LANE_LOOP_VAR_ATTR) == "row_lane"
+    assert all(isinstance(statement, ExtendedAST) for statement in rewritten)
+
+
+def test_post_pack_reduction_hoist_accepts_profitable_two_row_loop() -> None:
+    for loop in ("cutlass.range_constexpr(2)", "range(2)"):
+        source = _PACKED_ROW_REDUCTION.replace("cutlass.range_constexpr(16)", loop)
+        code, _rewritten = _hoisted_packed_code(source)
+
+        assert code.index("dot_lo = cutlass.Float32(0)") < code.index(
+            f"for row_lane in {loop}"
+        )
+        assert code.count("cute.arch.fma_packed_f32x2") == 1
+
+
+def test_post_pack_reduction_hoist_requires_fast_math_mark_and_repetition() -> None:
+    for source, fast_math, marked in (
+        (_PACKED_ROW_REDUCTION, False, True),
+        (_PACKED_ROW_REDUCTION, True, False),
+        (
+            _PACKED_ROW_REDUCTION.replace("range_constexpr(16)", "range_constexpr(1)"),
+            True,
+            True,
+        ),
+    ):
+        original = ast.unparse(ast.parse(source))
+        code, _rewritten = _hoisted_packed_code(
+            source, fast_math=fast_math, marked=marked
+        )
+        assert code == original
+
+
+def test_post_pack_reduction_hoist_rejects_row_varying_input() -> None:
+    source = _PACKED_ROW_REDUCTION.replace(
+        "right_lo * scale", "right_lo * scale + row_lane"
+    )
+    original = ast.unparse(ast.parse(source))
+
+    code, _rewritten = _hoisted_packed_code(source)
+
+    assert code == original
+
+
+def test_post_pack_reduction_hoist_rejects_rebound_or_mutated_input() -> None:
+    for source in (
+        _PACKED_ROW_REDUCTION.replace(
+            "row_value = row_base + row_lane",
+            "row_value = row_base + row_lane\n    scale = row_lane",
+        ),
+        _PACKED_ROW_REDUCTION.replace(
+            "output = row_value + dot",
+            "left[0] = row_value\n    output = row_value + dot",
+        ),
+    ):
+        original = ast.unparse(ast.parse(source))
+        code, _rewritten = _hoisted_packed_code(source)
+        assert code == original
+
+
+def test_post_pack_reduction_hoist_requires_private_register_sources() -> None:
+    for source in (
+        _PACKED_ROW_REDUCTION.replace("left[pair_lane", "source[pair_lane"),
+        _PACKED_ROW_REDUCTION.replace(
+            "for row_lane in cutlass.range_constexpr(16):",
+            "left_alias = left\nfor row_lane in cutlass.range_constexpr(16):",
+        ).replace("left[pair_lane", "left_alias[pair_lane"),
+    ):
+        original = ast.unparse(ast.parse(source))
+        code, _rewritten = _hoisted_packed_code(source)
+        assert code == original
+
+
+def test_post_pack_reduction_hoist_preserves_dead_effect_and_escaping_value() -> None:
+    for source in (
+        _PACKED_ROW_REDUCTION.replace(
+            "dead_value = dead_index + offset", "dead_value = observe(dead_index)"
+        ),
+        _PACKED_ROW_REDUCTION.replace(
+            "dead_value = dead_index + offset", "dead_value = operator.pow(0, -1)"
+        ),
+        _PACKED_ROW_REDUCTION.replace(
+            "output = row_value + dot", "output = row_value + dot + dead_value"
+        ),
+    ):
+        original = ast.unparse(ast.parse(source))
+        code, _rewritten = _hoisted_packed_code(source)
+        assert code == original
+
+
+def test_post_pack_reduction_hoist_rejects_stale_result_and_local_rebind() -> None:
+    for source in (
+        _PACKED_ROW_REDUCTION.replace(
+            "row_value = row_base + row_lane",
+            "prior_dot = dot\n    row_value = row_base + row_lane",
+        ),
+        _PACKED_ROW_REDUCTION.replace(
+            "row_value = row_base + row_lane",
+            "del dot\n    row_value = row_base + row_lane",
+        ),
+        _PACKED_ROW_REDUCTION.replace(
+            "left_hi = cutlass.Float32(left[pair_lane * 2 + 1])",
+            "left_lo = cutlass.Float32(left[pair_lane * 2 + 1])",
+        ),
+    ):
+        original = ast.unparse(ast.parse(source))
+        code, _rewritten = _hoisted_packed_code(source)
+        assert code == original
+
+
+def test_post_pack_reduction_hoist_rejects_runtime_division_and_lane_alias() -> None:
+    division = _PACKED_ROW_REDUCTION.replace(
+        "left_lo = cutlass.Float32(left[pair_lane * 2])",
+        "left_lo = cutlass.Float32(left[pair_lane * 2]) / divisor",
+    )
+    for source, rename_groups in (
+        (division, None),
+        (_PACKED_ROW_REDUCTION, {"scale": "row_lane"}),
+    ):
+        original = ast.unparse(ast.parse(source))
+        code, _rewritten = _hoisted_packed_code(source, rename_groups=rename_groups)
+        assert code == original
+
+
+def test_post_pack_reduction_hoist_rejects_opaque_math_and_data_attribute() -> None:
+    opaque_math = _PACKED_ROW_REDUCTION.replace(
+        "right_lo * scale", "right_lo * cute.math.observe(scale)"
+    )
+    data_attribute = _PACKED_ROW_REDUCTION.replace(
+        "row_value = row_base + row_lane",
+        "holder.value = row_lane\n    row_value = row_base + row_lane",
+    ).replace("right_lo * scale", "right_lo * holder.value")
+    for source in (opaque_math, data_attribute):
+        original = ast.unparse(ast.parse(source))
+        code, _rewritten = _hoisted_packed_code(source)
+        assert code == original
+
+
+def test_post_pack_reduction_hoist_rejects_post_rename_name_collision() -> None:
+    original = ast.unparse(ast.parse(_PACKED_ROW_REDUCTION))
+
+    code, _rewritten = _hoisted_packed_code(rename_groups={"left_lo": "dead_index"})
+
+    assert code == original
+
+
+def test_post_pack_reduction_hoists_within_existing_control_flow() -> None:
+    source = "if enabled:\n" + "\n".join(
+        f"    {line}" if line else line for line in _PACKED_ROW_REDUCTION.splitlines()
+    )
+
+    code, _rewritten = _hoisted_packed_code(source)
+
+    assert code.index("if enabled:") < code.index("dot_lo = cutlass.Float32(0)")
+    assert code.index("dot_lo = cutlass.Float32(0)") < code.index(
+        "for row_lane in cutlass.range_constexpr(16)"
+    )
+
+
+def test_post_pack_reduction_uses_earliest_safe_version_branch_position() -> None:
+    declarations, row_loop = _PACKED_ROW_REDUCTION.strip().split(
+        "for row_lane in cutlass.range_constexpr(16):", 1
+    )
+    optimized = ("for row_lane in cutlass.range_constexpr(16):" + row_loop).replace(
+        "for row_lane in cutlass.range_constexpr(16):",
+        "scalar_preload = load_scalar()\n"
+        "cute.arch.cp_async_wait_group(2)\n"
+        "initial_values = load_initial_values()\n"
+        "for row_lane in cutlass.range_constexpr(16):",
+    )
+    source = (
+        declarations
+        + "if valid:\n"
+        + "\n".join(f"    {line}" if line else line for line in optimized.splitlines())
+        + "\nelse:\n"
+        + "\n".join(
+            f"    {line}" if line else line
+            for line in (
+                "for row_lane in cutlass.range_constexpr(16):" + row_loop
+            ).splitlines()
+        )
+        + "\n"
+    )
+    original = ast.parse(source)
+    original_branch = cast("ast.If", original.body[2])
+    original_fallback = ast.dump(
+        ast.Module(body=original_branch.orelse, type_ignores=[]),
+        include_attributes=False,
+    )
+
+    code, rewritten = _hoisted_packed_code(source)
+    version = cast("ast.If", rewritten[2])
+    optimized_code = ast.unparse(ast.Module(body=version.body, type_ignores=[]))
+
+    assert code.index("right = cute.make_rmem_tensor") < code.index(
+        "dot_lo = cutlass.Float32(0)"
+    )
+    assert optimized_code.index("dot_lo = cutlass.Float32(0)") < optimized_code.index(
+        "scalar_preload = load_scalar()"
+    )
+    assert optimized_code.index(
+        "scalar_preload = load_scalar()"
+    ) < optimized_code.index("cute.arch.cp_async_wait_group(2)")
+    assert optimized_code.count("cute.arch.fma_packed_f32x2") == 1
+    assert optimized_code.count("cute.arch.warp_reduction_sum") == 1
+    assert (
+        ast.dump(
+            ast.Module(body=version.orelse, type_ignores=[]), include_attributes=False
+        )
+        == original_fallback
+    )
+
+
+def test_post_pack_reduction_hoist_rejects_branch_local_escape() -> None:
+    declarations, row_loop = _PACKED_ROW_REDUCTION.strip().split(
+        "for row_lane in cutlass.range_constexpr(16):", 1
+    )
+    source = (
+        declarations
+        + "if valid:\n"
+        + "\n".join(
+            f"    {line}" if line else line
+            for line in (
+                "for row_lane in cutlass.range_constexpr(16):" + row_loop
+            ).splitlines()
+        )
+        + "\nelse:\n    fallback = exact_masked_path()\n"
+        + "consume(dead_value)\n"
+    )
+    original = ast.unparse(ast.parse(source))
+
+    code, _rewritten = _hoisted_packed_code(source)
+
+    assert code == original
+
+
+def test_post_pack_reduction_hoist_does_not_enter_exception_region() -> None:
+    source = (
+        "dot_lo = cutlass.Float32(9)\n"
+        "try:\n"
+        "    dangerous()\n"
+        + "\n".join(
+            f"    {line}" if line else line
+            for line in _PACKED_ROW_REDUCTION.splitlines()
+        )
+        + "\nexcept Exception:\n    consume(dot_lo)\n"
+    )
+    original = ast.unparse(ast.parse(source))
+
+    code, _rewritten = _hoisted_packed_code(source)
+
+    assert code == original
+
+
+_FP32_REDUCTION = """
+cache = cute.make_rmem_tensor(8, cutlass.BFloat16)
+acc = cutlass.Float32(0)
+for lane in cutlass.range_constexpr(8):
+    value = cutlass.Float32(cache[lane])
+    product = value * cutlass.Float32(weight[lane])
+    acc = acc + cutlass.Float32(product)
+result = cute.arch.warp_reduction_sum(acc)
+"""
+
+
+def test_packs_even_fp32_reduction_on_blackwell() -> None:
+    code = _packed_code(_FP32_REDUCTION)
+
+    assert "cutlass.range_constexpr(4)" in code
+    assert code.count("cute.arch.fma_packed_f32x2") == 1
+    assert "cache[_factored_pair_lane_0 * 2]" in code
+    assert "cache[_factored_pair_lane_0 * 2 + 1]" in code
+    assert "acc = cutlass.Float32(_acc_lo_0) + cutlass.Float32(_acc_hi_0)" in code
+
+
+def test_packs_fused_fp32_reductions_and_lane_local_store() -> None:
+    code = _packed_code(
+        """
+cache = cute.make_rmem_tensor(8, cutlass.BFloat16)
+first_acc = cutlass.Float32(0)
+second_acc = cutlass.Float32(0)
+for lane in cutlass.range_constexpr(8):
+    raw = source[lane]
+    cache[lane] = raw
+    value = cutlass.Float32(raw) * cutlass.Float32(decay[lane])
+    first_product = value * cutlass.Float32(lhs[lane])
+    first_acc = first_acc + cutlass.Float32(first_product)
+    second_product = value * cutlass.Float32(rhs[lane])
+    second_acc = second_acc + cutlass.Float32(second_product)
+first = cute.arch.warp_reduction_sum(first_acc)
+second = cute.arch.warp_reduction_sum(second_acc)
+"""
+    )
+
+    assert code.count("cute.arch.fma_packed_f32x2") == 2
+    assert "cache[_factored_pair_lane_0 * 2]" in code
+    assert "cache[_factored_pair_lane_0 * 2 + 1]" in code
+    assert "first_acc = cutlass.Float32(_first_acc_lo_0)" in code
+    assert "second_acc = cutlass.Float32(_second_acc_lo_0)" in code
+
+
+def test_packs_fp32_update_ending_in_append() -> None:
+    code = _packed_code(
+        """
+cache = cute.make_rmem_tensor(8, cutlass.BFloat16)
+values = []
+for lane in cutlass.range_constexpr(8):
+    state = cutlass.Float32(cache[lane]) * cutlass.Float32(decay[lane])
+    product = cutlass.Float32(query[lane]) * scale
+    update = state + product
+    values.append(cutlass.BFloat16(update))
+consume(values)
+""",
+        float_scalar_names={"scale"},
+    )
+
+    assert "cutlass.range_constexpr(4)" in code
+    assert "cute.arch.fma_packed_f32x2" in code
+    assert code.count("values.append") == 2
+    assert code.index(
+        "values.append(cutlass.BFloat16(_factored_update_lo_0))"
+    ) < code.index("values.append(cutlass.BFloat16(_factored_update_hi_0))")
+
+
+def test_packed_fp32_loop_requires_fast_math_and_blackwell() -> None:
+    original = ast.unparse(ast.parse(_FP32_REDUCTION))
+
+    assert _packed_code(_FP32_REDUCTION, fast_math=False) == original
+    assert _packed_code(_FP32_REDUCTION, target_device_capability=(9, 0)) == original
+    assert _packed_code(_FP32_REDUCTION, target_device_capability=None) == original
+
+
+def test_does_not_pack_odd_width_fp32_loop() -> None:
+    source = _FP32_REDUCTION.replace("range_constexpr(8)", "range_constexpr(7)")
+
+    assert _packed_code(source) == ast.unparse(ast.parse(source))
+
+
+def test_does_not_pack_loop_with_unknown_effect() -> None:
+    source = """
+cache = cute.make_rmem_tensor(8, cutlass.BFloat16)
+acc = cutlass.Float32(0)
+for lane in cutlass.range_constexpr(8):
+    value = cutlass.Float32(cache[lane])
+    observe(value)
+    acc = acc + value
+result = cute.arch.warp_reduction_sum(acc)
+"""
+
+    assert _packed_code(source) == ast.unparse(ast.parse(source))
+
+
+def test_does_not_pack_store_through_aliased_fragment() -> None:
+    source = """
+cache = cute.make_rmem_tensor(8, cutlass.BFloat16)
+alias = cache
+acc = cutlass.Float32(0)
+for lane in cutlass.range_constexpr(8):
+    value = cutlass.Float32(source[lane])
+    cache[lane] = value
+    acc = acc + value
+result = cute.arch.warp_reduction_sum(acc)
+"""
+
+    assert _packed_code(source) == ast.unparse(ast.parse(source))
+
+
+def test_does_not_pack_store_with_noninjective_lane_index() -> None:
+    source = """
+cache = cute.make_rmem_tensor(8, cutlass.Float32)
+acc = cutlass.Float32(0)
+for lane in cutlass.range_constexpr(8):
+    value = cutlass.Float32(source[lane])
+    cache[lane % 2] = value
+    acc = acc + value
+result = cute.arch.warp_reduction_sum(acc)
+"""
+
+    assert _packed_code(source) == ast.unparse(ast.parse(source))
+
+
+def test_does_not_pack_overlapping_affine_store_mappings() -> None:
+    source = """
+cache = cute.make_rmem_tensor(9, cutlass.Float32)
+first_acc = cutlass.Float32(0)
+second_acc = cutlass.Float32(0)
+for lane in cutlass.range_constexpr(8):
+    first = cutlass.Float32(source[lane])
+    second = cutlass.Float32(other[lane])
+    cache[lane] = first
+    cache[lane + 1] = second
+    first_acc = first_acc + first
+    second_acc = second_acc + second
+consume(first_acc, second_acc, cache)
+"""
+
+    assert _packed_code(source) == ast.unparse(ast.parse(source))
+
+
+def test_does_not_assume_loop_local_index_component_is_invariant() -> None:
+    source = """
+cache = cute.make_rmem_tensor(8, cutlass.Float32)
+acc = cutlass.Float32(0)
+for lane in cutlass.range_constexpr(8):
+    offset = -lane
+    value = cutlass.Float32(source[lane])
+    cache[lane + offset] = value
+    acc = acc + value
+result = cute.arch.warp_reduction_sum(acc)
+"""
+
+    assert _packed_code(source) == ast.unparse(ast.parse(source))
+
+
+def test_does_not_pack_cross_lane_fragment_dependency() -> None:
+    source = """
+cache = cute.make_rmem_tensor(8, cutlass.Float32)
+acc = cutlass.Float32(0)
+for lane in cutlass.range_constexpr(8):
+    cache[lane] = cutlass.Float32(source[lane])
+    value = cache[lane - 1]
+    acc = acc + value
+result = cute.arch.warp_reduction_sum(acc)
+"""
+
+    assert _packed_code(source) == ast.unparse(ast.parse(source))
+
+
+def test_does_not_pack_loop_local_value_used_after_loop() -> None:
+    source = """
+cache = cute.make_rmem_tensor(8, cutlass.Float32)
+acc = cutlass.Float32(0)
+for lane in cutlass.range_constexpr(8):
+    value = cache[lane]
+    acc = acc + value
+result = value + cute.arch.warp_reduction_sum(acc)
+"""
+
+    assert _packed_code(source) == ast.unparse(ast.parse(source))
+
+
+def test_does_not_pack_conditionally_overwritten_loop_local() -> None:
+    source = """
+cache = cute.make_rmem_tensor(8, cutlass.Float32)
+acc = cutlass.Float32(0)
+for lane in cutlass.range_constexpr(8):
+    value = cache[lane]
+    acc = acc + value
+if condition:
+    value = cutlass.Float32(0)
+consume(value, acc)
+"""
+
+    assert _packed_code(source) == ast.unparse(ast.parse(source))
+
+
+def test_does_not_pack_loop_local_escaping_enclosing_branch() -> None:
+    source = """
+cache = cute.make_rmem_tensor(8, cutlass.Float32)
+if condition:
+    acc = cutlass.Float32(0)
+    for lane in cutlass.range_constexpr(8):
+        value = cache[lane]
+        acc = acc + value
+else:
+    value = cutlass.Float32(0)
+consume(value)
+"""
+
+    assert _packed_code(source) == ast.unparse(ast.parse(source))
+
+
+def test_does_not_pack_loop_local_used_on_enclosing_loop_backedge() -> None:
+    source = """
+value = cutlass.Float32(7)
+for outer in range(4):
+    consume(value)
+    cache = cute.make_rmem_tensor(8, cutlass.Float32)
+    acc = cutlass.Float32(0)
+    for lane in cutlass.range_constexpr(8):
+        value = cache[lane]
+        acc = acc + value
+"""
+
+    assert _packed_code(source) == ast.unparse(ast.parse(source))
+
+
+def test_does_not_pack_mixed_fp32_float64_expression() -> None:
+    source = """
+left = cute.make_rmem_tensor(8, cutlass.Float32)
+right = cute.make_rmem_tensor(8, cutlass.Float64)
+acc = cutlass.Float32(0)
+for lane in cutlass.range_constexpr(8):
+    product = left[lane] * right[lane]
+    acc = acc + product
+consume(acc)
+"""
+
+    assert _packed_code(source) == ast.unparse(ast.parse(source))
+
+
+def test_does_not_pack_fp32_expression_with_int64_operand() -> None:
+    source = """
+cache = cute.make_rmem_tensor(8, cutlass.Float32)
+acc = cutlass.Float32(0)
+for lane in cutlass.range_constexpr(8):
+    wide = cutlass.Int64(source[lane])
+    product = cache[lane] * wide
+    acc = acc + cutlass.Float32(product)
+consume(acc)
+"""
+
+    packed = _packed_code(source)
+
+    assert "fma_packed_f32x2" not in packed
+    assert "mul_packed_f32x2" not in packed
+    assert packed.count("cutlass.Int64") == 2
+    assert "add_packed_f32x2" in packed
+
+
+def test_does_not_trust_rebound_float_scalar_fact() -> None:
+    source = """
+cache = cute.make_rmem_tensor(8, cutlass.Float32)
+scale, other = pair
+values = []
+for lane in cutlass.range_constexpr(8):
+    product = cache[lane] * scale
+    values.append(product)
+consume(values)
+"""
+
+    assert _packed_code(source, float_scalar_names={"scale"}) == ast.unparse(
+        ast.parse(source)
+    )
+
+
+def test_does_not_pack_append_with_nested_effect() -> None:
+    source = """
+cache = cute.make_rmem_tensor(8, cutlass.Float32)
+values = []
+for lane in cutlass.range_constexpr(8):
+    value = cache[lane] * scale
+    values.append(convert_and_record(value))
+consume(values)
+"""
+
+    assert _packed_code(source) == ast.unparse(ast.parse(source))
+
+
+def test_packed_fp32_loop_is_idempotent() -> None:
+    body = ast.parse(_FP32_REDUCTION).body
+    once = pack_fp32_constexpr_loops(
+        body,
+        fast_math=True,
+        target_device_capability=(10, 0),
+    )
+    once_code = ast.unparse(ast.Module(body=once, type_ignores=[]))
+
+    twice = pack_fp32_constexpr_loops(
+        once,
+        fast_math=True,
+        target_device_capability=(10, 0),
+    )
+
+    assert ast.unparse(ast.Module(body=twice, type_ignores=[])) == once_code

--- a/test/test_cute_fuse_two_pass_loads.py
+++ b/test/test_cute_fuse_two_pass_loads.py
@@ -17,10 +17,16 @@ Lives in ``helion/_compiler/cute/fuse_two_pass_loads.py``.
 
 from __future__ import annotations
 
+import ast
+
 import pytest
 import torch
 
 import helion
+from helion._compiler.cute.fuse_two_pass_loads import fuse_two_pass_loads
+from helion._compiler.cute.persistent_branch_vec import (
+    vectorize_branch_local_persistent_fragments,
+)
 from helion._testing import DEVICE
 from helion._testing import HALF_DTYPE
 from helion._testing import TestCase
@@ -30,6 +36,467 @@ import helion.language as hl
 
 cutlass = pytest.importorskip("cutlass")
 cute = pytest.importorskip("cutlass.cute")
+
+
+def _nested_persistent_sweeps() -> list[ast.stmt]:
+    """Three guarded persistent sweeps with one later-origin load."""
+    return ast.parse(
+        """
+if active:
+    for synthetic_lane_7 in range(8):
+        a0 = (x.iterator + slot + synthetic_lane_7).load()
+    for synthetic_lane_7 in range(8):
+        slot_copy_0 = slot
+        a1 = (x.iterator + slot_copy_0 + synthetic_lane_7).load()
+        b1 = (y.iterator + slot_copy_0 + synthetic_lane_7).load()
+    for synthetic_lane_7 in range(8):
+        slot_copy_1 = slot
+        a2 = (x.iterator + slot_copy_1 + synthetic_lane_7).load()
+        b2 = (y.iterator + slot_copy_1 + synthetic_lane_7).load()
+"""
+    ).body
+
+
+def test_nested_persistent_sweeps_register_reload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HELION_FUSER_MODE", raising=False)
+    result = fuse_two_pass_loads(
+        _nested_persistent_sweeps(),
+        tensor_dtypes={"x": "cutlass.Float32", "y": "cutlass.Float32"},
+        reload_modes={7: "register"},
+    )
+    code = ast.unparse(ast.Module(body=result, type_ignores=[]))
+
+    # Allocations stay at kernel scope rather than under the dynamic guard.
+    assert len(result) == 3
+    assert all(isinstance(stmt, ast.Assign) for stmt in result[:2])
+    assert isinstance(result[2], ast.If)
+    assert code.count("cute.make_rmem_tensor(8, cutlass.Float32)") == 2
+    # A is loaded only in sweep one.  B is first loaded in sweep two, cached
+    # there, and reused in sweep three despite the copy aliases.
+    assert code.count(".load()") == 2
+    assert "a2 = _fuse_cache_0" in code
+    assert "b2 = _fuse_cache_1" in code
+
+
+def test_nested_persistent_sweeps_gmem_reload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HELION_FUSER_MODE", raising=False)
+    result = fuse_two_pass_loads(
+        _nested_persistent_sweeps(),
+        tensor_dtypes={"x": "cutlass.Float32", "y": "cutlass.Float32"},
+        reload_modes={7: "gmem"},
+    )
+    code = ast.unparse(ast.Module(body=result, type_ignores=[]))
+
+    assert "_fuse_cache_" not in code
+    assert code.count(".load()") == 5
+
+
+@pytest.mark.parametrize("prove_x_y_disjoint", (False, True))
+def test_persistent_sweep_cache_invalidated_by_intervening_store(
+    monkeypatch: pytest.MonkeyPatch,
+    prove_x_y_disjoint: bool,
+) -> None:
+    monkeypatch.delenv("HELION_FUSER_MODE", raising=False)
+    body = ast.parse(
+        """
+if active:
+    for synthetic_lane_7 in range(8):
+        a0 = (x.iterator + synthetic_lane_7).load()
+        b0 = (y.iterator + synthetic_lane_7).load()
+    (x.iterator + slot).store(replacement)
+    for synthetic_lane_7 in range(8):
+        a1 = (x.iterator + synthetic_lane_7).load()
+        b1 = (y.iterator + synthetic_lane_7).load()
+    for synthetic_lane_7 in range(8):
+        a2 = (x.iterator + synthetic_lane_7).load()
+        b2 = (y.iterator + synthetic_lane_7).load()
+"""
+    ).body
+
+    result = fuse_two_pass_loads(
+        body,
+        tensor_dtypes={"x": "cutlass.Float32", "y": "cutlass.Float32"},
+        reload_modes={7: "register"},
+        proven_disjoint_tensor_pairs=(
+            {frozenset(("x", "y"))} if prove_x_y_disjoint else None
+        ),
+    )
+    code = ast.unparse(ast.Module(body=result, type_ignores=[]))
+
+    # The x store always invalidates x.  A distinct argument name is not an
+    # aliasing proof: y can cross the write only when the caller supplies a
+    # runtime-backed disjointness fact.
+    assert code.count("(x.iterator + synthetic_lane_7).load()") == 2
+    assert "a1 = (x.iterator + synthetic_lane_7).load()" in code
+    assert "a2 = _fuse_cache_" in code
+    expected_y_loads = 1 if prove_x_y_disjoint else 2
+    assert code.count("(y.iterator + synthetic_lane_7).load()") == expected_y_loads
+    if prove_x_y_disjoint:
+        assert "b1 = _fuse_cache_" in code
+    else:
+        assert "b1 = (y.iterator + synthetic_lane_7).load()" in code
+    assert "b2 = _fuse_cache_" in code
+
+
+def test_auto_reload_stops_at_disjoint_write_phase_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HELION_FUSER_MODE", raising=False)
+    body = ast.parse(
+        """
+for synthetic_lane_7 in range(8):
+    before = (x.iterator + synthetic_lane_7).load()
+(out.iterator + slot).store(replacement)
+for synthetic_lane_7 in range(8):
+    after = (x.iterator + synthetic_lane_7).load()
+"""
+    ).body
+
+    result = fuse_two_pass_loads(
+        body,
+        tensor_dtypes={"x": "cutlass.Float32", "out": "cutlass.Float32"},
+        reload_modes={7: "auto"},
+        proven_disjoint_tensor_pairs={frozenset(("x", "out"))},
+    )
+    code = ast.unparse(ast.Module(body=result, type_ignores=[]))
+
+    assert "_fuse_cache_" not in code
+    assert code.count("(x.iterator + synthetic_lane_7).load()") == 2
+
+
+@pytest.mark.parametrize(
+    "atomic",
+    (
+        "cute.arch.atomic_add(x.iterator + slot, replacement)",
+        "_cute_atomic_add(x.iterator + slot, replacement)",
+        "_cute_atomic_add(opaque_ptr, replacement)",
+    ),
+)
+def test_persistent_sweep_cache_invalidated_by_intervening_atomic(
+    monkeypatch: pytest.MonkeyPatch,
+    atomic: str,
+) -> None:
+    monkeypatch.delenv("HELION_FUSER_MODE", raising=False)
+    body = ast.parse(
+        f"""
+if active:
+    for synthetic_lane_7 in range(8):
+        before = (x.iterator + synthetic_lane_7).load()
+    {atomic}
+    for synthetic_lane_7 in range(8):
+        after = (x.iterator + synthetic_lane_7).load()
+"""
+    ).body
+
+    result = fuse_two_pass_loads(
+        body,
+        tensor_dtypes={"x": "cutlass.Float32"},
+        reload_modes={7: "register"},
+    )
+    code = ast.unparse(ast.Module(body=result, type_ignores=[]))
+
+    assert "_fuse_cache_" not in code
+    assert code.count("(x.iterator + synthetic_lane_7).load()") == 2
+
+
+@pytest.mark.parametrize(
+    ("reload_mode", "expected_loads", "expect_cache"),
+    (("auto", 2, False), ("register", 1, True)),
+)
+def test_branch_local_exact_fragment_vector_load_store(
+    monkeypatch: pytest.MonkeyPatch,
+    reload_mode: str,
+    expected_loads: int,
+    expect_cache: bool,
+) -> None:
+    monkeypatch.delenv("HELION_FUSER_MODE", raising=False)
+    body = ast.parse(
+        """
+if active:
+    for synthetic_lane_7 in cutlass.range_constexpr(8):
+        lane_index = lane_base + cutlass.Int32(synthetic_lane_7)
+        before = _helion_persistent_branch_vec_load(7, 8, 'cutlass.BFloat16', '', x.iterator + cutlass.Int32(slot) * cutlass.Int32(x.layout.stride[0]) + cutlass.Int32(lane_index) * cutlass.Int32(x.layout.stride[1]), (x.iterator + cutlass.Int32(slot) * cutlass.Int32(x.layout.stride[0]) + cutlass.Int32(lane_index) * cutlass.Int32(x.layout.stride[1])).load() if active_index and lane_index < 128 else cutlass.BFloat16(0))
+    (out.iterator + slot).store(result)
+    for synthetic_lane_7 in cutlass.range_constexpr(8):
+        slot_copy = slot
+        lane_index_copy = lane_base + cutlass.Int32(synthetic_lane_7)
+        after = _helion_persistent_branch_vec_load(7, 8, 'cutlass.BFloat16', '', x.iterator + cutlass.Int32(slot_copy) * cutlass.Int32(x.layout.stride[0]) + cutlass.Int32(lane_index_copy) * cutlass.Int32(x.layout.stride[1]), (x.iterator + cutlass.Int32(slot_copy) * cutlass.Int32(x.layout.stride[0]) + cutlass.Int32(lane_index_copy) * cutlass.Int32(x.layout.stride[1])).load() if active_index and lane_index_copy < 128 else cutlass.BFloat16(0))
+        updated = after + delta
+        _helion_persistent_branch_vec_store(7, 8, 'cutlass.BFloat16', x.iterator + cutlass.Int32(slot_copy) * cutlass.Int32(x.layout.stride[0]) + cutlass.Int32(lane_index_copy) * cutlass.Int32(x.layout.stride[1]), cutlass.BFloat16(updated), active_index and lane_index_copy < 128)
+"""
+    ).body
+    fused = fuse_two_pass_loads(
+        body,
+        tensor_dtypes={
+            "x": "cutlass.BFloat16",
+            "out": "cutlass.BFloat16",
+        },
+        reload_modes={7: reload_mode},
+        proven_disjoint_tensor_pairs={frozenset(("x", "out"))},
+    )
+    result = vectorize_branch_local_persistent_fragments(fused)
+    code = ast.unparse(ast.Module(body=result, type_ignores=[]))
+
+    # The producer sweep snapshots all lanes before the consumer writes any of
+    # them. The exact-fragment marker proves that consumer iteration i cannot
+    # affect iteration j, so the final read reuses that register snapshot.
+    assert code.count("cute.arch.load(x.iterator") == expected_loads
+    assert ("cute.make_rmem_tensor(8, cutlass.BFloat16)" in code) is expect_cache
+    assert ("after = _fuse_cache_0" in code) is expect_cache
+    assert "_cute_store_u16_vec(x.iterator" in code
+    assert ").store(cutlass.BFloat16(updated))" not in code
+    assert "if active_index and" in code
+    assert "_helion_persistent_branch_vec_" not in code
+
+
+@pytest.mark.parametrize(
+    "consumer",
+    (
+        (
+            "_helion_persistent_branch_vec_store(7, 8, 'cutlass.BFloat16', "
+            "x.iterator + lane_index + 1, updated, None)"
+        ),
+        "cute.arch.atomic_add(x.iterator + lane_index, updated)",
+    ),
+    ids=("shifted-store", "atomic"),
+)
+def test_inplace_snapshot_fusion_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    consumer: str,
+) -> None:
+    monkeypatch.delenv("HELION_FUSER_MODE", raising=False)
+    body = ast.parse(
+        f"""
+for synthetic_lane_7 in cutlass.range_constexpr(8):
+    lane_index = lane_base + cutlass.Int32(synthetic_lane_7)
+    before = _helion_persistent_branch_vec_load(7, 8, 'cutlass.BFloat16', '', x.iterator + lane_index, (x.iterator + lane_index).load())
+for synthetic_lane_7 in cutlass.range_constexpr(8):
+    lane_index = lane_base + cutlass.Int32(synthetic_lane_7)
+    after = _helion_persistent_branch_vec_load(7, 8, 'cutlass.BFloat16', '', x.iterator + lane_index, (x.iterator + lane_index).load())
+    updated = after + delta
+    {consumer}
+"""
+    ).body
+
+    result = fuse_two_pass_loads(
+        body,
+        tensor_dtypes={"x": "cutlass.BFloat16"},
+        reload_modes={7: "register"},
+    )
+    code = ast.unparse(ast.Module(body=result, type_ignores=[]))
+
+    assert code.count("_helion_persistent_branch_vec_load") == 2
+    assert "_fuse_cache_" not in code
+
+
+def test_inplace_snapshot_fusion_rejects_store_before_load(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HELION_FUSER_MODE", raising=False)
+    body = ast.parse(
+        """
+for synthetic_lane_7 in cutlass.range_constexpr(8):
+    lane_index = lane_base + cutlass.Int32(synthetic_lane_7)
+    before = _helion_persistent_branch_vec_load(7, 8, 'cutlass.BFloat16', '', x.iterator + lane_index, (x.iterator + lane_index).load())
+for synthetic_lane_7 in cutlass.range_constexpr(8):
+    lane_index = lane_base + cutlass.Int32(synthetic_lane_7)
+    _helion_persistent_branch_vec_store(7, 8, 'cutlass.BFloat16', x.iterator + lane_index, replacement, None)
+    after = _helion_persistent_branch_vec_load(7, 8, 'cutlass.BFloat16', '', x.iterator + lane_index, (x.iterator + lane_index).load())
+"""
+    ).body
+
+    result = fuse_two_pass_loads(
+        body,
+        tensor_dtypes={"x": "cutlass.BFloat16"},
+        reload_modes={7: "register"},
+    )
+    code = ast.unparse(ast.Module(body=result, type_ignores=[]))
+
+    assert code.count("_helion_persistent_branch_vec_load") == 2
+    assert "_fuse_cache_" not in code
+
+
+def test_branch_local_shifted_exact_markers_stay_scalar() -> None:
+    body = ast.parse(
+        """
+for synthetic_lane_7 in cutlass.range_constexpr(8):
+    lane_index = lane_base + cutlass.Int32(synthetic_lane_7)
+    before = _helion_persistent_branch_vec_load(7, 8, 'cutlass.BFloat16', '', x.iterator + lane_index, (x.iterator + lane_index).load())
+    updated = before + 1
+    _helion_persistent_branch_vec_store(7, 8, 'cutlass.BFloat16', x.iterator + lane_index + 1, cutlass.BFloat16(updated), None)
+"""
+    ).body
+    result = vectorize_branch_local_persistent_fragments(body)
+    code = ast.unparse(ast.Module(body=result, type_ignores=[]))
+
+    assert "cute.arch.load(x.iterator" not in code
+    assert "(x.iterator + lane_index).load()" in code
+    assert "_cute_store_u16_vec(x.iterator" not in code
+    assert "(x.iterator + lane_index + 1).store" in code
+    assert "_helion_persistent_branch_vec_" not in code
+
+
+@pytest.mark.parametrize("write_kind", ("store", "atomic"))
+@pytest.mark.parametrize("prove_x_y_disjoint", (False, True))
+def test_branch_local_vector_load_treats_later_write_as_backedge_barrier(
+    write_kind: str,
+    prove_x_y_disjoint: bool,
+) -> None:
+    write = (
+        "(y.iterator + lane_index + 1).store(replacement)"
+        if write_kind == "store"
+        else "cute.arch.atomic_add(y.iterator + lane_index + 1, replacement)"
+    )
+    body = ast.parse(
+        f"""
+for synthetic_lane_7 in cutlass.range_constexpr(8):
+    lane_index = lane_base + cutlass.Int32(synthetic_lane_7)
+    value = _helion_persistent_branch_vec_load(7, 8, 'cutlass.BFloat16', '', x.iterator + lane_index, (x.iterator + lane_index).load())
+    {write}
+"""
+    ).body
+    result = vectorize_branch_local_persistent_fragments(
+        body,
+        proven_disjoint_tensor_pairs=(
+            {frozenset(("x", "y"))} if prove_x_y_disjoint else None
+        ),
+    )
+    code = ast.unparse(ast.Module(body=result, type_ignores=[]))
+
+    assert code.count("cute.arch.load(x.iterator") == (1 if prove_x_y_disjoint else 0)
+    assert code.count("(x.iterator + lane_index).load()") == (
+        0 if prove_x_y_disjoint else 1
+    )
+    assert "_helion_persistent_branch_vec_" not in code
+
+
+@pytest.mark.parametrize("prove_x_y_disjoint", (False, True))
+def test_branch_local_vector_store_treats_earlier_load_as_backedge_barrier(
+    prove_x_y_disjoint: bool,
+) -> None:
+    body = ast.parse(
+        """
+for synthetic_lane_7 in cutlass.range_constexpr(8):
+    lane_index = lane_base + cutlass.Int32(synthetic_lane_7)
+    observed = (x.iterator + lane_index - 1).load() if synthetic_lane_7 > 0 else cutlass.BFloat16(0)
+    replacement = observed + 1
+    _helion_persistent_branch_vec_store(7, 8, 'cutlass.BFloat16', y.iterator + lane_index, cutlass.BFloat16(replacement), None)
+"""
+    ).body
+    result = vectorize_branch_local_persistent_fragments(
+        body,
+        proven_disjoint_tensor_pairs=(
+            {frozenset(("x", "y"))} if prove_x_y_disjoint else None
+        ),
+    )
+    code = ast.unparse(ast.Module(body=result, type_ignores=[]))
+
+    assert ("_cute_store_u16_vec(y.iterator" in code) is prove_x_y_disjoint
+    assert (").store(cutlass.BFloat16(replacement))" in code) is not prove_x_y_disjoint
+    assert "_helion_persistent_branch_vec_" not in code
+
+
+@pytest.mark.parametrize("write_kind", ("store", "atomic"))
+@pytest.mark.parametrize("prove_x_y_disjoint", (False, True))
+def test_branch_local_vector_store_treats_other_write_as_backedge_barrier(
+    write_kind: str,
+    prove_x_y_disjoint: bool,
+) -> None:
+    other_write = (
+        "(x.iterator + lane_index + 1).store(replacement)"
+        if write_kind == "store"
+        else "cute.arch.atomic_add(x.iterator + lane_index + 1, replacement)"
+    )
+    body = ast.parse(
+        f"""
+for synthetic_lane_7 in cutlass.range_constexpr(8):
+    lane_index = lane_base + cutlass.Int32(synthetic_lane_7)
+    replacement = cutlass.BFloat16(synthetic_lane_7)
+    _helion_persistent_branch_vec_store(7, 8, 'cutlass.BFloat16', y.iterator + lane_index, replacement, None)
+    {other_write}
+"""
+    ).body
+    result = vectorize_branch_local_persistent_fragments(
+        body,
+        proven_disjoint_tensor_pairs=(
+            {frozenset(("x", "y"))} if prove_x_y_disjoint else None
+        ),
+    )
+    code = ast.unparse(ast.Module(body=result, type_ignores=[]))
+
+    assert ("_cute_store_u16_vec(y.iterator" in code) is prove_x_y_disjoint
+    assert (
+        "(y.iterator + lane_index).store(replacement)" in code
+    ) is not prove_x_y_disjoint
+    assert "_helion_persistent_branch_vec_" not in code
+
+
+def test_non_copy_rename_is_not_address_equivalence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HELION_FUSER_MODE", raising=False)
+    body = ast.parse(
+        """
+for synthetic_lane_7 in range(8):
+    before = (x.iterator + index + synthetic_lane_7).load()
+for synthetic_lane_7 in range(8):
+    index_1 = index + 1
+    after = (x.iterator + index_1 + synthetic_lane_7).load()
+"""
+    ).body
+    result = fuse_two_pass_loads(
+        body,
+        tensor_dtypes={"x": "cutlass.Float32"},
+        reload_modes={7: "register"},
+    )
+    code = ast.unparse(ast.Module(body=result, type_ignores=[]))
+
+    assert "_fuse_cache_" not in code
+    assert code.count(".load()") == 2
+
+
+@pytest.mark.parametrize("prove_x_y_disjoint", (False, True))
+@pytest.mark.parametrize("write_kind", ("store", "atomic"))
+def test_consumer_loop_write_is_a_backedge_barrier(
+    monkeypatch: pytest.MonkeyPatch,
+    prove_x_y_disjoint: bool,
+    write_kind: str,
+) -> None:
+    monkeypatch.delenv("HELION_FUSER_MODE", raising=False)
+    write = (
+        "(y.iterator + synthetic_lane_7).store(after)"
+        if write_kind == "store"
+        else "cute.arch.atomic_add(y.iterator + synthetic_lane_7, after)"
+    )
+    body = ast.parse(
+        f"""
+for synthetic_lane_7 in range(8):
+    before = (x.iterator + synthetic_lane_7).load()
+for synthetic_lane_7 in range(8):
+    after = (x.iterator + synthetic_lane_7).load()
+    {write}
+"""
+    ).body
+    result = fuse_two_pass_loads(
+        body,
+        tensor_dtypes={"x": "cutlass.Float32", "y": "cutlass.Float32"},
+        reload_modes={7: "register"},
+        proven_disjoint_tensor_pairs=(
+            {frozenset(("x", "y"))} if prove_x_y_disjoint else None
+        ),
+    )
+    code = ast.unparse(ast.Module(body=result, type_ignores=[]))
+
+    # The consumer's store executes before its next loop iteration.  Reusing
+    # the producer cache is therefore legal only with an explicit x/y
+    # disjointness proof.
+    assert code.count("(x.iterator + synthetic_lane_7).load()") == (
+        1 if prove_x_y_disjoint else 2
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/test/test_cute_hoist_lane_invariant_reductions.py
+++ b/test/test_cute_hoist_lane_invariant_reductions.py
@@ -1,0 +1,1253 @@
+"""Static safety tests for profitable grid-lane invariant reduction hoisting."""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from typing import cast
+
+from helion._compiler.ast_extension import ExtendedAST
+from helion._compiler.ast_extension import convert
+from helion._compiler.ast_read_writes import HELION_LANE_LOOP_VAR_ATTR
+from helion._compiler.ast_read_writes import ast_rename
+from helion._compiler.cute.hoist_lane_invariant_reductions import (
+    hoist_lane_invariant_reductions,
+)
+
+_TENSORS = {"bias", "gate", "head", "indices", "key", "out", "state"}
+_TENSOR_DTYPES = {
+    "bias": "cutlass.Float32",
+    "gate": "cutlass.BFloat16",
+    "head": "cutlass.Float32",
+    "indices": "cutlass.Int32",
+    "key": "cutlass.BFloat16",
+    "out": "cutlass.Float32",
+    "state": "cutlass.BFloat16",
+}
+_DISJOINT = {
+    frozenset((left, right)) for left in _TENSORS for right in _TENSORS if left != right
+}
+
+
+def _lane_loop(source: str) -> list[ast.stmt]:
+    body = ast.parse(source).body
+    assert len(body) == 1 and isinstance(body[0], ast.For)
+    setattr(body[0], HELION_LANE_LOOP_VAR_ATTR, "row_lane")
+    return body
+
+
+def _rewrite(
+    source: str,
+    *,
+    disjoint: set[frozenset[str]] = _DISJOINT,
+    rename_groups: dict[str, str] | None = None,
+    thread_block_dims: tuple[int, int, int] | None = None,
+) -> list[ast.stmt]:
+    return hoist_lane_invariant_reductions(
+        _lane_loop(source),
+        tensor_names=_TENSORS,
+        tensor_dtypes=_TENSOR_DTYPES,
+        proven_disjoint_tensor_pairs=disjoint,
+        rename_groups=rename_groups,
+        thread_block_dims=thread_block_dims,
+        uniform_names={
+            "base",
+            "batch",
+            "cond",
+            "external",
+            "other",
+            "row_base",
+            "seed",
+            "seed_1",
+            "seed_2",
+            "vector_type",
+        },
+    )
+
+
+def _rewrite_body(
+    source: str,
+    *,
+    disjoint: set[frozenset[str]] = _DISJOINT,
+    rename_groups: dict[str, str] | None = None,
+    tensor_dtypes: dict[str, str] = _TENSOR_DTYPES,
+    extended: bool = False,
+) -> list[ast.stmt]:
+    parsed = ast.parse(source)
+    module = cast("ast.Module", convert(parsed)) if extended else parsed
+    body = module.body
+    lane_loops = [
+        node
+        for stmt in body
+        for node in ast.walk(stmt)
+        if isinstance(node, ast.For)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "row_lane"
+    ]
+    assert len(lane_loops) == 1
+    setattr(lane_loops[0], HELION_LANE_LOOP_VAR_ATTR, "row_lane")
+    return hoist_lane_invariant_reductions(
+        body,
+        tensor_names=set(tensor_dtypes),
+        tensor_dtypes=tensor_dtypes,
+        proven_disjoint_tensor_pairs=disjoint,
+        rename_groups=rename_groups,
+        uniform_names={"base", "scale"},
+        float_scalar_names={"scale"},
+        thread_block_dims=(16, 8, 1),
+    )
+
+
+def _source(body: list[ast.stmt]) -> str:
+    return ast.unparse(ast.Module(body=body, type_ignores=[]))
+
+
+_POSITIVE = """
+for row_lane in range(16):
+    row = row_base + row_lane
+    state_index_load = (indices.iterator + batch).load()
+    state_index = cutlass.Int32(state_index_load)
+    invalid = operator.lt(state_index, 0)
+    if invalid:
+        (out.iterator + row).store(0)
+    else:
+        acc = cutlass.Float32(0)
+        vec = cute.arch.load(key.iterator + base, vector_type)
+        for k_lane in cutlass.range_constexpr(8):
+            value = cutlass.Float32(vec[k_lane])
+            acc = acc + value * value
+        norm = cutlass.Float32(
+            cute.arch.warp_reduction_sum(acc, threads_in_group=16)
+        )
+        state_value = (state.iterator + row).load()
+        (out.iterator + row).store(norm + state_value)
+"""
+
+
+def test_wide_lane_loop_unswitches_and_hoists_invariant_reduction() -> None:
+    result = _rewrite(_POSITIVE)
+    assert len(result) == 4
+    assert isinstance(result[-1], ast.If)
+    lifted = result[-1]
+    assert len(lifted.orelse) == 5
+    assert isinstance(lifted.orelse[-1], ast.For)
+
+    code = _source(result)
+    assert code.count("warp_reduction_sum") == 1
+    assert code.index("norm =") < code.rindex("for row_lane in range(16)")
+    assert code.index("state_index_load =") < code.index("if invalid:")
+    assert code.index("state_value =") > code.rindex("for row_lane in range(16)")
+
+
+def test_output_lane_owner_does_not_block_uniform_unswitch() -> None:
+    source = _POSITIVE.replace(
+        "        (out.iterator + row).store(norm + state_value)",
+        "        if cute.arch.lane_idx() % 16 == 0:\n"
+        "            (out.iterator + row).store(norm + state_value)",
+    )
+
+    code = _source(_rewrite(source))
+
+    assert code.count("warp_reduction_sum") == 1
+    assert code.index("norm =") < code.rindex("for row_lane in range(16)")
+    assert "if cute.arch.lane_idx() % 16 == 0:" in code
+
+
+def test_full_lane_bound_is_removed_before_reduction_hoist() -> None:
+    source = _POSITIVE.replace(
+        "vec = cute.arch.load(key.iterator + base, vector_type)",
+        "vec = (cute.arch.load(key.iterator + base, vector_type)\n"
+        "               if cutlass.Int32(cute.arch.thread_idx()[1]) * 16\n"
+        "               + cutlass.Int32(row_lane) < 128\n"
+        "               else cutlass.Float32(0))",
+    )
+    code = _source(_rewrite(source, thread_block_dims=(16, 8, 1)))
+
+    assert code.index("norm =") < code.rindex("for row_lane in range(16)")
+    assert "thread_idx()[1]" not in code[: code.rindex("for row_lane in range(16)")]
+
+
+def test_partial_lane_bound_is_not_removed() -> None:
+    source = _POSITIVE.replace(
+        "vec = cute.arch.load(key.iterator + base, vector_type)",
+        "vec = (cute.arch.load(key.iterator + base, vector_type)\n"
+        "               if cutlass.Int32(cute.arch.thread_idx()[1]) * 16\n"
+        "               + cutlass.Int32(row_lane) < 127\n"
+        "               else cutlass.Float32(0))",
+    )
+    code = _source(_rewrite(source, thread_block_dims=(16, 8, 1)))
+
+    assert code.index("norm =") > code.rindex("for row_lane in range(16)")
+
+
+def test_overflowing_lane_bound_is_not_simplified() -> None:
+    source = _POSITIVE.replace(
+        "vec = cute.arch.load(key.iterator + base, vector_type)",
+        "vec = (cute.arch.load(key.iterator + base, vector_type)\n"
+        "               if cutlass.Int32(row_lane) * 2147483648 >= 0\n"
+        "               else cutlass.Float32(0))",
+    )
+    code = _source(_rewrite(source, thread_block_dims=(16, 8, 1)))
+
+    assert code.index("norm =") > code.rindex("for row_lane in range(16)")
+
+
+def test_two_lane_loop_hoists_expensive_invariant_reduction() -> None:
+    result = _rewrite(_POSITIVE.replace("range(16)", "range(2)", 1))
+    code = _source(result)
+
+    assert code.count("warp_reduction_sum") == 1
+    assert code.index("norm =") < code.rindex("for row_lane in range(2)")
+
+
+def test_single_lane_loop_is_unchanged() -> None:
+    result = _rewrite(_POSITIVE.replace("range(16)", "range(1)", 1))
+    assert len(result) == 1 and isinstance(result[0], ast.For)
+    assert _source(result).count("for row_lane in range(1)") == 1
+
+
+def test_two_lane_loop_leaves_cheap_reduction_in_place() -> None:
+    source = """
+for row_lane in range(2):
+    row = row_base + row_lane
+    value = cutlass.Float32(seed)
+    reduced = cutlass.Float32(
+        cute.arch.warp_reduction_sum(value, threads_in_group=16)
+    )
+    (out.iterator + row).store(reduced)
+"""
+    result = _rewrite(source)
+
+    assert len(result) == 1 and isinstance(result[0], ast.For)
+    assert _source(result).index("reduced =") > _source(result).index(
+        "for row_lane in range(2)"
+    )
+
+
+def test_row_dependent_work_does_not_make_cheap_reduction_profitable() -> None:
+    source = """
+for row_lane in range(2):
+    row = row_base + row_lane
+    row_0 = row + 1
+    row_1 = row_0 + 1
+    row_2 = row_1 + 1
+    row_3 = row_2 + 1
+    row_4 = row_3 + 1
+    row_5 = row_4 + 1
+    row_6 = row_5 + 1
+    row_7 = row_6 + 1
+    row_8 = row_7 + 1
+    row_9 = row_8 + 1
+    value = cutlass.Float32(seed)
+    reduced = cutlass.Float32(
+        cute.arch.warp_reduction_sum(value, threads_in_group=16)
+    )
+    (out.iterator + row).store(reduced + row_9)
+"""
+    code = _source(_rewrite(source))
+
+    assert code.index("reduced =") > code.index("for row_lane in range(2)")
+
+
+def test_overlapping_reduction_scores_only_marginal_work() -> None:
+    source = """
+for row_lane in range(2):
+    row = row_base + row_lane
+    acc = cutlass.Float32(0)
+    for k_lane in cutlass.range_constexpr(8):
+        value = (key.iterator + base + k_lane).load()
+        acc = acc + cutlass.Float32(value) * cutlass.Float32(value)
+    expensive = cutlass.Float32(
+        cute.arch.warp_reduction_sum(acc, threads_in_group=16)
+    )
+    cheap = cutlass.Float32(
+        cute.arch.warp_reduction_sum(expensive, threads_in_group=16)
+    )
+    (out.iterator + row).store(expensive + cheap)
+"""
+    code = _source(_rewrite(source))
+    row_loop = code.index("for row_lane in range(2)")
+
+    assert code.index("expensive =") < row_loop
+    assert code.index("cheap =") > row_loop
+
+
+def test_hoist_requires_storage_disjoint_proof() -> None:
+    result = _rewrite(_POSITIVE, disjoint=set())
+    assert len(result) == 1 and isinstance(result[0], ast.For)
+
+
+def test_lane_dependent_reduction_stays_inside_loop() -> None:
+    source = _POSITIVE.replace("key.iterator + base", "key.iterator + base + row")
+    result = _rewrite(source)
+    assert isinstance(result[-1], ast.If)
+    lifted = result[-1]
+    assert len(lifted.orelse) == 1
+    assert isinstance(lifted.orelse[0], ast.For)
+    assert "warp_reduction_sum" in ast.unparse(lifted.orelse[0])
+
+
+def test_atomic_in_lane_loop_rejects_hoist() -> None:
+    source = _POSITIVE.replace(
+        "(out.iterator + row).store(norm + state_value)",
+        "cute.arch.atomic_add(out.iterator + row, norm + state_value)",
+    )
+    result = _rewrite(source)
+    assert len(result) == 1 and isinstance(result[0], ast.For)
+
+
+def test_unknown_call_in_reduction_slice_rejects_hoist() -> None:
+    source = _POSITIVE.replace(
+        "value = cutlass.Float32(vec[k_lane])",
+        "value = opaque_transform(vec[k_lane])",
+    )
+    result = _rewrite(source)
+    assert len(result) == 1 and isinstance(result[0], ast.For)
+
+
+def test_loop_carried_guard_is_not_unswitched() -> None:
+    source = _POSITIVE.replace(
+        "(out.iterator + row).store(0)",
+        "invalid = False\n        (out.iterator + row).store(0)",
+    )
+    result = _rewrite(source)
+    assert len(result) == 1
+    loop = cast("ast.For", result[0])
+    assert isinstance(loop, ast.For)
+    assert isinstance(loop.body[-1], ast.If)
+
+
+def test_effectful_guard_expression_is_not_unswitched() -> None:
+    result = _rewrite(_POSITIVE.replace("if invalid:", "if predicate():"))
+    assert len(result) == 1 and isinstance(result[0], ast.For)
+
+
+def test_for_else_is_preserved_by_declining_rewrite() -> None:
+    source = _POSITIVE + "else:\n    finalize()\n"
+    result = _rewrite(source)
+    assert len(result) == 1
+    loop = cast("ast.For", result[0])
+    assert len(loop.orelse) == 1
+    assert "finalize()" in ast.unparse(loop.orelse[0])
+
+
+def test_unknown_effect_in_remainder_rejects_load_motion() -> None:
+    source = _POSITIVE.replace(
+        "(out.iterator + row).store(norm + state_value)",
+        "(out.iterator + row).store(norm + state_value)\n"
+        "        opaque_sync_or_mutation()",
+    )
+    result = _rewrite(source)
+    assert len(result) == 1 and isinstance(result[0], ast.For)
+
+
+def test_selected_cache_backedge_rejects_reduction_hoist() -> None:
+    source = _POSITIVE.replace(
+        "value = cutlass.Float32(vec[k_lane])",
+        "value = cutlass.Float32(vec[k_lane])\n"
+        "            _fuse_cache_0[k_lane] = value",
+    ).replace(
+        "state_value = (state.iterator + row).load()",
+        "_fuse_cache_0[0] = other\n        state_value = (state.iterator + row).load()",
+    )
+    result = _rewrite(source)
+    assert isinstance(result[-1], ast.If)
+    lifted = result[-1]
+    assert len(lifted.orelse) == 1
+    assert isinstance(lifted.orelse[0], ast.For)
+
+
+def test_selected_result_backedge_rejects_reduction_hoist() -> None:
+    source = _POSITIVE.replace(
+        "(out.iterator + row).store(norm + state_value)",
+        "(out.iterator + row).store(norm + state_value)\n"
+        "        norm = cutlass.Float32(0)",
+    )
+    result = _rewrite(source)
+    assert isinstance(result[-1], ast.If)
+    lifted = result[-1]
+    assert len(lifted.orelse) == 1
+    assert isinstance(lifted.orelse[0], ast.For)
+
+
+def test_inner_licm_rejects_late_reaching_definition() -> None:
+    source = _POSITIVE.replace(
+        "value = cutlass.Float32(vec[k_lane])",
+        "use_before_definition = x + k_lane\n"
+        "            x = cutlass.Float32(external)\n"
+        "            value = cutlass.Float32(vec[k_lane]) + use_before_definition",
+    )
+    code = _source(_rewrite(source))
+    assert code.index("use_before_definition =") < code.index(
+        "x = cutlass.Float32(external)"
+    )
+
+
+def test_repeated_scalar_hoist_rejects_read_before_first_definition() -> None:
+    source = _POSITIVE.replace(
+        "state_value = (state.iterator + row).load()",
+        "old_x = x + row_lane\n"
+        "        x = cutlass.Float32(seed)\n"
+        "        x = cutlass.Float32(seed)\n"
+        "        state_value = (state.iterator + row).load()",
+    )
+    code = _source(_rewrite(source))
+    row_loop = code.rindex("for row_lane in range(16)")
+    assert code.index("old_x =", row_loop) < code.index("x = cutlass.Float32(seed)")
+
+
+def test_repeated_cache_read_is_not_hoisted_across_cache_mutation() -> None:
+    source = _POSITIVE.replace(
+        "state_value = (state.iterator + row).load()",
+        "cached = _fuse_cache_7[0]\n"
+        "        _fuse_cache_7[0] = row_lane\n"
+        "        cached = _fuse_cache_7[0]\n"
+        "        state_value = (state.iterator + row).load()",
+    )
+    code = _source(_rewrite(source))
+    row_loop = code.rindex("for row_lane in range(16)")
+    assert code.count("cached = _fuse_cache_7[0]") == 2
+    assert code.index("cached = _fuse_cache_7[0]") > row_loop
+
+
+def test_mutable_store_staging_list_is_reinitialized_per_row() -> None:
+    source = _POSITIVE.replace(
+        "state_value = (state.iterator + row).load()",
+        "_persistent_branch_store_values_0 = []\n"
+        "        _persistent_branch_store_values_0.append(norm)\n"
+        "        state_value = (state.iterator + row).load()",
+    )
+    code = _source(_rewrite(source))
+    row_loop = code.rindex("for row_lane in range(16)")
+    assert code.index("_persistent_branch_store_values_0 = []") > row_loop
+
+
+def test_post_codegen_rename_alias_write_rejects_scalar_hoist() -> None:
+    source = _POSITIVE.replace(
+        "state_value = (state.iterator + row).load()",
+        "alias = cutlass.Float32(seed)\n"
+        "        use_alias = alias + row_lane\n"
+        "        alias = cutlass.Float32(seed)\n"
+        "        canonical = row_lane\n"
+        "        state_value = (state.iterator + row).load()",
+    )
+    code = _source(_rewrite(source, rename_groups={"alias": "canonical"}))
+    row_loop = code.rindex("for row_lane in range(16)")
+    assert code.count("alias = cutlass.Float32(seed)") == 2
+    assert code.index("alias = cutlass.Float32(seed)") > row_loop
+
+
+def test_post_codegen_rename_alias_write_rejects_guard_unswitch() -> None:
+    source = """
+for row_lane in range(16):
+    row = row_base + row_lane
+    if cond:
+        cond_alias = False
+        (out.iterator + row).store(0)
+    else:
+        acc = cutlass.Float32(0)
+        vec = cute.arch.load(key.iterator + base, vector_type)
+        for k_lane in cutlass.range_constexpr(8):
+            value = cutlass.Float32(vec[k_lane])
+            acc = acc + value * value
+        norm = cutlass.Float32(
+            cute.arch.warp_reduction_sum(acc, threads_in_group=16)
+        )
+        (out.iterator + row).store(norm)
+"""
+    result = _rewrite(source, rename_groups={"cond_alias": "cond"})
+    assert len(result) == 1 and isinstance(result[0], ast.For)
+
+
+def test_inner_licm_rejects_two_selected_rename_aliases() -> None:
+    source = _POSITIVE.replace(
+        "value = cutlass.Float32(vec[k_lane])",
+        "alias_1 = cutlass.Float32(seed_1)\n"
+        "            use_1 = alias_1 + k_lane\n"
+        "            alias_2 = cutlass.Float32(seed_2)\n"
+        "            use_2 = alias_2 + k_lane\n"
+        "            value = cutlass.Float32(vec[k_lane]) + use_1 + use_2",
+    )
+    code = _source(
+        _rewrite(
+            source,
+            rename_groups={"alias_1": "canonical", "alias_2": "canonical"},
+        )
+    )
+    inner_loop = code.index("for k_lane in cutlass.range_constexpr(8)")
+    assert code.index("alias_1 =", inner_loop) > inner_loop
+    assert code.index("alias_2 =", inner_loop) > inner_loop
+
+
+def test_repeated_staging_read_is_not_hoisted_across_append() -> None:
+    source = _POSITIVE.replace(
+        "state_value = (state.iterator + row).load()",
+        "staged = _persistent_branch_store_values_0[-1]\n"
+        "        _persistent_branch_store_values_0.append(row_lane)\n"
+        "        staged = _persistent_branch_store_values_0[-1]\n"
+        "        state_value = (state.iterator + row).load()",
+    )
+    code = _source(_rewrite(source))
+    row_loop = code.rindex("for row_lane in range(16)")
+    assert code.count("staged = _persistent_branch_store_values_0[-1]") == 2
+    assert code.index("staged = _persistent_branch_store_values_0[-1]") > row_loop
+
+
+def test_operator_setitem_is_not_treated_as_pure() -> None:
+    source = _POSITIVE.replace(
+        "state_value = (state.iterator + row).load()",
+        "operator.setitem(cache, 0, row_lane)\n"
+        "        state_value = (state.iterator + row).load()",
+    )
+    result = _rewrite(source)
+    assert len(result) == 1 and isinstance(result[0], ast.For)
+
+
+def test_guard_depending_on_outer_thread_value_is_not_unswitched() -> None:
+    body = ast.parse(
+        "thread_flag = cute.arch.thread_idx()[0] < 16\n"
+        + _POSITIVE.replace("if invalid:", "if thread_flag:")
+    ).body
+    loop = cast("ast.For", body[1])
+    setattr(loop, HELION_LANE_LOOP_VAR_ATTR, "row_lane")
+    result = hoist_lane_invariant_reductions(
+        body,
+        tensor_names=_TENSORS,
+        proven_disjoint_tensor_pairs=_DISJOINT,
+        uniform_names={"base", "batch", "row_base", "vector_type"},
+    )
+    assert isinstance(result[1], ast.For)
+
+
+def test_guard_uniformity_tracks_prior_rename_alias_write() -> None:
+    body = ast.parse(
+        "cond_alias = cute.arch.thread_idx()[0]\n"
+        "for row_lane in range(16):\n"
+        "    row = row_base + row_lane\n"
+        "    if cond:\n"
+        "        (out.iterator + row).store(0)\n"
+        "    else:\n"
+        "        acc = cutlass.Float32(0)\n"
+        "        vec = cute.arch.load(key.iterator + base, vector_type)\n"
+        "        for k_lane in cutlass.range_constexpr(8):\n"
+        "            value = cutlass.Float32(vec[k_lane])\n"
+        "            acc = acc + value * value\n"
+        "        norm = cutlass.Float32(\n"
+        "            cute.arch.warp_reduction_sum(acc, threads_in_group=16)\n"
+        "        )\n"
+        "        (out.iterator + row).store(norm)\n"
+    ).body
+    loop = cast("ast.For", body[1])
+    setattr(loop, HELION_LANE_LOOP_VAR_ATTR, "row_lane")
+    result = hoist_lane_invariant_reductions(
+        body,
+        tensor_names=_TENSORS,
+        proven_disjoint_tensor_pairs=_DISJOINT,
+        rename_groups={"cond_alias": "cond"},
+        uniform_names={"base", "cond", "row_base", "vector_type"},
+    )
+    assert isinstance(result[1], ast.For)
+
+
+def test_inner_licm_rejects_cache_mutation_after_selected_read() -> None:
+    source = _POSITIVE.replace(
+        "value = cutlass.Float32(vec[k_lane])",
+        "cached = _fuse_cache_7[0]\n"
+        "            value = cutlass.Float32(vec[k_lane]) + cached\n"
+        "            _fuse_cache_7[0] = k_lane",
+    )
+    code = _source(_rewrite(source))
+    inner_loop = code.index("for k_lane in cutlass.range_constexpr(8)")
+    assert code.index("cached = _fuse_cache_7[0]", inner_loop) > inner_loop
+
+
+def test_inner_licm_rejects_cache_mutation_before_selected_read() -> None:
+    source = _POSITIVE.replace(
+        "value = cutlass.Float32(vec[k_lane])",
+        "_fuse_cache_7[0] = k_lane\n"
+        "            cached = _fuse_cache_7[0]\n"
+        "            value = cutlass.Float32(vec[k_lane]) + cached",
+    )
+    code = _source(_rewrite(source))
+    inner_loop = code.index("for k_lane in cutlass.range_constexpr(8)")
+    assert code.index("cached = _fuse_cache_7[0]", inner_loop) > inner_loop
+
+
+def test_reduction_hoist_rejects_external_staging_mutation() -> None:
+    source = _POSITIVE.replace(
+        "acc = cutlass.Float32(0)",
+        "acc = cutlass.Float32(_persistent_branch_store_values_0[-1])",
+    ).replace(
+        "state_value = (state.iterator + row).load()",
+        "_persistent_branch_store_values_0.append(row_lane)\n"
+        "        state_value = (state.iterator + row).load()",
+    )
+    result = _rewrite(source)
+    assert isinstance(result[-1], ast.If)
+    lifted = result[-1]
+    assert len(lifted.orelse) == 1
+    assert isinstance(lifted.orelse[0], ast.For)
+
+
+def test_identical_repeated_scalar_definitions_hoist_once() -> None:
+    source = _POSITIVE.replace(
+        "state_value = (state.iterator + row).load()",
+        "factor = cutlass.Float32(seed)\n"
+        "        left = factor + row\n"
+        "        factor = cutlass.Float32(seed)\n"
+        "        state_value = (state.iterator + row).load()",
+    ).replace("norm + state_value", "norm + state_value + left + factor")
+    code = _source(_rewrite(source))
+    row_loop = code.rindex("for row_lane in range(16)")
+    assert code.count("factor = cutlass.Float32(seed)") == 1
+    assert code.index("factor = cutlass.Float32(seed)") < row_loop
+
+
+def test_cutlass_pipeline_call_is_not_treated_as_pure() -> None:
+    source = _POSITIVE.replace(
+        "state_value = (state.iterator + row).load()",
+        "pipeline = cutlass.pipeline.PipelineAsync.create(storage)\n"
+        "        state_value = (state.iterator + row).load()",
+    )
+    result = _rewrite(source)
+    assert len(result) == 1 and isinstance(result[0], ast.For)
+
+
+def test_fully_hoistable_loop_keeps_loop_target_semantics() -> None:
+    source = """
+for row_lane in range(16):
+    acc = cutlass.Float32(seed)
+    norm = cutlass.Float32(
+        cute.arch.warp_reduction_sum(acc, threads_in_group=16)
+    )
+"""
+    result = _rewrite(source)
+    assert len(result) == 1 and isinstance(result[0], ast.For)
+
+
+_VECTOR_CACHE = """
+_fuse_cache_10 = cute.make_rmem_tensor(4, cutlass.BFloat16)
+_fuse_cache_11 = cute.make_rmem_tensor(4, cutlass.Float32)
+for row_lane in range(16):
+    head_value = (head.iterator + base).load()
+    head_scaled = head_value * scale
+    for element in cutlass.range_constexpr(4):
+        index = base + cutlass.Int32(element)
+        raw = (gate.iterator + index).load()
+        _fuse_cache_10[(element - 0) // 1] = raw
+        gate_value = cutlass.Float32(raw)
+        bias_value = (bias.iterator + index).load()
+        _fuse_cache_11[(element - 0) // 1] = bias_value
+        combined = gate_value + bias_value
+        decay_input = head_scaled * combined
+        sigmoid = cute.math.rcp(
+            1.0 + cute.math.exp2(
+                -cutlass.Float32(decay_input) * 1.4426950408889634,
+                fastmath=True,
+            ),
+            approx=True,
+            ftz=True,
+        )
+        decay = cute.math.exp2(sigmoid * scale)
+        sink_0 = decay + row_lane
+    for element in cutlass.range_constexpr(4):
+        index = base + cutlass.Int32(element)
+        raw = _fuse_cache_10[(element - 0) // 1]
+        gate_value = cutlass.Float32(raw)
+        bias_value = _fuse_cache_11[(element - 0) // 1]
+        combined = gate_value + bias_value
+        decay_input = head_scaled * combined
+        sigmoid = cute.math.rcp(
+            1.0 + cute.math.exp2(
+                -cutlass.Float32(decay_input) * 1.4426950408889634,
+                fastmath=True,
+            ),
+            approx=True,
+            ftz=True,
+        )
+        decay = cute.math.exp2(sigmoid * scale)
+        sink_1 = decay + row_lane
+    head_value = (head.iterator + base).load()
+    head_scaled = head_value * scale
+    for element in cutlass.range_constexpr(4):
+        index = base + cutlass.Int32(element)
+        raw = _fuse_cache_10[(element - 0) // 1]
+        gate_value = cutlass.Float32(raw)
+        bias_value = _fuse_cache_11[(element - 0) // 1]
+        combined = gate_value + bias_value
+        decay_input = head_scaled * combined
+        sigmoid = cute.math.rcp(
+            1.0 + cute.math.exp2(
+                -cutlass.Float32(decay_input) * 1.4426950408889634,
+                fastmath=True,
+            ),
+            approx=True,
+            ftz=True,
+        )
+        decay = cute.math.exp2(sigmoid * scale)
+        sink_2 = decay + row_lane
+    (out.iterator + row_lane).store(sink_0 + sink_1 + sink_2)
+"""
+
+
+def test_nested_constexpr_vector_chain_is_cached_once() -> None:
+    code = _source(_rewrite_body(_VECTOR_CACHE))
+    row_loop = code.index("for row_lane in range(16)")
+
+    assert code.count("cute.math.exp2(") == 2
+    assert code.count("fastmath=True") == 1
+    assert code.count("approx=True") == 1
+    assert code.count("ftz=True") == 1
+    assert code.count("_fuse_cache_11[element]") == 3
+    assert "_fuse_cache_11[_lane_invariant_0] =" in code
+    assert "cute.make_rmem_tensor(4, cutlass.Float32)" in code
+    assert "cute.make_rmem_tensor(4, cutlass.BFloat16)" not in code
+    assert code.index("for _lane_invariant_0 in cutlass.range_constexpr(4)") < row_loop
+    assert code.count("(out.iterator + row_lane).store") == 1
+
+
+def test_extended_ast_vector_chain_runs_after_uniform_unswitch() -> None:
+    parsed = ast.parse(_VECTOR_CACHE)
+    row_loop = cast("ast.For", parsed.body[-1])
+    declarations = ast.unparse(ast.Module(body=parsed.body[:-1], type_ignores=[]))
+    branch_body = ast.unparse(ast.Module(body=row_loop.body, type_ignores=[]))
+    source = (
+        f"{declarations}\n"
+        "for row_lane in range(16):\n"
+        "    invalid = base < 0\n"
+        "    if invalid:\n"
+        "        (out.iterator + row_lane).store(0)\n"
+        "    else:\n"
+        f"{textwrap.indent(branch_body, '        ')}\n"
+    )
+    converted = cast("ast.Module", convert(ast.parse(source)))
+    assert isinstance(converted.body[0], ExtendedAST)
+
+    result = _rewrite_body(source, extended=True)
+    code = _source(result)
+
+    assert code.count("cute.math.exp2(") == 2
+    assert code.count("for row_lane in range(16)") == 2
+    assert code.index("if invalid:") < code.index(
+        "for _lane_invariant_0 in cutlass.range_constexpr(4)"
+    )
+    assert code.index(
+        "for _lane_invariant_0 in cutlass.range_constexpr(4)"
+    ) < code.rindex("for row_lane in range(16)")
+
+
+def test_unswitched_vector_chain_rejects_cross_branch_cache_accesses() -> None:
+    parsed = ast.parse(_VECTOR_CACHE)
+    row_loop = cast("ast.For", parsed.body[-1])
+    declarations = ast.unparse(ast.Module(body=parsed.body[:-1], type_ignores=[]))
+    branch_body = textwrap.indent(
+        ast.unparse(ast.Module(body=row_loop.body, type_ignores=[])), "        "
+    )
+    source = (
+        f"{declarations}\n"
+        "for row_lane in range(16):\n"
+        "    invalid = base < 0\n"
+        "    if invalid:\n"
+        f"{branch_body}\n"
+        "    else:\n"
+        f"{branch_body}\n"
+    )
+
+    code = _source(_rewrite_body(source, extended=True))
+
+    assert code.count("cute.math.exp2(") == 12
+    assert code.count("for row_lane in range(16)") == 2
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_requires_disjoint_loads() -> None:
+    code = _source(_rewrite_body(_VECTOR_CACHE, disjoint=set()))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_validates_cache_producer_load_root() -> None:
+    source = _VECTOR_CACHE.replace(
+        "_fuse_cache_11[(element - 0) // 1] = bias_value",
+        "_fuse_cache_11[(element - 0) // 1] = (bias_alias.iterator + index).load()",
+    )
+    code = _source(_rewrite_body(source, rename_groups={"bias_alias": "bias"}))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_row_dependency() -> None:
+    source = _VECTOR_CACHE.replace(
+        "combined = gate_value + bias_value",
+        "combined = gate_value + bias_value + row_lane",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_unknown_math_leaf() -> None:
+    source = _VECTOR_CACHE.replace(
+        "decay = cute.math.exp2(sigmoid * scale)",
+        "decay = cute.math.unreviewed(sigmoid * scale)",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.unreviewed(") == 3
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_arbitrary_bitcast_receiver() -> None:
+    source = _VECTOR_CACHE.replace(
+        "gate_value = cutlass.Float32(raw)",
+        "gate_value = opaque(raw).bitcast(cutlass.Float32)",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("opaque(raw).bitcast(cutlass.Float32)") == 3
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_mismatched_bitcast_width() -> None:
+    source = _VECTOR_CACHE.replace(
+        "gate_value = cutlass.Float32(raw)",
+        "gate_value = cutlass.Uint16(raw).bitcast(cutlass.Float32)",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("bitcast(cutlass.Float32)") == 3
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_wrong_cache_dtype() -> None:
+    source = _VECTOR_CACHE.replace(
+        "cute.make_rmem_tensor(4, cutlass.Float32)",
+        "cute.make_rmem_tensor(4, cutlass.BFloat16)",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_models_input_cache_conversion() -> None:
+    source = _VECTOR_CACHE.replace(
+        "cute.make_rmem_tensor(4, cutlass.BFloat16)",
+        "cute.make_rmem_tensor(4, cutlass.Float16)",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_nonidentity_cache_index() -> None:
+    source = _VECTOR_CACHE.replace(
+        "_fuse_cache_11[(element - 0) // 1] = bias_value",
+        "_fuse_cache_11[element // 2] = bias_value",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_intervening_cache_write() -> None:
+    source = _VECTOR_CACHE.replace(
+        "    for element in cutlass.range_constexpr(4):\n"
+        "        index = base + cutlass.Int32(element)\n"
+        "        raw = _fuse_cache_10[(element - 0) // 1]",
+        "    _fuse_cache_11[0] = cutlass.Float32(row_lane)\n"
+        "    for element in cutlass.range_constexpr(4):\n"
+        "        index = base + cutlass.Int32(element)\n"
+        "        raw = _fuse_cache_10[(element - 0) // 1]",
+        1,
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_intervening_augassign() -> None:
+    source = _VECTOR_CACHE.replace(
+        "    for element in cutlass.range_constexpr(4):",
+        "    head_scaled += row_lane\n    for element in cutlass.range_constexpr(4):",
+        1,
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_cache_handle_alias() -> None:
+    source = _VECTOR_CACHE.replace(
+        "for row_lane in range(16):",
+        "cache_alias = _fuse_cache_11\nfor row_lane in range(16):",
+    ).replace(
+        "(out.iterator + row_lane).store(sink_0 + sink_1 + sink_2)",
+        "alias_value = cache_alias[0]\n"
+        "    (out.iterator + row_lane).store("
+        "sink_0 + sink_1 + sink_2 + alias_value)",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_cache_handle_rebind() -> None:
+    source = _VECTOR_CACHE.replace(
+        "for row_lane in range(16):",
+        "other_cache = cute.make_rmem_tensor(4, cutlass.Float32)\n"
+        "for row_lane in range(16):\n"
+        "    _fuse_cache_11 = other_cache",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_control_flow_before_value() -> None:
+    source = _VECTOR_CACHE.replace(
+        "    for element in cutlass.range_constexpr(4):\n"
+        "        index = base + cutlass.Int32(element)",
+        "    for element in cutlass.range_constexpr(4):\n"
+        "        if element == 0:\n"
+        "            continue\n"
+        "        index = base + cutlass.Int32(element)",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_outer_control_transfer() -> None:
+    source = _VECTOR_CACHE.replace(
+        "    head_value = (head.iterator + base).load()",
+        "    if cond:\n        continue\n"
+        "    head_value = (head.iterator + base).load()",
+        1,
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_induction_variable_write() -> None:
+    source = _VECTOR_CACHE.replace(
+        "    for element in cutlass.range_constexpr(4):\n"
+        "        index = base + cutlass.Int32(element)",
+        "    for element in cutlass.range_constexpr(4):\n"
+        "        element = element + 1\n"
+        "        index = base + cutlass.Int32(element)",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_keeps_cache_with_external_consumer() -> None:
+    source = (
+        _VECTOR_CACHE.replace(
+            "        sink_0 = decay + row_lane",
+            "        sink_0 = decay + row_lane\n        other_0 = raw + row_lane",
+        )
+        .replace(
+            "        sink_1 = decay + row_lane",
+            "        sink_1 = decay + row_lane\n        other_1 = raw + row_lane",
+        )
+        .replace(
+            "        sink_2 = decay + row_lane",
+            "        sink_2 = decay + row_lane\n        other_2 = raw + row_lane",
+        )
+        .replace(
+            "sink_0 + sink_1 + sink_2)",
+            "sink_0 + sink_1 + sink_2 + other_0 + other_1 + other_2)",
+        )
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 6
+    assert code.count("_fuse_cache_10[") == 3
+    assert "_fuse_cache_10[(element - 0) // 1] = raw" in code
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_terminal_intermediate_collision() -> (
+    None
+):
+    source = """
+_fuse_cache_20 = cute.make_rmem_tensor(4, cutlass.Float32)
+for row_lane in range(16):
+    for element in cutlass.range_constexpr(4):
+        raw = cutlass.Float32((bias.iterator + element).load())
+        _fuse_cache_20[element] = raw
+        decay = cute.math.exp2(raw)
+        sink_0 = decay + row_lane
+    for element in cutlass.range_constexpr(4):
+        decay = _fuse_cache_20[element]
+        transformed = cute.math.exp2(decay)
+        other = decay + row_lane
+        sink_1 = transformed + row_lane
+    (out.iterator + row_lane).store(sink_0 + sink_1 + other)
+"""
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 2
+    assert "_fuse_cache_20[element] = raw" in code
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_fresh_names_cover_enclosing_scope() -> None:
+    source = _VECTOR_CACHE.replace(
+        "_fuse_cache_10 =",
+        "_lane_invariant_0 = cutlass.Float32(7)\n_fuse_cache_10 =",
+    ).replace(
+        "sink_0 + sink_1 + sink_2)",
+        "sink_0 + sink_1 + sink_2 + _lane_invariant_0)",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 2
+    assert "for _lane_invariant_1 in cutlass.range_constexpr(4)" in code
+    assert "_lane_invariant_0 = cutlass.Float32(7)" in code
+
+
+def test_nested_constexpr_vector_fresh_names_cover_future_renames() -> None:
+    result = _rewrite_body(
+        _VECTOR_CACHE,
+        rename_groups={"scale": "_lane_invariant_0"},
+    )
+    ast_rename(ast.Module(body=result, type_ignores=[]), {"scale": "_lane_invariant_0"})
+    code = _source(result)
+    assert code.count("cute.math.exp2(") == 2
+    assert "for _lane_invariant_1 in cutlass.range_constexpr(4)" in code
+    assert "for _lane_invariant_0 in" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_unknown_operand_dtype() -> None:
+    source = _VECTOR_CACHE.replace(
+        "decay = cute.math.exp2(sigmoid * scale)",
+        "decay = cute.math.exp2(bias_value * mystery)",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_mutated_external_subscript() -> None:
+    source = _VECTOR_CACHE.replace(
+        "combined = gate_value + bias_value",
+        "combined = gate_value + bias_value + cutlass.Float32(coeff[0])",
+    ).replace(
+        "    (out.iterator + row_lane).store",
+        "    coeff[0] = row_lane\n    (out.iterator + row_lane).store",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_mutated_selected_alias() -> None:
+    source = _VECTOR_CACHE.replace(
+        "    head_value = (head.iterator + base).load()",
+        "    coeff_alias = coeff\n"
+        "    coeff_alias[0] = row_lane\n"
+        "    head_value = (head.iterator + base).load()",
+        1,
+    ).replace(
+        "combined = gate_value + bias_value",
+        "combined = gate_value + bias_value + cutlass.Float32(coeff_alias[0])",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_does_not_cache_boolean_as_float() -> None:
+    source = _VECTOR_CACHE.replace(
+        "decay = cute.math.exp2(sigmoid * scale)",
+        "decay = not cute.math.exp2(sigmoid * scale)",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("decay = not cute.math.exp2") == 3
+    assert not any(
+        "_fuse_cache_11[_lane_invariant_" in line and "not " in line
+        for line in code.splitlines()
+    )
+
+
+def test_nested_constexpr_vector_chain_rejects_integer_true_divide_dtype() -> None:
+    source = """
+_fuse_cache_20 = cute.make_rmem_tensor(4, cutlass.Int32)
+for row_lane in range(16):
+    for element in cutlass.range_constexpr(4):
+        raw = (indices.iterator + element).load()
+        _fuse_cache_20[element] = raw
+        transformed = (
+            cutlass.Int32(cute.math.exp2(cutlass.Float32(raw)))
+            / cutlass.Int32(2)
+        )
+        sink_0 = transformed + row_lane
+    for element in cutlass.range_constexpr(4):
+        raw = _fuse_cache_20[element]
+        transformed = (
+            cutlass.Int32(cute.math.exp2(cutlass.Float32(raw)))
+            / cutlass.Int32(2)
+        )
+        sink_1 = transformed + row_lane
+    (out.iterator + row_lane).store(sink_0 + sink_1)
+"""
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 2
+    assert "_fuse_cache_20[element] = raw" in code
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_uses_explicit_arch_load_dtype() -> None:
+    source = _VECTOR_CACHE.replace(
+        "bias_value = (bias.iterator + index).load()",
+        "bias_value = cute.arch.load(bias.iterator + index, cutlass.Float16)",
+    ).replace(
+        "decay = cute.math.exp2(sigmoid * scale)",
+        "decay = cute.math.exp2(bias_value)",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_accepts_matching_arch_load_dtype() -> None:
+    source = _VECTOR_CACHE.replace(
+        "bias_value = (bias.iterator + index).load()",
+        "bias_value = cute.arch.load(bias.iterator + index, cutlass.Float32)",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 2
+    assert "_fuse_cache_11[_lane_invariant_0]" in code
+
+
+def test_nested_constexpr_vector_chain_rejects_unknown_arch_load_option() -> None:
+    source = _VECTOR_CACHE.replace(
+        "bias_value = (bias.iterator + index).load()",
+        "bias_value = cute.arch.load("
+        "bias.iterator + index, cutlass.Float32, volatile=True)",
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_rename_alias_mutation() -> None:
+    source = _VECTOR_CACHE.replace(
+        "    head_value = (head.iterator + base).load()",
+        "    alias = row_lane\n    head_value = (head.iterator + base).load()",
+        1,
+    )
+    code = _source(_rewrite_body(source, rename_groups={"head_value": "alias"}))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_lane_rename_alias() -> None:
+    source = _VECTOR_CACHE.replace(
+        "combined = gate_value + bias_value",
+        "combined = gate_value + bias_value + cutlass.Float32(other)",
+    )
+    code = _source(_rewrite_body(source, rename_groups={"other": "row_lane"}))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_cache_requires_same_path_allocation() -> None:
+    source = """
+if cond:
+    _fuse_cache_10 = cute.make_rmem_tensor(4, cutlass.BFloat16)
+    _fuse_cache_11 = cute.make_rmem_tensor(4, cutlass.Float32)
+else:
+""" + "\n".join(
+        f"    {line}" if line else line for line in _VECTOR_CACHE.splitlines()[3:]
+    )
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 6
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_supports_other_extent() -> None:
+    source = """
+_fuse_cache_20 = cute.make_rmem_tensor(3, cutlass.Float32)
+for row_lane in range(16):
+    for element in cutlass.range_constexpr(3):
+        raw = (gate.iterator + element).load()
+        _fuse_cache_20[element] = raw
+        value = cutlass.Float32(raw)
+        transformed = cute.math.exp2(value)
+        sink_0 = transformed + row_lane
+    for element in cutlass.range_constexpr(3):
+        raw = _fuse_cache_20[element]
+        value = cutlass.Float32(raw)
+        transformed = cute.math.exp2(value)
+        sink_1 = transformed + row_lane
+    (out.iterator + row_lane).store(sink_0 + sink_1)
+"""
+    dtypes = {**_TENSOR_DTYPES, "gate": "cutlass.Float32"}
+    code = _source(_rewrite_body(source, tensor_dtypes=dtypes))
+    assert code.count("cute.math.exp2(") == 1
+    assert "cute.make_rmem_tensor(3, cutlass.Float32)" in code
+    assert "for _lane_invariant_0 in cutlass.range_constexpr(3)" in code
+
+
+def test_nested_constexpr_vector_chain_rejects_narrow_float_literal_promotion() -> None:
+    source = """
+_fuse_cache_20 = cute.make_rmem_tensor(3, cutlass.Float16)
+for row_lane in range(16):
+    for element in cutlass.range_constexpr(3):
+        raw = (gate.iterator + element).load()
+        _fuse_cache_20[element] = raw
+        value = cutlass.Float16(raw)
+        transformed = cute.math.exp2(value) + 1
+        sink_0 = transformed + row_lane
+    for element in cutlass.range_constexpr(3):
+        raw = _fuse_cache_20[element]
+        value = cutlass.Float16(raw)
+        transformed = cute.math.exp2(value) + 1
+        sink_1 = transformed + row_lane
+    (out.iterator + row_lane).store(sink_0 + sink_1)
+"""
+    dtypes = {**_TENSOR_DTYPES, "gate": "cutlass.Float16"}
+    code = _source(_rewrite_body(source, tensor_dtypes=dtypes))
+    assert code.count("cute.math.exp2(") == 2
+    assert "_fuse_cache_20[element] = raw" in code
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_large_integer_promotion() -> None:
+    source = """
+_fuse_cache_20 = cute.make_rmem_tensor(3, cutlass.Float32)
+for row_lane in range(16):
+    for element in cutlass.range_constexpr(3):
+        raw = (bias.iterator + element).load()
+        _fuse_cache_20[element] = raw
+        transformed = cute.math.exp2(raw) + 4294967296
+        sink_0 = transformed + row_lane
+    for element in cutlass.range_constexpr(3):
+        raw = _fuse_cache_20[element]
+        transformed = cute.math.exp2(raw) + 4294967296
+        sink_1 = transformed + row_lane
+    (out.iterator + row_lane).store(sink_0 + sink_1)
+"""
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 2
+    assert "_fuse_cache_20[element] = raw" in code
+    assert "_lane_invariant_" not in code
+
+
+def test_nested_constexpr_vector_chain_rejects_mixed_ifexp_dtypes() -> None:
+    source = """
+_fuse_cache_20 = cute.make_rmem_tensor(3, cutlass.Float32)
+for row_lane in range(16):
+    for element in cutlass.range_constexpr(3):
+        raw = (bias.iterator + element).load()
+        _fuse_cache_20[element] = raw
+        transformed = cute.math.exp2(raw) if cond else scale
+        sink_0 = transformed + row_lane
+    for element in cutlass.range_constexpr(3):
+        raw = _fuse_cache_20[element]
+        transformed = cute.math.exp2(raw) if cond else scale
+        sink_1 = transformed + row_lane
+    (out.iterator + row_lane).store(sink_0 + sink_1)
+"""
+    code = _source(_rewrite_body(source))
+    assert code.count("cute.math.exp2(") == 2
+    assert "_fuse_cache_20[element] = raw" in code
+    assert "_lane_invariant_" not in code

--- a/test/test_cute_layout.py
+++ b/test/test_cute_layout.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import ast
 import dataclasses
 import unittest
 from unittest.mock import patch
 
+import pytest
 import torch
 
 import helion
@@ -16,6 +18,79 @@ from helion._testing import DEVICE
 from helion._testing import onlyBackends
 import helion.language as hl
 from helion.language import reduce_ops
+
+
+@helion.kernel(
+    backend="cute",
+    static_shapes=False,
+    config=helion.Config(
+        # V=32 consumes one thread axis, forcing the static K=128 reduction
+        # into a 32-thread x four-lane loop.  The four dependent reductions in
+        # the body must therefore be split into ordered lane passes.
+        block_sizes=[32],
+        num_warps=1,
+        num_stages=1,
+        indexing="pointer",
+    ),
+)
+def _state_update_and_project(
+    state: torch.Tensor,
+    k: torch.Tensor,
+    q: torch.Tensor,
+    v: torch.Tensor,
+    active: torch.Tensor,
+) -> torch.Tensor:
+    """Small recurrent-state update with reduction and broadcast fan-out."""
+    V = hl.specialize(state.size(0))
+    K = hl.specialize(state.size(1))
+    block_v = hl.register_block_size(1, V)
+    out = torch.empty([V], dtype=q.dtype, device=q.device)
+    for tile_v in hl.tile(V, block_size=block_v):
+        if active[0] == 0:
+            out[tile_v] = 0.0
+        else:
+            k_offsets = hl.arange(K)
+            state_tile = state[tile_v, k_offsets]
+            k_tile = k[k_offsets].float()
+            k_tile = k_tile / torch.sqrt((k_tile * k_tile).sum() + 1e-6)
+            residual = v[tile_v].float() - (state_tile * k_tile[None, :]).sum(-1)
+            updated = state_tile + residual[:, None] * k_tile[None, :]
+            q_tile = q[k_offsets].float()
+            q_tile = q_tile / torch.sqrt((q_tile * q_tile).sum() + 1e-6)
+            out[tile_v] = (updated * q_tile[None, :]).sum(-1).to(q.dtype)
+            state[tile_v, k_offsets] = updated
+    return out
+
+
+@onlyBackends(["cute"])
+def test_reduction_and_broadcast_fan_out_codegen_accepts_same_lane_update() -> None:
+    """Dynamic exact strides make the in-place state recurrence splittable."""
+    args = (
+        torch.randn(128, 128),
+        torch.randn(128, dtype=torch.bfloat16),
+        torch.randn(128, dtype=torch.bfloat16),
+        torch.randn(128, dtype=torch.bfloat16),
+        torch.ones(1, dtype=torch.int32),
+    )
+    _state_update_and_project.reset()
+    bound = _state_update_and_project.bind(args)
+    code = bound.to_code(bound.config_spec.default_config())
+
+    assert "_helion_lane_reduce" not in code
+    assert "input_tensor_metadata" in bound.env.compiler_fact_specialization_facts
+
+    zero_stride_state = torch.as_strided(
+        torch.randn(128),
+        (128, 128),
+        (1, 0),
+    )
+    zero_stride_bound = _state_update_and_project.bind((zero_stride_state, *args[1:]))
+    assert zero_stride_bound is not bound
+    with pytest.raises(
+        helion.exc.BackendUnsupported,
+        match="potentially aliasing write",
+    ):
+        zero_stride_bound.to_code(zero_stride_bound.config_spec.default_config())
 
 
 @onlyBackends(["cute"])
@@ -161,6 +236,33 @@ class TestLayoutAnnotation(unittest.TestCase):
         bound = self._compile_cute(copy_kernel, x)
         result = bound(x)
         torch.testing.assert_close(result, x)
+
+    def test_reduction_and_broadcast_fan_out(self) -> None:
+        """A state used by both a store and reduced projection keeps its layout."""
+        state = torch.randn(128, 128, device=DEVICE, dtype=torch.float32)
+        k = torch.randn(128, device=DEVICE, dtype=torch.bfloat16)
+        q = torch.randn(128, device=DEVICE, dtype=torch.bfloat16)
+        v = torch.randn(128, device=DEVICE, dtype=torch.bfloat16)
+        active = torch.ones(1, device=DEVICE, dtype=torch.int32)
+        state_ref = state.clone()
+
+        k_ref = torch.nn.functional.normalize(k.float(), dim=0)
+        q_ref = torch.nn.functional.normalize(q.float(), dim=0)
+        residual = v.float() - (state_ref * k_ref[None, :]).sum(-1)
+        state_ref += residual[:, None] * k_ref[None, :]
+        expected = (state_ref * q_ref[None, :]).sum(-1).to(q.dtype)
+
+        actual = _state_update_and_project(state, k, q, v, active)
+
+        torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(state, state_ref, rtol=2e-4, atol=2e-4)
+
+        inactive_state = torch.randn_like(state)
+        inactive_ref = inactive_state.clone()
+        inactive = torch.zeros_like(active)
+        inactive_out = _state_update_and_project(inactive_state, k, q, v, inactive)
+        torch.testing.assert_close(inactive_out, torch.zeros_like(inactive_out))
+        torch.testing.assert_close(inactive_state, inactive_ref)
 
 
 @dataclasses.dataclass
@@ -424,6 +526,221 @@ class TestLayoutChangeInsertion(unittest.TestCase):
 
         _insert_layout_changes(_FakeGraphInfo(graph))  # type: ignore[arg-type]
         _validate_layout_contracts(_FakeGraphInfo(graph))  # type: ignore[arg-type]
+
+    def test_validate_allows_reduction_only_inherited_path_mismatch(self) -> None:
+        """A reduction-only pointwise path owns its inherited transition."""
+        from helion._compiler.cute.layout import LayoutConstraint
+        from helion._compiler.cute.layout_propagation import _validate_layout_contracts
+
+        producer_layout = ThreadLayout.make_1d(
+            128, num_threads=32, tag=LayoutTag.INHERITED
+        )
+        reduction_layout = ThreadLayout.make_1d(
+            128, num_threads=64, tag=LayoutTag.INHERITED
+        )
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = torch.randn(128)
+        x.meta[META_KEY] = LayoutConstraint(output_layout=producer_layout)
+        absolute = graph.call_function(torch.abs, args=(x,))
+        absolute.meta["val"] = torch.randn(128)
+        absolute.meta[META_KEY] = LayoutConstraint(
+            input_layout=reduction_layout,
+            output_layout=reduction_layout,
+        )
+        reduction = graph.call_function(
+            torch.ops.aten.sum.dim_IntList,
+            args=(absolute, [-1], False),
+        )
+        reduction.meta["val"] = torch.randn(())
+        graph.output(reduction)
+
+        _validate_layout_contracts(_FakeGraphInfo(graph))  # type: ignore[arg-type]
+
+    def test_reduced_output_layout_does_not_propagate_to_full_tile(self) -> None:
+        """An inherited reduction-output layout must not constrain its input."""
+        from helion._compiler.cute.layout import LayoutConstraint
+        from helion._compiler.cute.layout_propagation import _collect_user_layouts
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = torch.randn(8, 128)
+        full_tile = ThreadLayout.make_row_major(
+            8, 128, num_threads=128, tag=LayoutTag.COALESCED
+        )
+        x.meta[META_KEY] = LayoutConstraint(preferred_output=full_tile)
+
+        reduction = graph.call_function(
+            torch.ops.aten.sum.dim_IntList, args=(x, [-1], False)
+        )
+        reduction.meta["val"] = torch.randn(8)
+        # Model a dynamic-shape layout whose symbolic tile size could not be
+        # proven smaller than the producer's during layout propagation.
+        inherited = full_tile.with_tag(LayoutTag.INHERITED)
+        reduction.meta[META_KEY] = LayoutConstraint(preferred_input=inherited)
+        graph.output(reduction)
+
+        self.assertEqual(_collect_user_layouts(x), [])
+
+    def test_seeded_reduction_layout_propagates_to_full_tile(self) -> None:
+        """A semantic reduction-axis layout remains a valid producer vote."""
+        from helion._compiler.cute.layout import LayoutConstraint
+        from helion._compiler.cute.layout_propagation import _collect_user_layouts
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = torch.randn(8, 128)
+        full_tile = ThreadLayout.make_row_major(
+            8, 128, num_threads=128, tag=LayoutTag.COALESCED
+        )
+        x.meta[META_KEY] = LayoutConstraint(preferred_output=full_tile)
+
+        reduction = graph.call_function(
+            torch.ops.aten.sum.dim_IntList, args=(x, [-1], False)
+        )
+        reduction.meta["val"] = torch.randn(8)
+        seeded = full_tile.with_tag(LayoutTag.REDUCTION)
+        reduction.meta[META_KEY] = LayoutConstraint(preferred_input=seeded)
+        graph.output(reduction)
+
+        self.assertEqual(_collect_user_layouts(x), [seeded])
+
+    def test_broadcast_output_layout_does_not_propagate_to_operand(self) -> None:
+        """A broadcast result layout must not constrain a smaller operand."""
+        from helion._compiler.cute.layout import LayoutConstraint
+        from helion._compiler.cute.layout_propagation import _collect_user_layouts
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = torch.randn(1, 128)
+        operand_layout = ThreadLayout.make_1d(
+            128, num_threads=128, tag=LayoutTag.COALESCED
+        )
+        x.meta[META_KEY] = LayoutConstraint(preferred_output=operand_layout)
+
+        y = graph.placeholder("y")
+        y.meta["val"] = torch.randn(8, 1)
+        broadcast = graph.call_function(torch.mul, args=(x, y))
+        broadcast.meta["val"] = torch.randn(8, 128)
+        output_layout = ThreadLayout.make_row_major(
+            8, 128, num_threads=128, tag=LayoutTag.INHERITED
+        )
+        broadcast.meta[META_KEY] = LayoutConstraint(preferred_input=output_layout)
+        graph.output(broadcast)
+
+        self.assertEqual(_collect_user_layouts(x), [])
+
+    def test_layout_compatibility_does_not_guard_on_unbacked_symbols(self) -> None:
+        """Distinct unbacked layout extents are safely treated as incompatible."""
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        from helion._compiler.cute.layout_propagation import _layouts_compatible
+
+        shape_env = ShapeEnv()
+        left_extent = shape_env.create_unbacked_symint()
+        right_extent = shape_env.create_unbacked_symint()
+        left = ThreadLayout((left_extent,), (1,), (1,), (1,))
+        right = ThreadLayout((right_extent,), (1,), (1,), (1,))
+
+        self.assertFalse(_layouts_compatible(left, right))
+
+    def test_layout_compatibility_does_not_truncate_leading_axes(self) -> None:
+        """Equal trailing axes cannot hide different complete tile sizes."""
+        from helion._compiler.cute.layout_propagation import _layouts_compatible
+
+        left = ThreadLayout((32,), (1,), (8, 4), (4, 1))
+        right = ThreadLayout((32,), (1,), (16, 4), (4, 1))
+
+        self.assertEqual(left.tile_numel(), 1024)
+        self.assertEqual(right.tile_numel(), 2048)
+        self.assertFalse(_layouts_compatible(left, right))
+
+    def test_reduction_only_pointwise_path_does_not_vote(self) -> None:
+        """A reduction-side branch must not block a non-reduction layout vote."""
+        from helion._compiler.cute.layout import LayoutConstraint
+        from helion._compiler.cute.layout_propagation import _collect_user_layouts
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = torch.randn(128)
+        reduction_path = graph.call_function(torch.square, args=(x,))
+        reduction_path.meta["val"] = torch.randn(128)
+        reduction_path.meta[META_KEY] = LayoutConstraint(
+            preferred_input=ThreadLayout.make_1d(
+                128, num_threads=64, tag=LayoutTag.INHERITED
+            )
+        )
+        reduction = graph.call_function(
+            torch.ops.aten.sum.dim_IntList,
+            args=(reduction_path, [-1], False),
+        )
+        reduction.meta["val"] = torch.randn(())
+
+        consumer = graph.call_function(torch.neg, args=(x,))
+        consumer.meta["val"] = torch.randn(128)
+        chosen = ThreadLayout.make_1d(128, num_threads=32, tag=LayoutTag.INHERITED)
+        consumer.meta[META_KEY] = LayoutConstraint(preferred_input=chosen)
+        graph.output((reduction, consumer))
+
+        self.assertEqual(_collect_user_layouts(x), [chosen])
+
+    @staticmethod
+    def _guarded_lane_reduction(*, thread_dependent: bool = False) -> ast.For:
+        from helion._compiler.tile_strategy import _create_lane_loop
+
+        condition = (
+            "cutlass.Int32(cute.arch.thread_idx()[0]) == 0"
+            if thread_dependent
+            else "external_flag"
+        )
+        prefix = ast.parse(f"lane_value = lane + 1\ncondition = {condition}").body
+        marker = ast.parse(
+            "reduced = _helion_lane_reduce("
+            "lane_value, 'sum', cutlass.Float32(0), 32, 1, 0, '', 1)"
+        ).body
+        guard = ast.If(
+            test=ast.Name(id="condition", ctx=ast.Load()),
+            body=marker,
+            orelse=[],
+        )
+        return _create_lane_loop("lane", 4, [*prefix, guard])
+
+    def test_lane_guard_requires_uniform_external_dependencies(self) -> None:
+        """A guard is not lifted when an external value is not proven uniform."""
+        from helion import exc
+        from helion._compiler.tile_strategy import _lift_lane_invariant_if
+        from helion._compiler.tile_strategy import split_lane_loop_reductions
+
+        loop = self._guarded_lane_reduction()
+        self.assertIsNone(_lift_lane_invariant_if(loop, "lane", {"cutlass"}))
+        with self.assertRaisesRegex(exc.BackendUnsupported, "thread uniformity"):
+            split_lane_loop_reductions([loop])
+
+    def test_lane_guard_rejects_thread_dependent_condition(self) -> None:
+        """A CUDA-thread-dependent guard cannot enclose a collective."""
+        from helion._compiler.tile_strategy import _lift_lane_invariant_if
+
+        loop = self._guarded_lane_reduction(thread_dependent=True)
+        self.assertIsNone(_lift_lane_invariant_if(loop, "lane", {"cutlass", "cute"}))
+
+    def test_lane_guard_empty_branch_preserves_lane_prefix(self) -> None:
+        """Lifting an empty branch keeps unconditional per-lane statements."""
+        from helion._compiler.tile_strategy import _lift_lane_invariant_if
+
+        loop = self._guarded_lane_reduction()
+        lifted = _lift_lane_invariant_if(
+            loop,
+            "lane",
+            {"cutlass", "external_flag"},
+        )
+        self.assertIsNotNone(lifted)
+        assert lifted is not None
+        outer_if = lifted[-1]
+        self.assertIsInstance(outer_if, ast.If)
+        assert isinstance(outer_if, ast.If)
+        self.assertEqual(len(outer_if.orelse), 1)
+        self.assertIsInstance(outer_if.orelse[0], ast.For)
+        self.assertIn("lane_value = lane + 1", ast.unparse(outer_if.orelse[0]))
 
 
 @onlyBackends(["cute"])

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -14886,6 +14886,7 @@ class TestCuteLowerings(unittest.TestCase):
             _thread_count=256,
             _synthetic_cute_lane_var="synthetic_lane_0",
             _synthetic_cute_lane_extent=4,
+            _cute_reduction_vec_width=1,
             block_size_var=lambda block_idx: "_RDIM_SIZE_0",
             index_var=lambda block_idx: "indices_0",
             _get_thread_axis=lambda: 0,

--- a/test/test_cute_persistent_reduction.py
+++ b/test/test_cute_persistent_reduction.py
@@ -1,0 +1,2031 @@
+"""Generic coverage for CuTe persistent subwarp reductions."""
+
+from __future__ import annotations
+
+import ast
+from types import SimpleNamespace
+from typing import Any
+from typing import cast
+
+import pytest
+import torch
+
+import helion
+from helion._compiler import tile_strategy
+from helion._compiler.autotuner_heuristics.cute import (
+    CutePersistentSubwarpRowsHeuristic,
+)
+from helion._compiler.backend import CuteBackend
+from helion._compiler.cute.memory_ops import _persistent_vec_scope_safe
+from helion._testing import DEVICE
+from helion._testing import TestCase
+from helion._testing import code_and_output
+from helion._testing import onlyBackends
+from helion.autotuner.config_spec import BlockSizeSpec
+from helion.autotuner.config_spec import ConfigSpec
+from helion.autotuner.config_spec import NumThreadsSpec
+from helion.autotuner.config_spec import ReductionLoopSpec
+import helion.language as hl
+
+
+def test_lane_split_without_marker_skips_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    body = ast.parse("if flag:\n    value = source + 1").body
+    monkeypatch.setattr(
+        tile_strategy,
+        "_update_scalar_definitions",
+        lambda *_: pytest.fail("unexpected provenance scan"),
+    )
+    assert tile_strategy.split_lane_loop_reductions(body) is body
+
+
+def test_chunk_hoist_without_running_sums_skips_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    body = ast.parse("value = source + 1").body
+    monkeypatch.setattr(
+        tile_strategy,
+        "_collect_statement_provenance",
+        lambda *_: pytest.fail("unexpected provenance scan"),
+    )
+    assert (
+        tile_strategy.hoist_lane_invariant_chunk_recurrence(body, running_sums=set())
+        is body
+    )
+
+
+@helion.kernel(backend="cute", static_shapes=True)
+def _persistent_state_update(
+    state: torch.Tensor,
+    packed_key_query: torch.Tensor,
+    value: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    rows, width = state.shape
+    out = torch.empty([rows], dtype=state.dtype, device=state.device)
+    next_state = torch.empty_like(state)
+    for tile_rows in hl.tile(rows):
+        cols = hl.arange(width)
+        key_tile = packed_key_query[cols].float()
+        key_tile = key_tile * torch.rsqrt((key_tile * key_tile).sum() + 1e-6)
+        state_tile = state[tile_rows, cols].float()
+        residual = value[tile_rows].float() - (state_tile * key_tile[None, :]).sum(-1)
+        updated = state_tile + residual[:, None] * key_tile[None, :]
+        query_tile = packed_key_query[width + cols].float()
+        out[tile_rows] = (updated * query_tile[None, :]).sum(-1).to(state.dtype)
+        next_state[tile_rows, cols] = updated
+    return out, next_state
+
+
+@helion.kernel(backend="cute", static_shapes=False)
+def _persistent_dynamic_grid_update(
+    state: torch.Tensor,
+    packed: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    batch = state.size(0)
+    heads = hl.specialize(state.size(1))
+    rows = hl.specialize(state.size(2))
+    width = hl.specialize(state.size(3))
+    out = torch.empty([batch, heads, rows], dtype=state.dtype, device=state.device)
+    next_state = torch.empty_like(state)
+    for tile_batch, tile_head, tile_row in hl.tile(
+        [batch, heads, rows], block_size=[1, 1, None]
+    ):
+        cols = hl.arange(width)
+        batch_index = tile_batch.id
+        head_index = tile_head.id
+        packed_values = packed[
+            batch_index,
+            head_index * width + cols,
+        ].float()
+        state_values = state[batch_index, head_index, tile_row, cols].float()
+        updated = state_values + packed_values
+        out[batch_index, head_index, tile_row] = updated.sum(-1).to(state.dtype)
+        next_state[batch_index, head_index, tile_row, cols] = updated
+    return out, next_state
+
+
+@helion.kernel(backend="cute", static_shapes=False)
+def _persistent_indexed_state_update(
+    state_indices: torch.Tensor,
+    state: torch.Tensor,
+    packed: torch.Tensor,
+) -> torch.Tensor:
+    batch = state_indices.size(0)
+    rows = hl.specialize(state.size(1))
+    width = hl.specialize(state.size(2))
+    out = torch.empty([batch, rows], dtype=state.dtype, device=state.device)
+    for tile_batch, tile_row in hl.tile([batch, rows], block_size=[1, None]):
+        batch_index = tile_batch.id
+        state_index = state_indices[batch_index]
+        if state_index < 0:
+            out[batch_index, tile_row] = 0
+        else:
+            cols = hl.arange(width)
+            packed_values = packed[batch_index, cols].float()
+            packed_values = packed_values * torch.rsqrt(
+                (packed_values * packed_values).sum() + 1e-6
+            )
+            state_values = state[state_index, tile_row, cols].float()
+            updated = state_values + packed_values[None, :]
+            out[batch_index, tile_row] = (
+                (updated * packed_values[None, :]).sum(-1).to(state.dtype)
+            )
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=False)
+def _persistent_indexed_inplace_state_update(
+    state_indices: torch.Tensor,
+    state: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    batch = state_indices.size(0)
+    rows = hl.specialize(state.size(1))
+    width = hl.specialize(state.size(2))
+    for tile_batch, tile_row in hl.tile([batch, rows], block_size=[1, None]):
+        batch_index = tile_batch.id
+        state_index = state_indices[batch_index]
+        if state_index < 0:
+            out[batch_index, tile_row] = 0
+        else:
+            cols = hl.arange(width)
+            key_values = key[batch_index, cols].float()
+            key_values = key_values * torch.rsqrt(
+                (key_values * key_values).sum() + 1e-6
+            )
+            state_values = state[state_index, tile_row, cols].float()
+            residual = value[batch_index, tile_row].float() - (
+                state_values * key_values[None, :]
+            ).sum(-1)
+            updated = state_values + residual[:, None] * key_values[None, :]
+            out[batch_index, tile_row] = (
+                (updated * key_values[None, :]).sum(-1).to(state.dtype)
+            )
+            state[state_index, tile_row, cols] = updated
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=False)
+def _persistent_shifted_state_update(
+    state_indices: torch.Tensor,
+    state: torch.Tensor,
+) -> torch.Tensor:
+    batch = state_indices.size(0)
+    rows = hl.specialize(state.size(1))
+    width = hl.specialize(state.size(2))
+    out = torch.empty([batch, rows], dtype=state.dtype, device=state.device)
+    for tile_batch, tile_row in hl.tile([batch, rows], block_size=[1, None]):
+        batch_index = tile_batch.id
+        state_index = state_indices[batch_index]
+        if state_index < 0:
+            out[batch_index, tile_row] = 0
+        else:
+            cols = hl.arange(width)
+            shifted_cols = cols + 1
+            state_values = state[state_index, tile_row, shifted_cols].float()
+            out[batch_index, tile_row] = state_values.sum(-1).to(state.dtype)
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=True)
+def _persistent_shifted_direct_update(
+    state: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    rows, width = state.shape
+    out = torch.empty([rows], dtype=state.dtype, device=state.device)
+    next_state = torch.empty_like(state)
+    for tile_rows in hl.tile(rows):
+        cols = hl.arange(width)
+        shifted_cols = cols + 1
+        values = state[tile_rows, shifted_cols].float()
+        out[tile_rows] = values.sum(-1).to(state.dtype)
+        next_state[tile_rows, shifted_cols] = values + 1
+    return out, next_state
+
+
+@helion.kernel(backend="cute", static_shapes=True)
+def _persistent_store_only(destination: torch.Tensor) -> torch.Tensor:
+    rows, width = destination.shape
+    out = torch.empty([rows], dtype=torch.float32, device=destination.device)
+    for tile_rows in hl.tile(rows):
+        cols = hl.arange(width)
+        values = cols.to(torch.float32)
+        out[tile_rows] = values.sum(-1)
+        destination[tile_rows, cols] = values[None, :].to(destination.dtype)
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=True)
+def _alias_sensitive_persistent_sweeps(
+    x: torch.Tensor,
+    y: torch.Tensor,
+) -> torch.Tensor:
+    rows, width = x.shape
+    out = torch.empty([rows], dtype=torch.float32, device=x.device)
+    for tile_rows in hl.tile(rows):
+        cols = hl.arange(width)
+        first = x[tile_rows, cols].float().sum(-1)
+        y[tile_rows, cols] = first[:, None]
+        second = (x[tile_rows, cols].float() + first[:, None]).sum(-1)
+        out[tile_rows] = first + second
+    return out
+
+
+@onlyBackends(["cute"])
+def test_seed_uses_block_ids_with_permuted_specs() -> None:
+    args = (
+        torch.randn(16, 128, dtype=torch.bfloat16),
+        torch.randn(256, dtype=torch.bfloat16),
+        torch.randn(16, dtype=torch.bfloat16),
+    )
+    bound = _persistent_state_update.bind(args)
+    env = bound.env
+    reduction_block = next(
+        block_id for block_id, block in enumerate(env.block_sizes) if block.reduction
+    )
+    row_block = env.config_spec.block_sizes.valid_block_ids()[0]
+    assert reduction_block not in env.config_spec.reduction_loops.valid_block_ids()
+    assert reduction_block in env.config_spec.reduction_block_ids
+    for sequence in (
+        env.config_spec.num_threads,
+        env.config_spec.cute_vector_widths,
+        env.config_spec.cute_lane_layouts,
+        env.config_spec.cute_reduction_reloads,
+    ):
+        assert reduction_block in sequence.valid_block_ids()
+
+    # Exercise the helper against deliberately different sequence orders;
+    # positional list literals would silently assign one block's setting to
+    # the other.
+    env.config_spec.num_threads.reverse()
+    env.config_spec.cute_vector_widths.reverse()
+    env.config_spec.cute_lane_layouts.reverse()
+    host_function = bound.host_function
+    assert host_function is not None
+    seed = CutePersistentSubwarpRowsHeuristic.get_seed_config(
+        env, host_function.device_ir
+    )
+    assert seed is not None
+
+    def by_block(spec: Any, raw_values: object) -> dict[int, object]:
+        assert isinstance(raw_values, list)
+        return dict(
+            zip(
+                spec.valid_block_ids(),
+                raw_values,
+                strict=True,
+            )
+        )
+
+    assert (
+        by_block(env.config_spec.block_sizes, seed.config["block_sizes"])[row_block]
+        == 16
+    )
+    threads = by_block(env.config_spec.num_threads, seed.config["num_threads"])
+    assert threads[row_block] == 8
+    assert threads[reduction_block] == 16
+    assert (
+        by_block(
+            env.config_spec.cute_vector_widths,
+            seed.config["cute_vector_widths"],
+        )[reduction_block]
+        == 8
+    )
+    assert (
+        by_block(
+            env.config_spec.cute_reduction_reloads,
+            seed.config["cute_reduction_reloads"],
+        )[reduction_block]
+        == "register"
+    )
+    assert "reduction_loops" not in seed.config
+    assert not CutePersistentSubwarpRowsHeuristic.promote_seed_to_default
+
+    # The layout is semantically inactive for a persistent one-fragment
+    # reduction.  Normalize both choices to one autotuner identity.
+    raw_layouts = seed.config["cute_lane_layouts"]
+    assert isinstance(raw_layouts, list)
+    strided_values = cast("list[str]", list(raw_layouts))
+    strided_values[
+        env.config_spec.cute_lane_layouts.block_id_to_index(reduction_block)
+    ] = "strided"
+    strided = helion.Config.from_dict(
+        {**seed.config, "cute_lane_layouts": strided_values}
+    )
+    assert env.config_spec.normalized_config(
+        strided
+    ) == env.config_spec.normalized_config(seed)
+    config_generation = env.config_spec.create_config_generation()
+    blocked_flat, _ = config_generation.canonicalize_flat(
+        config_generation.flatten(seed)
+    )
+    strided_flat, _ = config_generation.canonicalize_flat(
+        config_generation.flatten(strided)
+    )
+    assert strided_flat == blocked_flat
+
+    code = bound.to_code(seed)
+    assert "block=(16, 8, 1)" in code
+    assert "threads_in_group=16" in code
+    assert code.count("ir.VectorType.get([8], cutlass.Uint16.mlir_type)") >= 3
+    assert any(
+        " + 128" in line and "cute.arch.load" in line for line in code.splitlines()
+    )
+    assert "_cute_store_u16_vec" in code
+    assert "_cute_grouped_reduce_shared_two_stage" not in code
+
+
+@onlyBackends(["cute"])
+def test_persistent_subwarp_seed_includes_full_row_alternate() -> None:
+    args = (
+        torch.randn(1, 12, 128, 128, dtype=torch.bfloat16),
+        torch.randn(1, 12 * 128, dtype=torch.bfloat16),
+    )
+    bound = _persistent_dynamic_grid_update.bind(args)
+    host_function = bound.host_function
+    assert host_function is not None
+    seeds = CutePersistentSubwarpRowsHeuristic.get_seed_configs(
+        bound.env, host_function.device_ir
+    )
+    assert seeds is not None
+
+    row_block = bound.env.config_spec.block_sizes.valid_block_ids()[0]
+    row_index = bound.env.config_spec.block_sizes.block_id_to_index(row_block)
+    assert [seed.config["block_sizes"][row_index] for seed in seeds] == [
+        16,
+        16,
+        16,
+        32,
+        128,
+    ]
+    row_thread_index = bound.env.config_spec.num_threads.block_id_to_index(row_block)
+    recurrent_style = seeds[1]
+    assert recurrent_style.config["num_threads"][row_thread_index] == 1
+    assert recurrent_style.config["num_warps"] == 1
+    row_one = seeds[2]
+    assert row_one.config["num_threads"][row_thread_index] == 16
+    assert row_one.config["num_warps"] == 8
+    one_warp = seeds[3]
+    assert one_warp.config["num_threads"][row_thread_index] == 2
+    assert one_warp.config["num_warps"] == 1
+    # Rank zero remains the established schedule, so no-autotune behavior is
+    # unchanged until the full-row alternate wins an actual benchmark.
+    assert seeds[0] == CutePersistentSubwarpRowsHeuristic.get_seed_config(
+        bound.env, host_function.device_ir
+    )
+
+
+@onlyBackends(["cute"])
+def test_persistent_subwarp_seed_includes_recurrent_style_alternate() -> None:
+    args = (
+        torch.randn(1, 12, 128, 128, dtype=torch.bfloat16),
+        torch.randn(1, 12 * 128, dtype=torch.bfloat16),
+    )
+    bound = _persistent_dynamic_grid_update.bind(args)
+    host_function = bound.host_function
+    assert host_function is not None
+    seeds = CutePersistentSubwarpRowsHeuristic.get_seed_configs(
+        bound.env, host_function.device_ir
+    )
+    assert seeds is not None
+
+    row_block = bound.env.config_spec.block_sizes.valid_block_ids()[0]
+    reduction_block = next(
+        block_id
+        for block_id, block in enumerate(bound.env.block_sizes)
+        if block.reduction
+    )
+
+    def by_block(spec: Any, raw_values: object) -> dict[int, object]:
+        assert isinstance(raw_values, list)
+        return dict(
+            zip(
+                spec.valid_block_ids(),
+                raw_values,
+                strict=True,
+            )
+        )
+
+    recurrent = [
+        seed
+        for seed in seeds
+        if by_block(bound.env.config_spec.block_sizes, seed.config["block_sizes"])[
+            row_block
+        ]
+        == 16
+        and by_block(bound.env.config_spec.num_threads, seed.config["num_threads"])[
+            row_block
+        ]
+        == 1
+        and by_block(bound.env.config_spec.num_threads, seed.config["num_threads"])[
+            reduction_block
+        ]
+        == 32
+    ]
+    assert len(recurrent) == 1
+    seed = recurrent[0]
+    assert (
+        by_block(
+            bound.env.config_spec.cute_vector_widths,
+            seed.config["cute_vector_widths"],
+        )[reduction_block]
+        == 4
+    )
+    assert seed.config["num_warps"] == 1
+    assert seed.config["num_stages"] == 1
+    assert seed.config["pid_type"] == "flat"
+    assert (
+        by_block(
+            bound.env.config_spec.cute_reduction_reloads,
+            seed.config["cute_reduction_reloads"],
+        )[reduction_block]
+        == "register"
+    )
+    assert seed != CutePersistentSubwarpRowsHeuristic.get_seed_config(
+        bound.env, host_function.device_ir
+    )
+
+
+@onlyBackends(["cute"])
+def test_persistent_subwarp_recurrent_style_seed_requires_k128() -> None:
+    args = (
+        torch.randn(1, 12, 128, 256, dtype=torch.bfloat16),
+        torch.randn(1, 12 * 256, dtype=torch.bfloat16),
+    )
+    bound = _persistent_dynamic_grid_update.bind(args)
+    host_function = bound.host_function
+    assert host_function is not None
+    seeds = CutePersistentSubwarpRowsHeuristic.get_seed_configs(
+        bound.env, host_function.device_ir
+    )
+    assert seeds is not None
+
+    row_block = bound.env.config_spec.block_sizes.valid_block_ids()[0]
+    reduction_block = next(
+        block_id
+        for block_id, block in enumerate(bound.env.block_sizes)
+        if block.reduction
+    )
+
+    def by_block(spec: Any, raw_values: object) -> dict[int, object]:
+        assert isinstance(raw_values, list)
+        return dict(
+            zip(
+                spec.valid_block_ids(),
+                raw_values,
+                strict=True,
+            )
+        )
+
+    assert not any(
+        by_block(bound.env.config_spec.block_sizes, seed.config["block_sizes"])[
+            row_block
+        ]
+        == 16
+        and by_block(bound.env.config_spec.num_threads, seed.config["num_threads"])[
+            row_block
+        ]
+        == 1
+        and by_block(bound.env.config_spec.num_threads, seed.config["num_threads"])[
+            reduction_block
+        ]
+        == 32
+        and by_block(
+            bound.env.config_spec.cute_vector_widths,
+            seed.config["cute_vector_widths"],
+        )[reduction_block]
+        == 4
+        for seed in seeds
+    )
+
+
+@onlyBackends(["cute"])
+def test_full_row_seed_hoists_invariant_norm_before_state_rows() -> None:
+    args = (
+        torch.tensor([0], dtype=torch.int32),
+        torch.randn(2, 128, 128, dtype=torch.bfloat16),
+        torch.randn(1, 128, dtype=torch.bfloat16),
+        torch.randn(1, 128, dtype=torch.bfloat16),
+        torch.empty(1, 128, dtype=torch.bfloat16),
+    )
+    bound = _persistent_indexed_inplace_state_update.bind(args)
+    host_function = bound.host_function
+    assert host_function is not None
+    seeds = CutePersistentSubwarpRowsHeuristic.get_seed_configs(
+        bound.env, host_function.device_ir
+    )
+    assert seeds is not None and len(seeds) == 5
+
+    code = bound.to_code(seeds[-1])
+    lines = code.splitlines()
+    active_row_loop = max(
+        index
+        for index, line in enumerate(lines)
+        if "for lane_" in line and "range(16)" in line
+    )
+    norm_line = next(index for index, line in enumerate(lines) if "sum_1 =" in line)
+    state_load_line = next(
+        index
+        for index, line in enumerate(lines)
+        if "cute.arch.load(state.iterator" in line
+    )
+    state_store_line = next(
+        index
+        for index, line in enumerate(lines)
+        if "_cute_store_u16_vec(state.iterator" in line
+    )
+    assert norm_line < active_row_loop < state_load_line < state_store_line
+
+
+@onlyBackends(["cute"])
+def test_tail_vector_load_uses_a_safe_outer_index() -> None:
+    args = (
+        torch.randn(17, 128, dtype=torch.bfloat16),
+        torch.randn(256, dtype=torch.bfloat16),
+        torch.randn(17, dtype=torch.bfloat16),
+    )
+    bound = _persistent_state_update.bind(args)
+    host_function = bound.host_function
+    assert host_function is not None
+    seed = CutePersistentSubwarpRowsHeuristic.get_seed_config(
+        bound.env, host_function.device_ir
+    )
+    assert seed is not None
+
+    code = bound.to_code(seed)
+    state_vector_load = next(
+        line
+        for line in code.splitlines()
+        if "_persistent_branch_vec_" in line and "cute.arch.load(state.iterator" in line
+    )
+    assert "if mask_0" in state_vector_load
+    assert "else cutlass.Int32(0)" in state_vector_load
+    assert "_cute_store_u16_vec" in code
+
+
+@onlyBackends(["cute"])
+def test_dynamic_grid_vector_hoist_preserves_device_scope_aliases() -> None:
+    args = (
+        torch.randn(1, 12, 16, 128, dtype=torch.bfloat16),
+        torch.randn(1, 12 * 128, dtype=torch.bfloat16),
+    )
+    bound = _persistent_dynamic_grid_update.bind(args)
+    env = bound.env
+    reduction_block = next(
+        block_id for block_id, block in enumerate(env.block_sizes) if block.reduction
+    )
+    row_block = env.config_spec.block_sizes.valid_block_ids()[0]
+
+    def values_for(spec: Any, values: dict[int, object], default: object):
+        return [values.get(block_id, default) for block_id in spec.valid_block_ids()]
+
+    config = helion.Config.from_dict(
+        {
+            "block_sizes": values_for(env.config_spec.block_sizes, {row_block: 16}, 16),
+            "num_threads": values_for(
+                env.config_spec.num_threads,
+                {row_block: 8, reduction_block: 16},
+                0,
+            ),
+            "cute_vector_widths": values_for(
+                env.config_spec.cute_vector_widths,
+                {reduction_block: 8},
+                1,
+            ),
+            "cute_lane_layouts": values_for(
+                env.config_spec.cute_lane_layouts,
+                {reduction_block: "blocked"},
+                "blocked",
+            ),
+            "cute_reduction_reloads": values_for(
+                env.config_spec.cute_reduction_reloads,
+                {reduction_block: "register"},
+                "auto",
+            ),
+            "num_warps": 4,
+            "num_stages": 1,
+            "pid_type": "flat",
+        }
+    )
+    code = bound.to_code(config)
+    vector_loads = [
+        line
+        for line in code.splitlines()
+        if "_persistent_branch_vec_" in line and "cute.arch.load" in line
+    ]
+
+    assert len(vector_loads) >= 2
+    assert all(".size(" not in line for line in vector_loads)
+    assert any("tile_offset_" in line or "indices_" in line for line in vector_loads)
+
+
+@onlyBackends(["cute"])
+def test_dynamic_state_index_uses_branch_local_exact_fragments() -> None:
+    args = (
+        torch.tensor([1], dtype=torch.int64),
+        torch.randn(4, 16, 128, dtype=torch.bfloat16),
+        torch.randn(1, 128, dtype=torch.bfloat16),
+    )
+    bound = _persistent_indexed_state_update.bind(args)
+    env = bound.env
+    reduction_block = next(
+        block_id for block_id, block in enumerate(env.block_sizes) if block.reduction
+    )
+    row_block = env.config_spec.block_sizes.valid_block_ids()[0]
+
+    def values_for(spec: Any, values: dict[int, object], default: object):
+        return [values.get(block_id, default) for block_id in spec.valid_block_ids()]
+
+    config = helion.Config.from_dict(
+        {
+            "block_sizes": values_for(env.config_spec.block_sizes, {row_block: 16}, 16),
+            "num_threads": values_for(
+                env.config_spec.num_threads,
+                {row_block: 8, reduction_block: 16},
+                0,
+            ),
+            "cute_vector_widths": values_for(
+                env.config_spec.cute_vector_widths,
+                {reduction_block: 8},
+                1,
+            ),
+            "cute_lane_layouts": values_for(
+                env.config_spec.cute_lane_layouts,
+                {reduction_block: "blocked"},
+                "blocked",
+            ),
+            "cute_reduction_reloads": values_for(
+                env.config_spec.cute_reduction_reloads,
+                {reduction_block: "register"},
+                "auto",
+            ),
+            "num_warps": 4,
+            "num_stages": 1,
+            "pid_type": "flat",
+        }
+    )
+    code = bound.to_code(config)
+
+    state_index_load = code.index("state_indices.iterator")
+    branch_vec_load = code.index("cute.arch.load(state.iterator")
+    assert state_index_load < branch_vec_load
+    assert code.count("cute.arch.load(state.iterator") == 1
+    assert ".size(" not in code[branch_vec_load : code.index("\n", branch_vec_load)]
+    assert not any(
+        "state.iterator" in line and ".load()" in line for line in code.splitlines()
+    )
+    assert "_helion_persistent_branch_vec_" not in code
+
+
+@onlyBackends(["cute"])
+def test_dynamic_indexed_inplace_state_update_meta_compiles() -> None:
+    """A decode-shaped exact state RMW is lane-local, despite sharing storage."""
+    args = (
+        torch.tensor([1, 2], dtype=torch.int64),
+        torch.randn(4, 16, 128, dtype=torch.bfloat16),
+        torch.randn(2, 128, dtype=torch.bfloat16),
+        torch.randn(2, 16, dtype=torch.bfloat16),
+        torch.empty(2, 16, dtype=torch.bfloat16),
+    )
+    bound = _persistent_indexed_inplace_state_update.bind(args)
+    host_function = bound.host_function
+    assert host_function is not None
+    seed = CutePersistentSubwarpRowsHeuristic.get_seed_config(
+        bound.env, host_function.device_ir
+    )
+    assert seed is not None
+
+    code = bound.to_code(seed)
+
+    assert code.count("cute.arch.load(state.iterator") >= 1
+    assert "_cute_store_u16_vec(state.iterator" in code
+    assert "_helion_persistent_branch_vec_" not in code
+
+
+@onlyBackends(["cute"])
+def test_dynamic_state_vector_alignment_is_cache_specialized() -> None:
+    _persistent_indexed_state_update.reset()
+    state_indices = torch.tensor([1], dtype=torch.int64)
+    packed = torch.randn(1, 128, dtype=torch.bfloat16)
+    aligned_state = torch.randn(4, 16, 128, dtype=torch.bfloat16)
+    aligned = _persistent_indexed_state_update.bind(
+        (state_indices, aligned_state, packed)
+    )
+    env = aligned.env
+    reduction_block = next(
+        block_id for block_id, block in enumerate(env.block_sizes) if block.reduction
+    )
+    row_block = env.config_spec.block_sizes.valid_block_ids()[0]
+
+    def values_for(spec: Any, values: dict[int, object], default: object):
+        return [values.get(block_id, default) for block_id in spec.valid_block_ids()]
+
+    config = helion.Config.from_dict(
+        {
+            "block_sizes": values_for(env.config_spec.block_sizes, {row_block: 16}, 16),
+            "num_threads": values_for(
+                env.config_spec.num_threads,
+                {row_block: 8, reduction_block: 16},
+                0,
+            ),
+            "cute_vector_widths": values_for(
+                env.config_spec.cute_vector_widths,
+                {reduction_block: 8},
+                1,
+            ),
+            "cute_lane_layouts": values_for(
+                env.config_spec.cute_lane_layouts,
+                {reduction_block: "blocked"},
+                "blocked",
+            ),
+            "cute_reduction_reloads": values_for(
+                env.config_spec.cute_reduction_reloads,
+                {reduction_block: "register"},
+                "auto",
+            ),
+            "num_warps": 4,
+            "num_stages": 1,
+            "pid_type": "flat",
+        }
+    )
+    assert "cute.arch.load(state.iterator" in aligned.to_code(config)
+
+    # Keep the same shape and logical strides but offset the input pointer by
+    # one bf16.  This must receive a different bound-kernel specialization and
+    # cannot use the 16-byte vector transaction emitted for ``aligned_state``.
+    storage = torch.randn(4 * 16 * 128 + 1, dtype=torch.bfloat16)
+    unaligned_state = torch.as_strided(
+        storage,
+        (4, 16, 128),
+        (16 * 128, 128, 1),
+        storage_offset=1,
+    )
+    unaligned = _persistent_indexed_state_update.bind(
+        (state_indices, unaligned_state, packed)
+    )
+    assert unaligned is not aligned
+    unaligned_code = unaligned.to_code(config)
+    assert "cute.arch.load(state.iterator" not in unaligned_code
+
+
+@onlyBackends(["cute"])
+def test_shifted_state_fragment_stays_scalar_at_partial_boundary() -> None:
+    args = (
+        torch.tensor([1], dtype=torch.int64),
+        torch.randn(4, 16, 128, dtype=torch.bfloat16),
+    )
+    bound = _persistent_shifted_state_update.bind(args)
+    env = bound.env
+    reduction_block = next(
+        block_id for block_id, block in enumerate(env.block_sizes) if block.reduction
+    )
+    row_block = env.config_spec.block_sizes.valid_block_ids()[0]
+
+    def values_for(spec: Any, values: dict[int, object], default: object):
+        return [values.get(block_id, default) for block_id in spec.valid_block_ids()]
+
+    config = helion.Config.from_dict(
+        {
+            "block_sizes": values_for(env.config_spec.block_sizes, {row_block: 16}, 16),
+            "num_threads": values_for(
+                env.config_spec.num_threads,
+                {row_block: 8, reduction_block: 16},
+                0,
+            ),
+            "cute_vector_widths": values_for(
+                env.config_spec.cute_vector_widths,
+                {reduction_block: 8},
+                1,
+            ),
+            "cute_lane_layouts": values_for(
+                env.config_spec.cute_lane_layouts,
+                {reduction_block: "blocked"},
+                "blocked",
+            ),
+            "cute_reduction_reloads": values_for(
+                env.config_spec.cute_reduction_reloads,
+                {reduction_block: "register"},
+                "auto",
+            ),
+            "num_warps": 4,
+            "num_stages": 1,
+            "pid_type": "flat",
+        }
+    )
+    code = bound.to_code(config)
+
+    # The last logical fragment addresses columns 121..128, so a vector load
+    # would read column 128 OOB.
+    assert "cute.arch.load(state.iterator" not in code
+    assert any(
+        "state.iterator" in line and ".load()" in line for line in code.splitlines()
+    )
+    assert "_helion_persistent_branch_vec_" not in code
+
+
+@onlyBackends(["cute"])
+def test_normal_persistent_vectors_require_exact_aligned_fragments() -> None:
+    shifted_args = (torch.randn(16, 128, dtype=torch.bfloat16),)
+    shifted = _persistent_shifted_direct_update.bind(shifted_args)
+    shifted_env = shifted.env
+    shifted_reduction_block = next(
+        block_id
+        for block_id, block in enumerate(shifted_env.block_sizes)
+        if block.reduction
+    )
+    shifted_row_block = shifted_env.config_spec.block_sizes.valid_block_ids()[0]
+
+    def values_for(spec: Any, values: dict[int, object], default: object):
+        return [values.get(block_id, default) for block_id in spec.valid_block_ids()]
+
+    shifted_config = helion.Config.from_dict(
+        {
+            "block_sizes": values_for(
+                shifted_env.config_spec.block_sizes,
+                {shifted_row_block: 16},
+                16,
+            ),
+            "num_threads": values_for(
+                shifted_env.config_spec.num_threads,
+                {shifted_row_block: 8, shifted_reduction_block: 16},
+                0,
+            ),
+            "cute_vector_widths": values_for(
+                shifted_env.config_spec.cute_vector_widths,
+                {shifted_reduction_block: 8},
+                1,
+            ),
+            "cute_lane_layouts": values_for(
+                shifted_env.config_spec.cute_lane_layouts,
+                {shifted_reduction_block: "blocked"},
+                "blocked",
+            ),
+            "cute_reduction_reloads": values_for(
+                shifted_env.config_spec.cute_reduction_reloads,
+                {shifted_reduction_block: "register"},
+                "auto",
+            ),
+            "num_warps": 4,
+            "num_stages": 1,
+            "pid_type": "flat",
+        }
+    )
+    shifted_code = shifted.to_code(shifted_config)
+    assert "cute.arch.load(state.iterator" not in shifted_code
+    assert "_cute_store_u16_vec(next_state.iterator" not in shifted_code
+
+    _persistent_state_update.reset()
+    aligned_state = torch.randn(16, 128, dtype=torch.bfloat16)
+    packed = torch.randn(256, dtype=torch.bfloat16)
+    value = torch.randn(16, dtype=torch.bfloat16)
+    aligned = _persistent_state_update.bind((aligned_state, packed, value))
+    aligned_host = aligned.host_function
+    assert aligned_host is not None
+    seed = CutePersistentSubwarpRowsHeuristic.get_seed_config(
+        aligned.env, aligned_host.device_ir
+    )
+    assert seed is not None
+    aligned_code = aligned.to_code(seed)
+    assert "cute.arch.load(state.iterator" in aligned_code
+    assert "_cute_store_u16_vec(next_state.iterator" in aligned_code
+
+    storage = torch.randn(16 * 128 + 1, dtype=torch.bfloat16)
+    unaligned_state = torch.as_strided(
+        storage,
+        (16, 128),
+        (128, 1),
+        storage_offset=1,
+    )
+    unaligned = _persistent_state_update.bind((unaligned_state, packed, value))
+    assert unaligned is not aligned
+    unaligned_code = unaligned.to_code(seed)
+    assert "cute.arch.load(state.iterator" not in unaligned_code
+
+
+@onlyBackends(["cute"])
+def test_normal_persistent_store_requires_runtime_alignment() -> None:
+    aligned_destination = torch.empty(16, 128, dtype=torch.bfloat16)
+    aligned = _persistent_store_only.bind((aligned_destination,))
+    env = aligned.env
+    reduction_block = next(
+        block_id for block_id, block in enumerate(env.block_sizes) if block.reduction
+    )
+    row_block = env.config_spec.block_sizes.valid_block_ids()[0]
+
+    def values_for(spec: Any, values: dict[int, object], default: object):
+        return [values.get(block_id, default) for block_id in spec.valid_block_ids()]
+
+    config = helion.Config.from_dict(
+        {
+            "block_sizes": values_for(env.config_spec.block_sizes, {row_block: 16}, 16),
+            "num_threads": values_for(
+                env.config_spec.num_threads,
+                {row_block: 8, reduction_block: 16},
+                0,
+            ),
+            "cute_vector_widths": values_for(
+                env.config_spec.cute_vector_widths,
+                {reduction_block: 8},
+                1,
+            ),
+            "cute_lane_layouts": values_for(
+                env.config_spec.cute_lane_layouts,
+                {reduction_block: "blocked"},
+                "blocked",
+            ),
+            "cute_reduction_reloads": values_for(
+                env.config_spec.cute_reduction_reloads,
+                {reduction_block: "register"},
+                "auto",
+            ),
+            "num_warps": 4,
+            "num_stages": 1,
+            "pid_type": "flat",
+        }
+    )
+    assert "_cute_store_u16_vec(destination.iterator" in aligned.to_code(config)
+
+    storage = torch.empty(16 * 128 + 1, dtype=torch.bfloat16)
+    unaligned_destination = torch.as_strided(
+        storage,
+        (16, 128),
+        (128, 1),
+        storage_offset=1,
+    )
+    unaligned = _persistent_store_only.bind((unaligned_destination,))
+    assert unaligned is not aligned
+    unaligned_code = unaligned.to_code(config)
+    assert "_cute_store_u16_vec(destination.iterator" not in unaligned_code
+    assert any(
+        "destination.iterator" in line and ".store(" in line
+        for line in unaligned_code.splitlines()
+    )
+
+
+@pytest.mark.parametrize("storage_relation", ("distinct", "overlap", "same"))
+@onlyBackends(["cute"])
+def test_external_tensor_runtime_alias_proof_is_cache_safe(
+    monkeypatch: Any,
+    storage_relation: str,
+) -> None:
+    from helion._compiler.device_function import DeviceFunction
+
+    _alias_sensitive_persistent_sweeps.reset()
+    if storage_relation == "overlap":
+        storage = torch.randn(16 * 128 + 1, dtype=torch.float32)
+        x = torch.as_strided(storage, (16, 128), (128, 1))
+        y = torch.as_strided(storage, (16, 128), (128, 1), storage_offset=1)
+    else:
+        x = torch.randn(16, 128, dtype=torch.float32)
+        y = x if storage_relation == "same" else torch.randn_like(x)
+    captured_pairs: list[set[frozenset[str]]] = []
+    original = DeviceFunction.proven_disjoint_tensor_pairs
+
+    def capture(device_function: DeviceFunction) -> set[frozenset[str]]:
+        result = original(device_function)
+        captured_pairs.append(result)
+        return result
+
+    monkeypatch.setattr(DeviceFunction, "proven_disjoint_tensor_pairs", capture)
+    bound = _alias_sensitive_persistent_sweeps.bind((x, y))
+    host_function = bound.host_function
+    assert host_function is not None
+    seed = CutePersistentSubwarpRowsHeuristic.get_seed_config(
+        bound.env, host_function.device_ir
+    )
+    assert seed is not None
+    if storage_relation == "distinct":
+        bound.to_code(seed)
+    else:
+        with pytest.raises(
+            helion.exc.BackendUnsupported, match="potentially aliasing write"
+        ):
+            bound.to_code(seed)
+
+    assert captured_pairs
+    assert (frozenset(("x", "y")) in captured_pairs[-1]) is (
+        storage_relation == "distinct"
+    )
+    assert frozenset(("x", "out")) in captured_pairs[-1]
+    assert frozenset(("y", "out")) in captured_pairs[-1]
+
+
+@onlyBackends(["cute"])
+def test_runtime_alias_specialization_separates_overlapping_launches() -> None:
+    _alias_sensitive_persistent_sweeps.reset()
+    x = torch.randn(16, 128, dtype=torch.float32)
+    distinct = _alias_sensitive_persistent_sweeps.bind((x, torch.randn_like(x)))
+    same = _alias_sensitive_persistent_sweeps.bind((x, x))
+    storage = torch.randn(16 * 128 + 1, dtype=torch.float32)
+    overlapping = _alias_sensitive_persistent_sweeps.bind(
+        (
+            torch.as_strided(storage, (16, 128), (128, 1)),
+            torch.as_strided(storage, (16, 128), (128, 1), storage_offset=1),
+        )
+    )
+
+    assert distinct is not same
+    assert distinct is not overlapping
+
+
+def test_persistent_hoist_scope_rejects_inner_loop_targets() -> None:
+    hoist_parent = ast.parse("dominating_value = thread_value").body
+    grid = SimpleNamespace(
+        lane_loops=[
+            ("outer_lane", 2),
+            ("synthetic_lane_1", 8),
+            ("inner_lane", 2),
+        ],
+        vec_lane_wrappers={},
+        lane_setup_statements=ast.parse(
+            """
+outer_alias = outer_lane + 3
+indirect_outer_alias = outer_alias + 1
+inner_alias = inner_lane + 7
+indirect_inner_alias = inner_alias + 1
+"""
+        ).body,
+        hoist_parent_statements=hoist_parent,
+    )
+    codegen = SimpleNamespace(
+        current_grid_state=grid,
+        statements_stack=[[], hoist_parent, []],
+        active_device_loops={},
+    )
+    state = SimpleNamespace(codegen=codegen)
+    strategy = SimpleNamespace(
+        _synthetic_cute_lane_var="synthetic_lane_1",
+        _cute_lane_base_index_var="reduction_lane_base_1",
+    )
+    typed_state = cast("Any", state)
+    typed_strategy = cast("Any", strategy)
+
+    assert _persistent_vec_scope_safe(typed_state, typed_strategy, "ptr + outer_lane")
+    assert _persistent_vec_scope_safe(typed_state, typed_strategy, "ptr + outer_alias")
+    assert _persistent_vec_scope_safe(
+        typed_state, typed_strategy, "ptr + indirect_outer_alias"
+    )
+    assert _persistent_vec_scope_safe(
+        typed_state, typed_strategy, "ptr + dominating_value"
+    )
+    assert not _persistent_vec_scope_safe(
+        typed_state, typed_strategy, "ptr + inner_lane"
+    )
+    assert not _persistent_vec_scope_safe(
+        typed_state, typed_strategy, "ptr + inner_alias"
+    )
+    assert not _persistent_vec_scope_safe(
+        typed_state, typed_strategy, "ptr + indirect_inner_alias"
+    )
+
+    nested_parent = ast.parse("parent_value = source.load()").body
+    codegen.statements_stack = [[], hoist_parent, nested_parent, []]
+    assert not _persistent_vec_scope_safe(
+        typed_state, typed_strategy, "ptr + parent_value"
+    )
+
+    for_node = ast.parse("for serial_index in range(4):\n    pass").body[0]
+    codegen.active_device_loops = {
+        0: [SimpleNamespace(for_node=for_node)],
+    }
+    assert not _persistent_vec_scope_safe(
+        typed_state, typed_strategy, "ptr + serial_index"
+    )
+
+
+def test_persistent_reduction_threads_do_not_consume_tile_budget() -> None:
+    spec = ConfigSpec(backend=CuteBackend())
+    spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=64))
+    # Deliberately permute num_threads relative to block_sizes.  Block 1 is a
+    # static persistent reduction and block 2 is a rollable reduction.
+    spec.num_threads.append(NumThreadsSpec(block_id=1, size_hint=128))
+    spec.num_threads.append(NumThreadsSpec(block_id=0, size_hint=64))
+    spec.num_threads.append(NumThreadsSpec(block_id=2, size_hint=512))
+    spec.reduction_loops.append(ReductionLoopSpec(block_id=2, size_hint=512))
+    spec.reduction_block_ids.update((1, 2))
+    config = helion.Config(
+        block_sizes=[64],
+        num_threads=[16, 8, 32],
+        reduction_loops=[None],
+    )
+
+    spec.normalize(config)
+
+    # Only the eight row threads consume the competing CTA budget.  Counting
+    # the persistent reduction's 16 threads as another tile axis would shrink
+    # this loop chunk incorrectly to 8 instead of 128.
+    assert config.config["reduction_loops"] == [128]
+
+
+def test_persistent_loop_rewrites_preserve_constexpr_iterator() -> None:
+    from helion._compiler.tile_strategy import _ChunkRecurrence
+    from helion._compiler.tile_strategy import _create_lane_loop
+    from helion._compiler.tile_strategy import _rewrite_chunk_recurrence
+    from helion._compiler.tile_strategy import (
+        interchange_lane_outside_serial_reductions,
+    )
+
+    lane = _create_lane_loop("lane", 8, [])
+    lane.iter = ast.parse("cutlass.range_constexpr(8)", mode="eval").body
+    serial_loop = ast.parse(
+        """
+for mb in range(2):
+    reduced = _helion_lane_reduce(
+        lane_value, 'sum', cutlass.Float32(0), 32, 1, 0, '', 1
+    )
+    sink.store(reduced)
+"""
+    ).body[0]
+    lane.body = [*ast.parse("lane_value = lane + 1").body, serial_loop]
+    interchanged = interchange_lane_outside_serial_reductions([lane])
+    assert (
+        ast.unparse(
+            ast.Module(body=cast("list[ast.stmt]", interchanged), type_ignores=[])
+        ).count("for lane in cutlass.range_constexpr(8)")
+        == 2
+    )
+
+    recurrence_lane = _create_lane_loop(
+        "lane",
+        8,
+        cast(
+            "list[ast.AST]",
+            ast.parse(
+                """
+partial = lane + acc
+base = acc
+dot_acc = dot_acc + partial
+acc = base + dot_acc
+"""
+            ).body,
+        ),
+    )
+    recurrence_lane.iter = ast.parse("cutlass.range_constexpr(8)", mode="eval").body
+    chunk_loop = ast.parse("for chunk in range(2):\n    pass").body[0]
+    assert isinstance(chunk_loop, ast.For)
+    chunk_loop.body = [recurrence_lane]
+    rewritten = _rewrite_chunk_recurrence(
+        chunk_loop,
+        _ChunkRecurrence(
+            dot_acc_var="dot_acc",
+            lane_idx=0,
+            lane_loop=recurrence_lane,
+            lane_var="lane",
+            sum_idx=2,
+            base_indices=(1,),
+            finalize_indices=(),
+            final_idx=3,
+            state_name="acc",
+        ),
+        ast.parse("dot_acc = 0").body[0],
+        {},
+        {},
+        {},
+    )
+    assert "for lane in cutlass.range_constexpr(8)" in ast.unparse(rewritten)
+
+
+@pytest.mark.parametrize("dependent", (False, True))
+@pytest.mark.parametrize("write_kind", ("store", "atomic"))
+def test_lane_split_rejects_interleaved_aliasing_write(
+    monkeypatch: pytest.MonkeyPatch,
+    dependent: bool,
+    write_kind: str,
+) -> None:
+    from helion import exc
+    from helion._compiler.tile_strategy import _create_lane_loop
+    from helion._compiler.tile_strategy import split_lane_loop_reductions
+
+    monkeypatch.delenv("HELION_FUSER_MODE", raising=False)
+    second_value = "second + reduced_0" if dependent else "second"
+    write = (
+        "(x.iterator + synthetic_lane_7).store(replacement)"
+        if write_kind == "store"
+        else "cute.arch.atomic_add(x.iterator + synthetic_lane_7, replacement)"
+    )
+    loop = _create_lane_loop(
+        "synthetic_lane_7",
+        8,
+        ast.parse(
+            f"""
+first = (x.iterator + synthetic_lane_7).load()
+reduced_0 = _helion_lane_reduce(first, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+{write}
+second = (x.iterator + synthetic_lane_7).load()
+second_input = {second_value}
+reduced_1 = _helion_lane_reduce(second_input, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+sink = reduced_0 + reduced_1
+"""
+        ).body,
+    )
+    with pytest.raises(exc.BackendUnsupported, match="potentially aliasing write"):
+        split_lane_loop_reductions([loop])
+
+
+def test_dependent_lane_split_preserves_invariant_carried_update() -> None:
+    from helion._compiler.tile_strategy import _create_lane_loop
+    from helion._compiler.tile_strategy import split_lane_loop_reductions
+
+    loop = _create_lane_loop(
+        "lane",
+        8,
+        ast.parse(
+            """
+carry_copy = carry
+first = lane + 1
+reduced_0 = _helion_lane_reduce(first, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+second = first + reduced_0
+reduced_1 = _helion_lane_reduce(second, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+next_carry = carry_copy + reduced_1
+"""
+        ).body,
+    )
+
+    split = split_lane_loop_reductions([loop])
+    code = ast.unparse(ast.Module(body=cast("list[ast.stmt]", split), type_ignores=[]))
+
+    assert code.count("for lane in range(8)") == 2
+    assert "reduced_1 = cute.arch.warp_reduction_sum(" in code
+    assert "next_carry = carry_copy + reduced_1" in code
+    assert code.index("reduced_1 =") < code.index("next_carry =")
+
+
+def test_lane_split_keeps_serially_carried_reduction_input_in_order() -> None:
+    from helion._compiler.tile_strategy import _create_lane_loop
+    from helion._compiler.tile_strategy import split_lane_loop_reductions
+
+    loop = _create_lane_loop(
+        "lane",
+        8,
+        ast.parse(
+            """
+acc = cutlass.Float32(0)
+for offset in range(4):
+    acc_copy = acc
+    acc_next = acc_copy + lane + offset
+reduced = _helion_lane_reduce(acc, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+sink.store(reduced)
+"""
+        ).body,
+    )
+
+    split = split_lane_loop_reductions([loop])
+    code = ast.unparse(ast.Module(body=cast("list[ast.stmt]", split), type_ignores=[]))
+
+    assert code.count("for lane in range(8)") == 1
+    assert "for offset in range(4)" in code
+    assert "reduced = acc" in code
+    assert "_lane_acc" not in code
+
+
+@pytest.mark.parametrize("reload_mode", ("register", "gmem"))
+@onlyBackends(["cute"])
+def test_same_tensor_launch_reloads_after_interleaved_store(
+    reload_mode: str,
+) -> None:
+    _alias_sensitive_persistent_sweeps.reset()
+    shared = torch.randn(16, 128, dtype=torch.bfloat16)
+    bound = _alias_sensitive_persistent_sweeps.bind((shared, shared))
+    host_function = bound.host_function
+    assert host_function is not None
+    seed = CutePersistentSubwarpRowsHeuristic.get_seed_config(
+        bound.env, host_function.device_ir
+    )
+    assert seed is not None
+    reduction_block = next(
+        block_id
+        for block_id, block in enumerate(bound.env.block_sizes)
+        if block.reduction
+    )
+    reloads = list(seed.config["cute_reduction_reloads"])
+    reloads[
+        bound.env.config_spec.cute_reduction_reloads.block_id_to_index(reduction_block)
+    ] = reload_mode
+    config = helion.Config.from_dict({**seed.config, "cute_reduction_reloads": reloads})
+
+    with pytest.raises(
+        helion.exc.BackendUnsupported, match="potentially aliasing write"
+    ):
+        bound.to_code(config)
+
+
+def test_lane_split_allows_proven_disjoint_interleaved_write() -> None:
+    from helion._compiler.tile_strategy import _create_lane_loop
+    from helion._compiler.tile_strategy import split_lane_loop_reductions
+
+    loop = _create_lane_loop(
+        "synthetic_lane_7",
+        8,
+        ast.parse(
+            """
+first = (x.iterator + synthetic_lane_7).load()
+reduced_0 = _helion_lane_reduce(first, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+(y.iterator + synthetic_lane_7).store(replacement)
+second = (x.iterator + synthetic_lane_7).load()
+reduced_1 = _helion_lane_reduce(second, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+sink = reduced_0 + reduced_1
+"""
+        ).body,
+    )
+    split = split_lane_loop_reductions(
+        [loop],
+        proven_disjoint_tensor_pairs={frozenset(("x", "y"))},
+    )
+    code = ast.unparse(ast.Module(body=cast("list[ast.stmt]", split), type_ignores=[]))
+
+    assert code.count("for synthetic_lane_7 in range(8)") >= 2
+    assert "_lane_acc" in code
+
+
+@pytest.mark.parametrize("store_shift", (0, 1))
+def test_lane_split_exact_same_lane_state_update(
+    store_shift: int,
+) -> None:
+    from helion._compiler.tile_strategy import _create_lane_loop
+    from helion._compiler.tile_strategy import split_lane_loop_reductions
+
+    store_index = "lane_index" if store_shift == 0 else "lane_index + 1"
+    loop = _create_lane_loop(
+        "synthetic_lane_7",
+        8,
+        ast.parse(
+            f"""
+lane_index = lane_base + cutlass.Int32(synthetic_lane_7)
+loaded = _helion_persistent_branch_vec_load(7, 8, 'cutlass.BFloat16', '', state.iterator + cutlass.Int32(slot) * cutlass.Int32(state.layout.stride[0]) + cutlass.Int32(lane_index) * cutlass.Int32(state.layout.stride[1]), (state.iterator + cutlass.Int32(slot) * cutlass.Int32(state.layout.stride[0]) + cutlass.Int32(lane_index) * cutlass.Int32(state.layout.stride[1])).load())
+partial = cutlass.Float32(loaded) * cutlass.Float32(loaded)
+reduced = _helion_lane_reduce(partial, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+updated = cutlass.Float32(loaded) + reduced
+_helion_persistent_branch_vec_store(7, 8, 'cutlass.BFloat16', state.iterator + cutlass.Int32(slot) * cutlass.Int32(state.layout.stride[0]) + cutlass.Int32({store_index}) * cutlass.Int32(state.layout.stride[1]), cutlass.BFloat16(updated), None)
+"""
+        ).body,
+    )
+    loop.iter = ast.parse("cutlass.range_constexpr(8)", mode="eval").body
+
+    if store_shift:
+        with pytest.raises(
+            helion.exc.BackendUnsupported, match="potentially aliasing write"
+        ):
+            split_lane_loop_reductions([loop])
+        return
+
+    split = split_lane_loop_reductions([loop])
+    code = ast.unparse(ast.Module(body=cast("list[ast.stmt]", split), type_ignores=[]))
+    assert code.count("for synthetic_lane_7 in cutlass.range_constexpr(8)") >= 2
+    assert "reduced_lane_acc" in code
+
+
+@pytest.mark.parametrize(
+    ("pointer_expr", "stride_values"),
+    (
+        ("state.iterator + cutlass.Int32(lane_index)", {}),
+        (
+            "state.iterator + cutlass.Int32(lane_index) * cutlass.Int32(state.layout.stride[1])",
+            {("state", 1): 128},
+        ),
+    ),
+    ids=("literal-unit-step", "specialized-tensor-stride"),
+)
+def test_lane_split_plain_scalar_exact_same_lane_state_update(
+    pointer_expr: str,
+    stride_values: dict[tuple[str, int], int],
+) -> None:
+    from helion._compiler.tile_strategy import _create_lane_loop
+    from helion._compiler.tile_strategy import split_lane_loop_reductions
+
+    loop = _create_lane_loop(
+        "synthetic_lane_7",
+        8,
+        ast.parse(
+            f"""
+lane_index = lane_base + cutlass.Int32(synthetic_lane_7)
+pointer = {pointer_expr}
+loaded = pointer.load()
+partial = cutlass.Float32(loaded) * cutlass.Float32(loaded)
+reduced = _helion_lane_reduce(partial, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+updated = cutlass.Float32(loaded) + reduced
+pointer.store(cutlass.BFloat16(updated))
+"""
+        ).body,
+    )
+
+    split = split_lane_loop_reductions(
+        [loop],
+        proven_tensor_stride_values=stride_values,
+    )
+    code = ast.unparse(ast.Module(body=cast("list[ast.stmt]", split), type_ignores=[]))
+
+    assert code.count("for synthetic_lane_7 in range(8)") >= 2
+    assert "reduced_lane_acc" in code
+
+
+@pytest.mark.parametrize("marked", (False, True), ids=("scalar", "marked"))
+def test_lane_split_allows_row_aligned_dynamic_state_slots(marked: bool) -> None:
+    from helion._compiler.tile_strategy import _create_lane_loop
+    from helion._compiler.tile_strategy import split_lane_loop_reductions
+
+    load_pointer = (
+        "state.iterator + cutlass.Int32(load_slot) * "
+        "cutlass.Int32(state.layout.stride[0]) + "
+        "cutlass.Int32(row) * cutlass.Int32(state.layout.stride[2]) + "
+        "cutlass.Int32(lane_index) * cutlass.Int32(state.layout.stride[3])"
+    )
+    store_pointer = load_pointer.replace("load_slot", "store_slot")
+    load = f"({load_pointer}).load()"
+    store = f"({store_pointer}).store(cutlass.BFloat16(updated))"
+    if marked:
+        load = (
+            "_helion_persistent_branch_vec_load(7, 8, 'cutlass.BFloat16', '', "
+            f"{load_pointer}, {load})"
+        )
+        store = (
+            "_helion_persistent_branch_vec_store(7, 8, "
+            f"'cutlass.BFloat16', {store_pointer}, "
+            "cutlass.BFloat16(updated), None)"
+        )
+    loop = _create_lane_loop(
+        "synthetic_lane_7",
+        8,
+        ast.parse(
+            f"""
+lane_index = lane_base + cutlass.Int32(synthetic_lane_7)
+loaded = {load}
+partial = cutlass.Float32(loaded) * cutlass.Float32(loaded)
+reduced = _helion_lane_reduce(partial, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+updated = cutlass.Float32(loaded) + reduced
+{store}
+"""
+        ).body,
+    )
+    loop.iter = ast.parse("cutlass.range_constexpr(8)", mode="eval").body
+
+    split = split_lane_loop_reductions(
+        [loop],
+        proven_tensor_stride_values={
+            ("state", 0): 524288,
+            ("state", 2): 128,
+            ("state", 3): 1,
+        },
+    )
+    code = ast.unparse(ast.Module(body=cast("list[ast.stmt]", split), type_ignores=[]))
+
+    assert code.count("for synthetic_lane_7 in cutlass.range_constexpr(8)") >= 2
+    assert "reduced_lane_acc" in code
+
+
+def test_lane_split_rejects_dynamic_rows_with_insufficient_stride() -> None:
+    from helion._compiler.tile_strategy import _create_lane_loop
+    from helion._compiler.tile_strategy import split_lane_loop_reductions
+
+    loop = _create_lane_loop(
+        "synthetic_lane_7",
+        8,
+        ast.parse(
+            """
+lane_index = lane_base + cutlass.Int32(synthetic_lane_7)
+loaded = (state.iterator + load_row * state.layout.stride[0] + lane_index).load()
+partial = cutlass.Float32(loaded) * cutlass.Float32(loaded)
+reduced = _helion_lane_reduce(partial, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+updated = cutlass.Float32(loaded) + reduced
+(state.iterator + store_row * state.layout.stride[0] + lane_index).store(updated)
+"""
+        ).body,
+    )
+
+    with pytest.raises(
+        helion.exc.BackendUnsupported, match="potentially aliasing write"
+    ):
+        split_lane_loop_reductions(
+            [loop],
+            proven_tensor_stride_values={("state", 0): 4},
+        )
+
+
+@pytest.mark.parametrize(
+    ("second_pointer", "second_write", "row_stride", "vector_store_count"),
+    (
+        (
+            "state.iterator + second_slot * state.layout.stride[0] + synthetic_lane_7",
+            "_helion_persistent_branch_vec_store(7, 8, 'cutlass.BFloat16', {pointer}, second_value, None)",
+            128,
+            2,
+        ),
+        (
+            "state.iterator + second_slot * state.layout.stride[0] + synthetic_lane_7 + 1",
+            "_helion_persistent_branch_vec_store(7, 8, 'cutlass.BFloat16', {pointer}, second_value, None)",
+            128,
+            0,
+        ),
+        (
+            "state.iterator + second_slot * state.layout.stride[0] + synthetic_lane_7",
+            "_helion_persistent_branch_vec_store(7, 8, 'cutlass.BFloat16', {pointer}, second_value, None)",
+            4,
+            0,
+        ),
+        (
+            "state.iterator + second_slot * state.layout.stride[0] + synthetic_lane_7",
+            "cute.arch.atomic_add({pointer}, second_value)",
+            128,
+            0,
+        ),
+    ),
+    ids=("row-disjoint", "shifted", "insufficient-stride", "atomic"),
+)
+def test_late_vectorizer_store_pairs_fail_closed(
+    second_pointer: str,
+    second_write: str,
+    row_stride: int,
+    vector_store_count: int,
+) -> None:
+    from helion._compiler.cute.persistent_branch_vec import (
+        vectorize_branch_local_persistent_fragments,
+    )
+
+    first_pointer = (
+        "state.iterator + first_slot * state.layout.stride[0] + synthetic_lane_7"
+    )
+    loop = ast.parse(
+        f"""
+for synthetic_lane_7 in cutlass.range_constexpr(8):
+    first_value = cutlass.BFloat16(synthetic_lane_7)
+    _helion_persistent_branch_vec_store(7, 8, 'cutlass.BFloat16', {first_pointer}, first_value, None)
+    second_value = cutlass.BFloat16(synthetic_lane_7 + 1)
+    {second_write.format(pointer=second_pointer)}
+"""
+    ).body
+    transformed = vectorize_branch_local_persistent_fragments(
+        loop,
+        proven_tensor_stride_values={("state", 0): row_stride},
+    )
+    code = ast.unparse(
+        ast.Module(body=cast("list[ast.stmt]", transformed), type_ignores=[])
+    )
+
+    assert code.count("_cute_store_u16_vec") == vector_store_count
+    if vector_store_count == 0:
+        assert "_persistent_branch_store_values" not in code
+
+
+@pytest.mark.parametrize(
+    ("load_pointer", "store_pointer", "write", "stride_values"),
+    (
+        (
+            "state.iterator + lane_index * state.layout.stride[1]",
+            "state.iterator + lane_index * state.layout.stride[1] + 1",
+            "({pointer}).store(updated)",
+            {("state", 1): 128},
+        ),
+        (
+            "state.iterator + lane_index * 0",
+            "state.iterator + lane_index * 0",
+            "({pointer}).store(updated)",
+            {},
+        ),
+        (
+            "state.iterator + lane_index * state.layout.stride[1]",
+            "state.iterator + lane_index * state.layout.stride[1]",
+            "({pointer}).store(updated)",
+            {("state", 1): 0},
+        ),
+        (
+            "state.iterator + cutlass.Int32(lane_index * 1073741824)",
+            "state.iterator + cutlass.Int32(lane_index * 1073741824)",
+            "({pointer}).store(updated)",
+            {},
+        ),
+        (
+            "state.iterator + lane_index // 2",
+            "state.iterator + lane_index // 2",
+            "({pointer}).store(updated)",
+            {},
+        ),
+        (
+            "state.iterator + lane_index * state.layout.stride[1]",
+            "state.iterator + lane_index * state.layout.stride[1]",
+            "({pointer}).store(updated)",
+            {},
+        ),
+        (
+            "base_pointer + lane_index",
+            "base_pointer + lane_index",
+            "({pointer}).store(updated)",
+            {},
+        ),
+        (
+            "state.iterator + lane_index",
+            "state.iterator + lane_index",
+            "cute.arch.atomic_add({pointer}, updated)",
+            {},
+        ),
+        (
+            "state.iterator + lane_index + carried_offset",
+            "state.iterator + lane_index + carried_offset",
+            "({pointer}).store(updated)",
+            {},
+        ),
+    ),
+    ids=(
+        "shifted",
+        "literal-zero-stride",
+        "specialized-zero-stride",
+        "int32-wrapping-stride",
+        "non-injective",
+        "unproven-runtime-stride",
+        "unknown-pointer",
+        "atomic",
+        "loop-carried-base",
+    ),
+)
+def test_lane_split_plain_scalar_same_lane_proof_fails_closed(
+    load_pointer: str,
+    store_pointer: str,
+    write: str,
+    stride_values: dict[tuple[str, int], int],
+) -> None:
+    from helion._compiler.tile_strategy import _create_lane_loop
+    from helion._compiler.tile_strategy import split_lane_loop_reductions
+
+    loop = _create_lane_loop(
+        "synthetic_lane_7",
+        8,
+        ast.parse(
+            f"""
+lane_index = lane_base + cutlass.Int32(synthetic_lane_7)
+{"carried_offset = carried_offset - 1" if "carried_offset" in load_pointer else ""}
+loaded = ({load_pointer}).load()
+partial = cutlass.Float32(loaded) * cutlass.Float32(loaded)
+reduced = _helion_lane_reduce(partial, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+updated = cutlass.Float32(loaded) + reduced
+{write.format(pointer=store_pointer)}
+"""
+        ).body,
+    )
+
+    with pytest.raises(
+        helion.exc.BackendUnsupported, match="potentially aliasing write"
+    ):
+        split_lane_loop_reductions(
+            [loop],
+            proven_tensor_stride_values=stride_values,
+        )
+
+
+def test_lane_split_plain_scalar_rejects_mutated_address_alias() -> None:
+    from helion._compiler.tile_strategy import _create_lane_loop
+    from helion._compiler.tile_strategy import split_lane_loop_reductions
+
+    loop = _create_lane_loop(
+        "synthetic_lane_7",
+        8,
+        ast.parse(
+            """
+lane_index = lane_base + cutlass.Int32(synthetic_lane_7)
+offset = outer_offset
+loaded = (state.iterator + lane_index + offset).load()
+partial = cutlass.Float32(loaded) * cutlass.Float32(loaded)
+reduced = _helion_lane_reduce(partial, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+offset += 1
+updated = cutlass.Float32(loaded) + reduced
+(state.iterator + lane_index + offset).store(updated)
+"""
+        ).body,
+    )
+
+    with pytest.raises(
+        helion.exc.BackendUnsupported, match="potentially aliasing write"
+    ):
+        split_lane_loop_reductions([loop])
+
+
+def test_lane_split_plain_scalar_rejects_mutated_lane_alias() -> None:
+    from helion._compiler.tile_strategy import _create_lane_loop
+    from helion._compiler.tile_strategy import split_lane_loop_reductions
+
+    loop = _create_lane_loop(
+        "synthetic_lane_7",
+        8,
+        ast.parse(
+            """
+lane_index = lane_base + cutlass.Int32(synthetic_lane_7)
+pointer = state.iterator + lane_index
+loaded = pointer.load()
+partial = cutlass.Float32(loaded) * cutlass.Float32(loaded)
+reduced = _helion_lane_reduce(partial, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+pointer += 1
+updated = cutlass.Float32(loaded) + reduced
+pointer.store(updated)
+"""
+        ).body,
+    )
+
+    with pytest.raises(
+        helion.exc.BackendUnsupported, match="potentially aliasing write"
+    ):
+        split_lane_loop_reductions([loop])
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        "lane_index *= 0",
+        "lane_index: int = 0",
+        "lane_index, other = 0, 0",
+        "if predicate:\n    lane_index = 0",
+    ),
+    ids=("augassign", "annotated", "tuple", "conditional"),
+)
+def test_lane_split_plain_scalar_rejects_stale_preload_definition(
+    mutation: str,
+) -> None:
+    from helion._compiler.tile_strategy import _create_lane_loop
+    from helion._compiler.tile_strategy import split_lane_loop_reductions
+
+    source = f"""
+lane_index = lane_base + cutlass.Int32(synthetic_lane_7)
+{mutation}
+loaded = (state.iterator + lane_index).load()
+partial = cutlass.Float32(loaded) * cutlass.Float32(loaded)
+reduced = _helion_lane_reduce(partial, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+updated = cutlass.Float32(loaded) + reduced
+(state.iterator + lane_index).store(updated)
+"""
+    loop = _create_lane_loop("synthetic_lane_7", 8, ast.parse(source).body)
+
+    with pytest.raises(
+        helion.exc.BackendUnsupported, match="potentially aliasing write"
+    ):
+        split_lane_loop_reductions([loop])
+
+
+def test_lane_split_plain_scalar_rejects_captured_shifted_aliases() -> None:
+    from helion._compiler.tile_strategy import _create_lane_loop
+    from helion._compiler.tile_strategy import split_lane_loop_reductions
+
+    loop = _create_lane_loop(
+        "synthetic_lane_7",
+        8,
+        ast.parse(
+            """
+offset = 0
+load_index = synthetic_lane_7 + offset
+offset = 1
+store_index = synthetic_lane_7 + offset
+offset = 2
+loaded = (state.iterator + load_index).load()
+partial = cutlass.Float32(loaded) * cutlass.Float32(loaded)
+reduced = _helion_lane_reduce(partial, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+updated = cutlass.Float32(loaded) + reduced
+(state.iterator + store_index).store(updated)
+"""
+        ).body,
+    )
+
+    with pytest.raises(
+        helion.exc.BackendUnsupported, match="potentially aliasing write"
+    ):
+        split_lane_loop_reductions([loop])
+
+
+@pytest.mark.parametrize(
+    ("initial", "mutation", "load_offset", "store_offset"),
+    (
+        (
+            "offset = 0",
+            "for offset in range(1, 2):\n    pass",
+            "offset",
+            "offset",
+        ),
+        (
+            "holder.value = 0",
+            "holder.value = 1",
+            "holder.value",
+            "holder.value",
+        ),
+        (
+            "holder.value = 0",
+            "alias = holder\nalias.value = 1",
+            "holder.value",
+            "holder.value",
+        ),
+    ),
+    ids=("for-target", "attribute-store", "attribute-store-through-alias"),
+)
+def test_lane_split_plain_scalar_rejects_captured_structured_writes(
+    initial: str,
+    mutation: str,
+    load_offset: str,
+    store_offset: str,
+) -> None:
+    from helion._compiler.tile_strategy import _create_lane_loop
+    from helion._compiler.tile_strategy import split_lane_loop_reductions
+
+    loop = _create_lane_loop(
+        "synthetic_lane_7",
+        8,
+        ast.parse(
+            f"""
+{initial}
+load_index = synthetic_lane_7 + {load_offset}
+{mutation}
+store_index = synthetic_lane_7 + {store_offset}
+loaded = (state.iterator + load_index).load()
+partial = cutlass.Float32(loaded) * cutlass.Float32(loaded)
+reduced = _helion_lane_reduce(partial, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+updated = cutlass.Float32(loaded) + reduced
+(state.iterator + store_index).store(updated)
+"""
+        ).body,
+    )
+
+    with pytest.raises(
+        helion.exc.BackendUnsupported, match="potentially aliasing write"
+    ):
+        split_lane_loop_reductions([loop])
+
+
+def test_lane_split_rejects_exact_store_before_same_lane_load() -> None:
+    from helion._compiler.tile_strategy import _create_lane_loop
+    from helion._compiler.tile_strategy import split_lane_loop_reductions
+
+    loop = _create_lane_loop(
+        "synthetic_lane_7",
+        8,
+        ast.parse(
+            """
+lane_index = lane_base + cutlass.Int32(synthetic_lane_7)
+_helion_persistent_branch_vec_store(7, 8, 'cutlass.BFloat16', state.iterator + lane_index, replacement, None)
+loaded = _helion_persistent_branch_vec_load(7, 8, 'cutlass.BFloat16', '', state.iterator + lane_index, (state.iterator + lane_index).load())
+reduced = _helion_lane_reduce(loaded, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+sink = reduced + loaded
+"""
+        ).body,
+    )
+    loop.iter = ast.parse("cutlass.range_constexpr(8)", mode="eval").body
+
+    with pytest.raises(
+        helion.exc.BackendUnsupported, match="potentially aliasing write"
+    ):
+        split_lane_loop_reductions([loop])
+
+
+@pytest.mark.parametrize("dependent", (False, True))
+@pytest.mark.parametrize("write_kind", ("store", "atomic"))
+@pytest.mark.parametrize("prove_x_y_disjoint", (False, True))
+def test_lane_split_treats_later_write_as_a_backedge_barrier(
+    dependent: bool,
+    write_kind: str,
+    prove_x_y_disjoint: bool,
+) -> None:
+    from helion._compiler.tile_strategy import _create_lane_loop
+    from helion._compiler.tile_strategy import split_lane_loop_reductions
+
+    second_value = "second + reduced_0" if dependent else "second"
+    write = (
+        "(y.iterator + synthetic_lane_7 + 1).store(replacement)"
+        if write_kind == "store"
+        else "cute.arch.atomic_add(y.iterator + synthetic_lane_7 + 1, replacement)"
+    )
+    loop = _create_lane_loop(
+        "synthetic_lane_7",
+        8,
+        ast.parse(
+            f"""
+first = (x.iterator + synthetic_lane_7).load()
+reduced_0 = _helion_lane_reduce(first, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+second = (x.iterator + synthetic_lane_7).load()
+second_input = {second_value}
+reduced_1 = _helion_lane_reduce(second_input, 'sum', cutlass.Float32(0), 16, 1, 0, '', 1, 1)
+{write}
+sink = reduced_0 + reduced_1
+"""
+        ).body,
+    )
+    if not prove_x_y_disjoint:
+        with pytest.raises(
+            helion.exc.BackendUnsupported, match="potentially aliasing write"
+        ):
+            split_lane_loop_reductions([loop])
+        return
+
+    split = split_lane_loop_reductions(
+        [loop],
+        proven_disjoint_tensor_pairs={frozenset(("x", "y"))},
+    )
+    code = ast.unparse(ast.Module(body=cast("list[ast.stmt]", split), type_ignores=[]))
+
+    assert code.count("for synthetic_lane_7 in range(8)") >= 2
+    assert "_lane_acc" in code
+
+
+def test_fallback_setup_dependency_stays_in_innermost_scope() -> None:
+    from helion._compiler.tile_strategy import DeviceGridState
+
+    grid = DeviceGridState(
+        cast("Any", SimpleNamespace(block_ids=[0, 1])),
+        {},
+        lane_loops=[("outer_lane", 2), ("inner_lane", 2)],
+        lane_setup_statements=cast(
+            "list[ast.AST]",
+            ast.parse(
+                """
+fallback = external_value
+dependent = outer_lane + fallback
+"""
+            ).body,
+        ),
+    )
+    wrapped = grid.wrap_body(
+        cast("list[ast.AST]", ast.parse("sink = dependent + inner_lane").body)
+    )
+    code = ast.unparse(
+        ast.Module(body=cast("list[ast.stmt]", wrapped), type_ignores=[])
+    )
+
+    inner = code.index("for inner_lane in range(2)")
+    fallback = code.index("fallback = external_value")
+    dependent = code.index("dependent = outer_lane + fallback")
+    assert inner < fallback < dependent
+
+
+@onlyBackends(["cute"])
+class TestCutePersistentReduction(TestCase):
+    def test_persistent_subwarp_vector_topology(self) -> None:
+        # Exercise a real tail tile: the second CTA has only one live row, so
+        # an unguarded state-vector hoist would read beyond row 16.
+        rows, width = 17, 128
+        state = torch.randn(rows, width, device=DEVICE, dtype=torch.bfloat16)
+        packed_key_query = torch.randn(2 * width, device=DEVICE, dtype=torch.bfloat16)
+        value = torch.randn(rows, device=DEVICE, dtype=torch.bfloat16)
+        state_ref = state.clone().float()
+
+        bound = _persistent_state_update.bind((state, packed_key_query, value))
+        env = bound.env
+        reduction_blocks = [
+            block_id
+            for block_id, block in enumerate(env.block_sizes)
+            if block.reduction
+        ]
+        self.assertEqual(len(reduction_blocks), 1)
+        reduction_block = reduction_blocks[0]
+        tile_blocks = env.config_spec.block_sizes.valid_block_ids()
+        self.assertEqual(len(tile_blocks), 1)
+        tile_block = tile_blocks[0]
+
+        def values_for(spec: object, values: dict[int, object], default: object):
+            return [
+                values.get(block_id, default)
+                for block_id in spec.valid_block_ids()  # type: ignore[attr-defined]
+            ]
+
+        code, (actual, actual_state) = code_and_output(
+            _persistent_state_update,
+            (state, packed_key_query, value),
+            block_sizes=values_for(env.config_spec.block_sizes, {tile_block: 16}, 16),
+            num_threads=values_for(
+                env.config_spec.num_threads,
+                {tile_block: 8, reduction_block: 16},
+                0,
+            ),
+            cute_vector_widths=values_for(
+                env.config_spec.cute_vector_widths,
+                {reduction_block: 8},
+                1,
+            ),
+            cute_lane_layouts=values_for(
+                env.config_spec.cute_lane_layouts,
+                {reduction_block: "blocked"},
+                "blocked",
+            ),
+            cute_reduction_reloads=values_for(
+                env.config_spec.cute_reduction_reloads,
+                {reduction_block: "register"},
+                "auto",
+            ),
+            num_warps=4,
+            num_stages=1,
+            pid_type="flat",
+        )
+
+        key_ref = packed_key_query[:width].float()
+        key_ref *= torch.rsqrt((key_ref * key_ref).sum() + 1e-6)
+        residual = value.float() - (state_ref * key_ref[None, :]).sum(-1)
+        state_ref += residual[:, None] * key_ref[None, :]
+        expected = (
+            (state_ref * packed_key_query[width:].float()[None, :])
+            .sum(-1)
+            .to(state.dtype)
+        )
+        torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(
+            actual_state, state_ref.to(state.dtype), rtol=2e-2, atol=2e-2
+        )
+
+        self.assertIn("block=(16, 8, 1)", code)
+        self.assertIn("threads_in_group=16", code)
+        self.assertGreaterEqual(
+            code.count("ir.VectorType.get([8], cutlass.Uint16.mlir_type)"), 3
+        )
+        self.assertIn("_cute_store_u16_vec", code)
+        self.assertNotIn("_cute_grouped_reduce_shared_two_stage", code)

--- a/test/test_cute_pointwise_vec.py
+++ b/test/test_cute_pointwise_vec.py
@@ -117,6 +117,14 @@ def _div1d_fastmath(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="cute", static_shapes=True)
+def _div1d(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(out.size()):
+        out[tile] = x[tile] / y[tile]
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=True)
 def _add_explicit_evict(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     out = torch.empty_like(x)
     for tile in hl.tile(x.size(0)):
@@ -381,6 +389,14 @@ class TestCutePointwiseVec(TestCase):
         code, out = code_and_output(_div1d_fastmath, (x, y), block_sizes=[1024])
         self.assertIn("cute.math.div", code)
         torch.testing.assert_close(out, x / y, rtol=1e-4, atol=1e-4)
+
+    def test_default_div_does_not_depend_on_torch_fastmath_context(self) -> None:
+        """Default division reads Helion's setting, not a private Torch symbol."""
+        x = torch.randn(2**14, device=DEVICE, dtype=torch.float32)
+        y = torch.rand(2**14, device=DEVICE, dtype=torch.float32) + 0.5
+        code, out = code_and_output(_div1d, (x, y), block_sizes=[1024])
+        self.assertNotIn("cute.math.div", code)
+        torch.testing.assert_close(out, x / y)
 
     def test_seed_eviction_list_sized_from_spec_slots(self) -> None:
         """Regression: a load carrying an explicit ``hl.load(...,

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -531,6 +531,21 @@ class TestReductions(RefEagerTestBase, TestCase):
         # produced a shape mismatch (issue #2643).
         bound = rms_over_arange.bind((qkv,))
         self.assertEqual(bound.env.config_spec.reduction_loops.valid_block_ids(), [])
+        if _get_backend() == "cute":
+            reduction_blocks = [
+                block_id
+                for block_id, block in enumerate(bound.env.block_sizes)
+                if block.reduction
+            ]
+            self.assertEqual(len(reduction_blocks), 1)
+            reduction_block = reduction_blocks[0]
+            for spec in (
+                bound.env.config_spec.num_threads,
+                bound.env.config_spec.cute_vector_widths,
+                bound.env.config_spec.cute_lane_layouts,
+                bound.env.config_spec.cute_reduction_reloads,
+            ):
+                self.assertIn(reduction_block, spec.valid_block_ids())
 
         _code, output = code_and_output(rms_over_arange, (qkv,))
         expected = qkv.to(torch.float32).pow(2).sum(dim=-1)


### PR DESCRIPTION
Stacked PRs:
 * #3591
 * #3590
 * __->__#3589
 * #3588
 * #3587


--- --- ---

### [cutedsl] Add optimized persistent reduction lowering

This adds reusable CuTe lowering support for persistent reductions. It factors
affine reduction expressions, fuses compatible two-pass loads, hoists
lane-invariant work when profitable, vectorizes branch-controlled persistent
loops, and carries the required layout and reload choices through device IR.
The corresponding schedule choices are exposed to the autotuner as knobs and
seeds.

The lowering is selected by structural legality checks rather than a kernel
name or KDA shape. Programs that do not match take a cheap no-op path before
the more expensive analysis, which also keeps unrelated large RNG programs
within their compile-time budget.

#### Latest decode results

These are end-to-end results from the submitted stack head, not an isolated
attribution to this PR.

| Workload | Best tested baseline (µs) | Helion (µs) | Speedup |
| --- | ---: | ---: | ---: |
| Packed B1 H12 vs CAKE | 8.928 | 8.352 | **1.1524×** |
| Packed B256 H12 vs CAKE | 37.664 | 37.664 | **1.0040×** |
| Recurrent T1 B15 H32 vs FlashInfer CuTe | 16.672 | 13.024 | **1.2201×** |
| Speculative T3 N8 H16 vs FlashInfer CuTe | 15.104 | 13.056 | **1.1438×** |

Packed B256 is parity. Measurements use 64 balanced CUDA-graph pairs on GB300,
with cold L2, private mutable state and output, and the matching semantic
baseline for each row. #3587 has the complete protocol.

This is the broadest compiler change in the stack. The important review points
are its legality and fallback boundaries, profitability decisions, and layout
propagation for unrelated CuTe persistent reductions.