### PR TITLE
[cutedsl] Add exact KDA chunk kernels

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 from .common import dedupe_configs
 from .cute import CuteAsyncPersistentSubwarpRowsHeuristic
 from .cute import CuteAsyncStateLoadHeuristic
+from .cute import CuteChunkPrepareHeuristic
+from .cute import CuteChunkRecurrenceHeuristic
 from .cute import CuteFixedTokenRank1Heuristic
 from .cute import CuteFlashAttentionHeuristic
 from .cute import CuteFp8GemmSkinnyMHeuristic
@@ -55,6 +57,8 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
     "cute": (
         CuteAsyncStateLoadHeuristic,
         CuteFp8GemmSkinnyMHeuristic,
+        CuteChunkRecurrenceHeuristic,
+        CuteChunkPrepareHeuristic,
         CuteFlashAttentionHeuristic,
         CutePackedSingleTokenRank1Heuristic,
         CuteFixedTokenRank1Heuristic,

--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -10,6 +10,10 @@ from torch._inductor.runtime.triton_heuristics import (
     get_max_y_grid,  # type: ignore[import-untyped]
 )
 
+from ...autotuner.config_spec import CUTE_CHUNK_PREPARE_SCHEDULE_KEY
+from ...autotuner.config_spec import CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY
+from ...autotuner.config_spec import CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY
+from ...autotuner.config_spec import _cute_chunk_recurrence_config_is_safe
 from ...autotuner.config_spec import get_valid_eviction_policies
 from ...runtime.config import Config
 from ..cute.cutedsl_compat import cp_async_supported
@@ -2746,6 +2750,137 @@ class CuteTcgen05GroupedDynamicBk64Heuristic(AutotunerHeuristic):
         config.config[TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY] = 3
         config.config["tcgen05_ab_stages"] = TCGEN05_GROUPED_DYNAMIC_AB4_STAGE
         return config
+
+
+class CuteChunkRecurrenceHeuristic(AutotunerHeuristic):
+    """Expose legal BT16 recurrence schedules and register caps."""
+
+    name = "cute_chunk_recurrence"
+    backend = "cute"
+    promote_seed_to_default = True
+    PROMOTE_TARGETS = (("cuda", "sm100"), ("cuda", "sm103"))
+    CACHE_SPECIALIZATION_FACTS = frozenset({"config_num_sm", "input_tensor_metadata"})
+
+    @classmethod
+    def register_facts(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> frozenset[CompilerHeuristicSpecializationFact]:
+        from ..cute.chunk_recurrence import _select_sm100_dv_partitions
+        from ..cute.chunk_recurrence import detect_chunk_recurrence_search_geometry
+
+        geometry = detect_chunk_recurrence_search_geometry(device_ir.graphs)
+        capability = env.config_spec.target_device_capability
+        if geometry is None or capability is None or capability[0] != 10:
+            return frozenset()
+        preferred = _select_sm100_dv_partitions(
+            total_chunks=geometry.total_chunks,
+            sequences=geometry.sequences,
+            heads=geometry.heads,
+            num_sm=env.config_spec.num_sm,
+        )
+        env.config_spec.enable_cute_chunk_recurrence_search(
+            preferred_partitions=preferred
+        )
+        return cls.CACHE_SPECIALIZATION_FACTS
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        return (
+            env.config_spec.cute_chunk_recurrence_dv_partitions is not None
+            and env.config_spec.cute_chunk_recurrence_register_cap is not None
+        )
+
+    @classmethod
+    def get_seed_configs(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> list[Config] | None:
+        fragment = env.config_spec.cute_chunk_recurrence_dv_partitions
+        register_cap_fragment = env.config_spec.cute_chunk_recurrence_register_cap
+        if fragment is None or register_cap_fragment is None:
+            return None
+        register_caps = (
+            72,
+            *(
+                cap
+                for cap in register_cap_fragment.choices
+                if cap is not None and cap != 72
+            ),
+            *((None,) if None in register_cap_fragment.choices else ()),
+        )
+        return [
+            Config.from_dict(
+                {
+                    CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY: partitions,
+                    CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY: register_cap,
+                }
+            )
+            for partitions in fragment.choices
+            for register_cap in register_caps
+            if _cute_chunk_recurrence_config_is_safe(partitions, register_cap)
+        ]
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        seeds = cls.get_seed_configs(env, device_ir)
+        return seeds[0] if seeds else None
+
+
+class CuteChunkPrepareHeuristic(AutotunerHeuristic):
+    """Expose exact BT16 prepare schedules with a geometry-derived seed."""
+
+    name = "cute_chunk_prepare"
+    backend = "cute"
+    promote_seed_to_default = True
+    PROMOTE_TARGETS = (("cuda", "sm100"), ("cuda", "sm103"))
+    CACHE_SPECIALIZATION_FACTS = frozenset({"config_num_sm", "input_tensor_metadata"})
+
+    @classmethod
+    def register_facts(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> frozenset[CompilerHeuristicSpecializationFact]:
+        from ..cute.chunk_prepare import preferred_chunk_prepare_schedule
+
+        capability = env.config_spec.target_device_capability
+        host_function = device_ir.host_function
+        if capability is None or capability[0] != 10 or host_function is None:
+            return frozenset()
+        with host_function:
+            preferred_schedule = preferred_chunk_prepare_schedule(
+                device_ir.graphs,
+                env=env,
+                num_sm=env.config_spec.num_sm,
+            )
+        if preferred_schedule is None:
+            return frozenset()
+        env.config_spec.enable_cute_chunk_prepare_schedule_search(
+            preferred_schedule=preferred_schedule
+        )
+        return cls.CACHE_SPECIALIZATION_FACTS
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        return env.config_spec.cute_chunk_prepare_schedule is not None
+
+    @classmethod
+    def get_seed_configs(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> list[Config] | None:
+        fragment = env.config_spec.cute_chunk_prepare_schedule
+        if fragment is None:
+            return None
+        return [
+            Config.from_dict({CUTE_CHUNK_PREPARE_SCHEDULE_KEY: schedule})
+            for schedule in fragment.choices
+        ]
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        seeds = cls.get_seed_configs(env, device_ir)
+        return seeds[0] if seeds else None
 
 
 class CuteFlashAttentionHeuristic(AutotunerHeuristic):

--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -913,6 +913,8 @@ class CuteBackend(Backend):
         tile_strategy: TileStrategyDispatch,
     ) -> None:
         from ..device_function import DeviceFunction
+        from .chunk_prepare import plan_chunk_prepare
+        from .chunk_recurrence import plan_chunk_recurrence
         from .fixed_token_rank1_recurrence import plan_fixed_token_rank1_recurrence
         from .layout_propagation import plan_layouts
         from .single_token_rank1_recurrence import plan_single_token_rank1_recurrence
@@ -921,6 +923,12 @@ class CuteBackend(Backend):
         )
         from .view_subtile import annotate_view_subtiles
 
+        plan_chunk_prepare(graphs, tile_strategy)
+        if DeviceFunction.current().cute_state.chunk_prepare_plan is not None:
+            return
+        plan_chunk_recurrence(graphs, tile_strategy)
+        if DeviceFunction.current().cute_state.chunk_recurrence_plan is not None:
+            return
         plan_single_token_rank1_recurrence(graphs, tile_strategy)
         if DeviceFunction.current().cute_state.single_token_rank1_plan is not None:
             return
@@ -945,6 +953,9 @@ class CuteBackend(Backend):
             or key == "cute_async_store_policy"
             or key == "cute_bf16x2_recurrence"
             or key == "cute_proven_bounds"
+            or key == "cute_chunk_recurrence_dv_partitions"
+            or key == "cute_chunk_recurrence_register_cap"
+            or key == "cute_chunk_prepare_schedule"
             or key == "cute_cluster_n"
             or key == "cute_min_blocks_per_mp"
             or key.startswith(("tcgen05_", "cute_flash_", "cute_async_load_"))
@@ -1839,6 +1850,8 @@ class CuteBackend(Backend):
             return []
 
     def launcher_keyword_args(self, config: Config, *, has_barrier: bool) -> list[str]:
+        from ...autotuner.config_spec import CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY
+        from ...autotuner.config_spec import _cute_chunk_recurrence_config_is_safe
         from ..device_function import DeviceFunction
         from ..host_function import HostFunction
         from .thread_budget import MAX_THREADS_PER_BLOCK
@@ -1861,6 +1874,32 @@ class CuteBackend(Backend):
         def launcher_args_with_compile_options(block_arg: str) -> list[str]:
             launcher_args = [block_arg]
             compile_options: list[str] = []
+            recurrence_register_cap = config.get(CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY)
+            if recurrence_register_cap is not None:
+                recurrence_plan = device_function.cute_state.chunk_recurrence_plan
+                if recurrence_plan is None or type(recurrence_register_cap) is not int:
+                    raise exc.BackendUnsupported(
+                        "cute", "invalid matched recurrence register cap"
+                    )
+                if not _cute_chunk_recurrence_config_is_safe(
+                    recurrence_plan.dv_partitions, recurrence_register_cap
+                ):
+                    raise exc.BackendUnsupported(
+                        "cute",
+                        "register caps are unsafe for the TMEM DV2 recurrence "
+                        "schedule's dynamic register allocation",
+                    )
+                compile_options.append(
+                    "--ptxas-options='--override-directive-values "
+                    f"--maxrregcount={recurrence_register_cap}'"
+                )
+            prepare_plan = device_function.cute_state.chunk_prepare_plan
+            if prepare_plan is not None and prepare_plan.schedule.startswith(
+                "split_alias_cpc"
+            ):
+                compile_options.append(
+                    "--ptxas-options='--override-directive-values --maxrregcount=48'"
+                )
             if config.get(TCGEN05_CUBIN_LINEINFO_CONFIG_KEY) is True:
                 compile_options.append("--generate-line-info")
             # ``--enable-tvm-ffi`` is emitted in codegen only when the
@@ -1912,6 +1951,16 @@ class CuteBackend(Backend):
             )
             return launcher_args_with_compile_options(
                 f"block=({fixed_rank1_threads}, 1, 1)"
+            )
+
+        # The exact chunk-prepare and chunk-recurrence lowerings own their physical
+        # launch topology rather than the carrier's logical tile axes.
+        if device_function.cute_state.chunk_prepare_plan is not None:
+            return launcher_args_with_compile_options("block=(128, 1, 1)")
+        recurrence_plan = device_function.cute_state.chunk_recurrence_plan
+        if recurrence_plan is not None:
+            return launcher_args_with_compile_options(
+                f"block=({recurrence_plan.threads}, 1, 1)"
             )
 
         # Fused tcgen05 flash-attention: 128 threads (single-warpgroup Stage-3)

--- a/helion/_compiler/cute/chunk_prepare.py
+++ b/helion/_compiler/cute/chunk_prepare.py
@@ -1,0 +1,2805 @@
+"""Whole-root lowering for the five-factor BT16 chunk-prepare graph.
+
+The schedule is intentionally narrow and fail closed.  It recognizes the
+semantic graph (including all rounding boundaries and physical output
+permutations), then replaces the complete root with the independently verified
+split-alias CuTe implementation in :mod:`chunk_prepare_split_alias_device`.
+That schedule deliberately overlaps the dead raw Q/K buffers with Qd/Ki; its
+extra release barriers are part of the lifetime proof and are not optional
+variants of the removed unaliased schedule.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+import dataclasses
+import operator
+from typing import TYPE_CHECKING
+from typing import cast
+
+import torch
+
+from ...autotuner.config_spec import CUTE_CHUNK_PREPARE_SCHEDULE_KEY
+from ...language.matmul_ops import dot
+from ..compile_environment import CompileEnvironment
+from .fx_matcher import _canonical_root_axis_ids
+from .fx_matcher import _linear_offsets_fit_i32
+from .fx_matcher import _xyz_grid_fits
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Iterable
+    from collections.abc import Sequence
+
+    import sympy
+    from torch._guards import Source
+
+    from ..device_ir import ForLoopGraphInfo
+    from ..device_ir import GraphInfo
+    from ..generate_ast import GenerateAST
+    from ..tile_dispatch import TileStrategyDispatch
+
+
+_BT = 16
+_DK = 128
+_SEMANTIC_CPC = 4
+_SCHEDULE_CPC_CHOICES = (1, 2, 3, 4, 5)
+_DEFAULT_SPLIT_ALIAS_CPC = 4
+_TARGET_SPLIT_ALIAS_WAVES = 8
+_THREADS = 128
+_SPLIT_ALIAS_SMEM_BYTES = 21_968
+_SPLIT_ALIAS_SCHEDULES = tuple(
+    f"split_alias_cpc{chunks_per_cta}" for chunks_per_cta in _SCHEDULE_CPC_CHOICES
+)
+_VALID_PREPARE_SCHEDULES = _SPLIT_ALIAS_SCHEDULES
+_BF16_MMA_COUNT = 168
+_FP16_MMA_COUNT = 24
+_SCALED_DEVICE_ABI = 3
+_UNSCALED_DEVICE_ABI = 4
+_LOG2_E = 1.4426950408889634
+_PACKED_WORKSPACE_SPECIALIZATION_KEY = "cute_kda_packed_workspace_v1"
+
+
+@dataclasses.dataclass(frozen=True)
+class _TensorRef:
+    fake: torch.Tensor
+    name: str
+
+
+@dataclasses.dataclass(frozen=True)
+class CuteChunkPreparePlan:
+    """Compile-time contract for one exact BT16/K128 prepare root.
+
+    ``device_abi`` versions the callable schedule. Workspace compatibility is
+    described independently by ``outputs_scaled`` and ``factor_key_xor``.
+    """
+
+    root_graph_id: int
+    chunk_size: int
+    key_size: int
+    chunks_per_cta: int
+    schedule: str
+    heads: int
+    total_tokens: int
+    total_chunks: int
+    gate_is_fp32: bool
+    outputs_scaled: bool
+    factor_key_xor: int
+    q: _TensorRef
+    k: _TensorRef
+    gate: _TensorRef
+    beta: _TensorRef
+    a_log: _TensorRef
+    dt_bias: _TensorRef
+    cu_seqlens: _TensorRef
+    cu_chunks: _TensorRef
+    chunk_to_seq: _TensorRef
+    kd: _TensorRef
+    qd: _TensorRef
+    ak: _TensorRef
+    aq: _TensorRef
+    g_total: _TensorRef
+    scale: sympy.Expr
+    gate_scale_log2: sympy.Expr
+    threads: int = _THREADS
+    smem_bytes: int = _SPLIT_ALIAS_SMEM_BYTES
+    bf16_mma_count: int = _BF16_MMA_COUNT
+    fp16_mma_count: int = _FP16_MMA_COUNT
+    device_abi: int = _SCALED_DEVICE_ABI
+
+
+@dataclasses.dataclass(frozen=True)
+class _CuteChunkPrepareMatch:
+    """Exact semantic/storage match shared by planning and autotune gating."""
+
+    root_graph_id: int
+    root_phase_index: int
+    heads: int
+    total_tokens: int
+    total_chunks: int
+    gate_is_fp32: bool
+    outputs_scaled: bool
+    factor_key_xor: int
+    q: _TensorRef
+    k: _TensorRef
+    gate: _TensorRef
+    beta: _TensorRef
+    a_log: _TensorRef
+    dt_bias: _TensorRef
+    cu_seqlens: _TensorRef
+    cu_chunks: _TensorRef
+    chunk_to_seq: _TensorRef
+    kd: _TensorRef
+    qd: _TensorRef
+    ak: _TensorRef
+    aq: _TensorRef
+    g_total: _TensorRef
+    chunk_group_coord: torch.fx.Node
+    head_coord: torch.fx.Node
+    scale: sympy.Expr
+    gate_scale_log2: sympy.Expr
+
+
+def _preferred_split_alias_chunks_per_cta(
+    *, total_chunks: int, heads: int, num_sm: int
+) -> int:
+    """Seed enough chunk grouping to target eight CTA waves.
+
+    This geometry-only seed produces CPC1 for underfilled launches and grows
+    through CPC5 as aggregate work increases. Full autotuning still evaluates
+    every legal split-alias CPC schedule.
+    """
+
+    if total_chunks <= 0 or heads <= 0 or num_sm <= 0:
+        return _DEFAULT_SPLIT_ALIAS_CPC
+    work_items = total_chunks * heads
+    target_capacity = _TARGET_SPLIT_ALIAS_WAVES * num_sm
+    chunks_per_cta = (work_items + target_capacity - 1) // target_capacity
+    return max(
+        _SCHEDULE_CPC_CHOICES[0],
+        min(_SCHEDULE_CPC_CHOICES[-1], chunks_per_cta),
+    )
+
+
+def _static_extent(value: object) -> int | None:
+    import sympy
+
+    from ..host_function import HostFunction
+    from ..variable_origin import AttributeOrigin
+    from ..variable_origin import GlobalOrigin
+
+    if isinstance(value, torch.SymInt):
+        value = value._sympy_()
+    if not isinstance(value, (int, sympy.Expr)):
+        return None
+    if isinstance(value, int):
+        return value
+    env = CompileEnvironment.current()
+    expr = env.specialize_expr(sympy.sympify(value))
+    replacements: dict[sympy.Basic, int] = {}
+    for symbol in expr.free_symbols:
+        origin_info = HostFunction.current().expr_to_origin.get(symbol)
+        if origin_info is None:
+            continue
+        origin = origin_info.origin
+        if isinstance(origin, AttributeOrigin) and isinstance(
+            origin.value, GlobalOrigin
+        ):
+            constant = HostFunction.current().fn.__globals__.get(origin.key)
+            if type(constant) is int:
+                replacements[symbol] = constant
+    if replacements:
+        expr = expr.xreplace(replacements)
+    if getattr(expr, "free_symbols", None):
+        return None
+    try:
+        return int(expr)
+    except TypeError:
+        return None
+
+
+def _static_float(value: object) -> float | None:
+    """Resolve a specialized scalar without accepting a live symbolic value."""
+
+    import sympy
+
+    from ..host_function import HostFunction
+    from ..variable_origin import AttributeOrigin
+    from ..variable_origin import GlobalOrigin
+
+    if isinstance(value, torch.fx.Node):
+        value = value.meta.get("val")
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, torch.SymFloat):
+        value = value._sympy_()
+    if not isinstance(value, sympy.Expr):
+        return None
+    env = CompileEnvironment.current()
+    expr = env.specialize_expr(value)
+    replacements: dict[sympy.Basic, float] = {}
+    for symbol in expr.free_symbols:
+        origin_info = HostFunction.current().expr_to_origin.get(symbol)
+        if origin_info is None:
+            continue
+        origin = origin_info.origin
+        if isinstance(origin, AttributeOrigin) and isinstance(
+            origin.value, GlobalOrigin
+        ):
+            constant = HostFunction.current().fn.__globals__.get(origin.key)
+            if isinstance(constant, (int, float)):
+                replacements[symbol] = float(constant)
+    if replacements:
+        expr = expr.xreplace(replacements)
+    if isinstance(expr, (int, float)):
+        return float(expr)
+    if expr.free_symbols:
+        return None
+    try:
+        return float(expr)
+    except TypeError:
+        return None
+
+
+def _is_call(node: object, target: object) -> bool:
+    return (
+        isinstance(node, torch.fx.Node)
+        and node.op == "call_function"
+        and node.target is target
+    )
+
+
+def _host_tensor_ref(node: object) -> _TensorRef | None:
+    from ...language._tracing_ops import _host_tensor
+
+    if (
+        not isinstance(node, torch.fx.Node)
+        or node.op != "call_function"
+        or node.target is not _host_tensor
+        or not node.args
+        or not isinstance(node.args[0], str)
+    ):
+        return None
+    value = node.meta.get("val")
+    if not isinstance(value, torch.Tensor):
+        return None
+    return _TensorRef(value, node.args[0])
+
+
+def _load_ref(node: object) -> _TensorRef | None:
+    from ...language import memory_ops
+
+    if not _is_call(node, memory_ops.load):
+        return None
+    assert isinstance(node, torch.fx.Node)
+    return _host_tensor_ref(node.args[0] if node.args else None)
+
+
+def _store_ref(node: object) -> _TensorRef | None:
+    from ...language import memory_ops
+
+    if not _is_call(node, memory_ops.store):
+        return None
+    assert isinstance(node, torch.fx.Node)
+    return _host_tensor_ref(node.args[0] if node.args else None)
+
+
+def _ref_key(ref: _TensorRef) -> tuple[int, str]:
+    return id(ref.fake), ref.name
+
+
+def _unique_refs(refs: Iterable[_TensorRef]) -> list[_TensorRef]:
+    result: dict[tuple[int, str], _TensorRef] = {}
+    for ref in refs:
+        result.setdefault(_ref_key(ref), ref)
+    return list(result.values())
+
+
+def _shape(value: torch.Tensor) -> tuple[int, ...] | None:
+    result = tuple(_static_extent(dim) for dim in value.shape)
+    if any(dim is None for dim in result):
+        return None
+    return cast("tuple[int, ...]", result)
+
+
+def _tensor_meta(node: object) -> torch.Tensor | None:
+    if not isinstance(node, torch.fx.Node):
+        return None
+    value = node.meta.get("val")
+    return value if isinstance(value, torch.Tensor) else None
+
+
+def _ancestors(node: object) -> set[torch.fx.Node]:
+    pending = [node]
+    seen: set[torch.fx.Node] = set()
+    while pending:
+        current = pending.pop()
+        if isinstance(current, (list, tuple)):
+            pending.extend(current)
+            continue
+        if not isinstance(current, torch.fx.Node):
+            continue
+        if current in seen:
+            continue
+        seen.add(current)
+        pending.extend(current.all_input_nodes)
+    return seen
+
+
+def _ancestor_ref_keys(node: object) -> set[tuple[int, str]]:
+    return {
+        _ref_key(ref)
+        for ancestor in _ancestors(node)
+        if (ref := _load_ref(ancestor)) is not None
+    }
+
+
+def _strip_value_casts(node: object) -> torch.fx.Node | None:
+    if not isinstance(node, torch.fx.Node):
+        return None
+    current = node
+    passthroughs = {
+        torch.ops.aten.clone.default,
+        torch.ops.aten.detach.default,
+        torch.ops.prims.convert_element_type.default,
+    }
+    for _ in range(16):
+        if current.op != "call_function" or current.target not in passthroughs:
+            return current
+        if not current.args or not isinstance(current.args[0], torch.fx.Node):
+            return None
+        current = current.args[0]
+    return None
+
+
+def _strip_index_broadcast(node: object) -> torch.fx.Node | None:
+    from ...language import view_ops
+
+    if not isinstance(node, torch.fx.Node):
+        return None
+    current = node
+    for _ in range(4):
+        if current.op != "call_function" or current.target is not view_ops.subscript:
+            return current
+        if len(current.args) < 2 or not isinstance(current.args[1], (list, tuple)):
+            return None
+        if any(index is not None and index != slice(None) for index in current.args[1]):
+            return None
+        if not isinstance(current.args[0], torch.fx.Node):
+            return None
+        current = current.args[0]
+    return None
+
+
+def _is_row_broadcast_of(node: object, source: torch.fx.Node) -> bool:
+    from ...language import view_ops
+
+    return bool(
+        isinstance(node, torch.fx.Node)
+        and _is_call(node, view_ops.subscript)
+        and len(node.args) == 2
+        and node.args[0] is source
+        and isinstance(node.args[1], (list, tuple))
+        and tuple(node.args[1]) == (slice(None), None)
+    )
+
+
+def _is_column_broadcast_of(node: object, source: torch.fx.Node) -> bool:
+    from ...language import view_ops
+
+    return bool(
+        isinstance(node, torch.fx.Node)
+        and _is_call(node, view_ops.subscript)
+        and len(node.args) == 2
+        and node.args[0] is source
+        and isinstance(node.args[1], (list, tuple))
+        and tuple(node.args[1]) == (None, slice(None))
+    )
+
+
+def _memory_indices(node: torch.fx.Node) -> tuple[object, ...] | None:
+    if len(node.args) < 2 or not isinstance(node.args[1], (list, tuple)):
+        return None
+    return tuple(node.args[1])
+
+
+def _binary_args(
+    node: object,
+    targets: tuple[object, ...],
+) -> tuple[object, object] | None:
+    if (
+        not isinstance(node, torch.fx.Node)
+        or node.op != "call_function"
+        or node.target not in targets
+        or len(node.args) < 2
+    ):
+        return None
+    return node.args[0], node.args[1]
+
+
+def _scaled_term(node: object, source: torch.fx.Node, scale: int) -> bool:
+    args = _binary_args(node, (operator.mul, torch.ops.aten.mul.Tensor))
+    if args is None:
+        return False
+    for value, constant in (args, reversed(args)):
+        if value is source and _static_extent(constant) == scale:
+            return True
+    return False
+
+
+def _is_transpose_of(node: object, source: torch.fx.Node) -> bool:
+    current = _strip_value_casts(node)
+    if not isinstance(current, torch.fx.Node) or current.op != "call_function":
+        return False
+    if current.target is not torch.ops.aten.permute.default or len(current.args) < 2:
+        return False
+    permutation = current.args[1]
+    return bool(
+        current.args[0] is source
+        and isinstance(permutation, (list, tuple))
+        and tuple(permutation) == (1, 0)
+    )
+
+
+def _has_scalar_xor(node: object, value: int) -> bool:
+    return any(
+        ancestor.op == "call_function"
+        and ancestor.target is torch.ops.aten.bitwise_xor.Scalar
+        and len(ancestor.args) >= 2
+        and ancestor.args[1] == value
+        for ancestor in _ancestors(node)
+    )
+
+
+def _tensor_is_exact_contiguous(ref: _TensorRef, shape: tuple[int, ...]) -> bool:
+    return (
+        _shape(ref.fake) == shape
+        and ref.fake.device.type == "cuda"
+        and ref.fake.is_contiguous()
+    )
+
+
+def _store_value(store: torch.fx.Node) -> torch.fx.Node | None:
+    if len(store.args) < 4 or store.args[3] is not None:
+        return None
+    value = store.args[2]
+    return value if isinstance(value, torch.fx.Node) else None
+
+
+def _is_convert(node: object, source: object, dtype: torch.dtype) -> bool:
+    return bool(
+        isinstance(node, torch.fx.Node)
+        and _is_call(node, torch.ops.prims.convert_element_type.default)
+        and node.args == (source, dtype)
+    )
+
+
+def _roundtrip_source(node: object, storage_dtype: torch.dtype) -> torch.fx.Node | None:
+    if (
+        not isinstance(node, torch.fx.Node)
+        or not _is_call(node, torch.ops.prims.convert_element_type.default)
+        or len(node.args) != 2
+        or node.args[1] is not torch.float32
+    ):
+        return None
+    rounded = node.args[0]
+    if (
+        not isinstance(rounded, torch.fx.Node)
+        or not _is_call(rounded, torch.ops.prims.convert_element_type.default)
+        or len(rounded.args) != 2
+        or rounded.args[1] is not storage_dtype
+        or not isinstance(rounded.args[0], torch.fx.Node)
+    ):
+        return None
+    return rounded.args[0]
+
+
+def _bf16_roundtrip_source(node: object) -> torch.fx.Node | None:
+    return _roundtrip_source(node, torch.bfloat16)
+
+
+def _single_user(
+    source: torch.fx.Node,
+    predicate: Callable[[torch.fx.Node], bool],
+) -> torch.fx.Node | None:
+    matches = [user for user in source.users if predicate(user)]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _zero_scalar(node: object) -> bool:
+    return bool(
+        isinstance(node, torch.fx.Node)
+        and _is_call(node, torch.ops.aten.scalar_tensor.default)
+        and node.args == (0.0,)
+        and node.kwargs.get("dtype") is torch.float32
+    )
+
+
+def _single_bf16_roundtrip(
+    nodes: Sequence[torch.fx.Node], source: torch.fx.Node
+) -> torch.fx.Node | None:
+    matches = [node for node in nodes if _bf16_roundtrip_source(node) is source]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _single_load_for_ref(
+    loads: Sequence[torch.fx.Node], ref: _TensorRef
+) -> torch.fx.Node | None:
+    matches = [
+        node
+        for node in loads
+        if (loaded := _load_ref(node)) is not None and _ref_key(loaded) == _ref_key(ref)
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _dot_signature(node: torch.fx.Node) -> tuple[object, ...] | None:
+    if len(node.args) < 4 or node.args[2] is not None:
+        return None
+    lhs = _tensor_meta(node.args[0])
+    rhs = _tensor_meta(node.args[1])
+    out = _tensor_meta(node)
+    if lhs is None or rhs is None or out is None:
+        return None
+    return (_shape(lhs), lhs.dtype, _shape(rhs), rhs.dtype, _shape(out), out.dtype)
+
+
+def _body_target_counts(
+    gate_is_fp32: bool, *, outputs_scaled: bool = True
+) -> Counter[object]:
+    from ...language import memory_ops
+    from ...language import scan_ops
+    from ...language import view_ops
+    from ...language._tracing_ops import _get_symnode
+    from ...language._tracing_ops import _host_tensor
+    from ...language._tracing_ops import _mask_to
+    from ...language.tile_ops import tile_id
+
+    counts: Counter[object] = Counter(
+        {
+            _host_tensor: 14,
+            _get_symnode: 5,
+            memory_ops.load: 10,
+            torch.ops.prims.convert_element_type.default: (58 if gate_is_fp32 else 59),
+            torch.ops.aten.add.Tensor: 11,
+            torch.ops.aten.sub.Tensor: 2,
+            torch.ops.aten.mul.Tensor: 20,
+            torch.ops.prims.iota.default: 3,
+            torch.ops.aten.lt.Tensor: 1,
+            tile_id: 1,
+            operator.mul: 2,
+            operator.add: 1,
+            view_ops.subscript: 30,
+            torch.ops.aten.tanh.default: 1,
+            torch.ops.aten.scalar_tensor.default: 6,
+            torch.ops.aten.where.self: 7,
+            scan_ops._associative_scan: 1,
+            torch.ops.aten.clamp_min.default: 3,
+            torch.ops.aten.exp2.default: 2,
+            torch.ops.aten.eq.Scalar: 1,
+            _mask_to: 1,
+            torch.ops.aten.sum.dim_IntList: 3,
+            torch.ops.aten.rsqrt.default: 2,
+            torch.ops.aten.full.default: 1,
+            torch.ops.aten.reciprocal.default: 1,
+            torch.ops.aten.sigmoid.default: 1,
+            torch.ops.aten.permute.default: 9,
+            dot: 10,
+            torch.ops.aten.ge.Tensor: 1,
+            torch.ops.aten.gt.Tensor: 1,
+            torch.ops.aten.unsqueeze.default: 6,
+            torch.ops.aten.lt.Scalar: 3,
+            torch.ops.aten.eq.Tensor: 2,
+            torch.ops.aten.ge.Scalar: 1,
+            torch.ops.aten.bitwise_and.Tensor: 1,
+            torch.ops.aten.neg.default: 1,
+            memory_ops.store: 5,
+            torch.ops.aten.bitwise_xor.Scalar: 2,
+            torch.ops.aten.__rshift__.Scalar: 1,
+            torch.ops.aten.bitwise_and.Scalar: 1,
+            torch.ops.aten.__lshift__.Scalar: 1,
+            torch.ops.aten.bitwise_xor.Tensor: 1,
+            torch.ops.aten.div.Tensor_mode: 1,
+        }
+    )
+    if not outputs_scaled:
+        counts.subtract(
+            {
+                _get_symnode: 1,
+                view_ops.subscript: 1,
+                torch.ops.aten.full.default: 1,
+                torch.ops.aten.mul.Tensor: 1,
+                torch.ops.prims.convert_element_type.default: 4,
+            }
+        )
+        counts[torch.ops.aten.bitwise_xor.Scalar] += 2
+    return counts
+
+
+def _single(items: Iterable[object]) -> object | None:
+    values = list(items)
+    return values[0] if len(values) == 1 else None
+
+
+def _aq_pair_index_matches(node: object, token_lane: torch.fx.Node) -> bool:
+    pair_args = _binary_args(node, (torch.ops.aten.div.Tensor_mode,))
+    if (
+        pair_args is None
+        or pair_args[1] != 2
+        or not isinstance(node, torch.fx.Node)
+        or node.kwargs != {"rounding_mode": "floor"}
+    ):
+        return False
+    xor_args = _binary_args(pair_args[0], (torch.ops.aten.bitwise_xor.Tensor,))
+    if xor_args is None:
+        return False
+    byte_offset, shifted = xor_args
+    byte_args = _binary_args(byte_offset, (torch.ops.aten.mul.Tensor,))
+    shifted_args = _binary_args(shifted, (torch.ops.aten.__lshift__.Scalar,))
+    if (
+        byte_args is None
+        or byte_args[1] != 2
+        or shifted_args is None
+        or shifted_args[1] != 4
+    ):
+        return False
+    offset_args = _binary_args(byte_args[0], (torch.ops.aten.add.Tensor,))
+    masked_args = _binary_args(shifted_args[0], (torch.ops.aten.bitwise_and.Scalar,))
+    if offset_args is None or masked_args is None or masked_args[1] != 1:
+        return False
+    row_args = _binary_args(offset_args[0], (torch.ops.aten.mul.Tensor,))
+    storage_col_args = _binary_args(
+        offset_args[1], (torch.ops.aten.bitwise_xor.Scalar,)
+    )
+    shifted_byte_args = _binary_args(
+        masked_args[0], (torch.ops.aten.__rshift__.Scalar,)
+    )
+    return bool(
+        row_args is not None
+        and _is_row_broadcast_of(row_args[0], token_lane)
+        and _static_extent(row_args[1]) == _BT
+        and storage_col_args is not None
+        and _is_column_broadcast_of(storage_col_args[0], token_lane)
+        and storage_col_args[1] == 8
+        and shifted_byte_args == (byte_offset, 7)
+    )
+
+
+def _match_chunk_group_coordinate(
+    loop: ForLoopGraphInfo,
+    loop_predicate: object,
+    loop_extent: torch.fx.Node,
+    total_chunks: int,
+) -> torch.fx.Node | None:
+    """Match ``chunk = group * CPC + local`` and prove both coordinates.
+
+    The replacement schedule reconstructs this affine coordinate instead of
+    executing the carrier loop. Its group and local terms must therefore be
+    the canonical root and inner-loop coordinates, with no hidden offset.
+    """
+
+    from ...language._tracing_ops import _get_symnode
+    from ...language.tile_ops import tile_id
+    from ..host_function import HostFunction
+    from ..variable_origin import BlockSizeOrigin
+    from ..variable_origin import GridOrigin
+    from ..variable_origin import TileIdOrigin
+
+    def exact_binary(
+        node: object,
+        targets: tuple[object, ...],
+    ) -> tuple[object, object] | None:
+        if (
+            not isinstance(node, torch.fx.Node)
+            or node.op != "call_function"
+            or node.target not in targets
+            or len(node.args) != 2
+            or node.kwargs
+        ):
+            return None
+        return node.args[0], node.args[1]
+
+    if len(loop.block_ids) != 1:
+        return None
+    predicate_args = exact_binary(
+        loop_predicate,
+        (operator.lt, torch.ops.aten.lt.Tensor),
+    )
+    if predicate_args is None or _static_extent(predicate_args[1]) != total_chunks:
+        return None
+    chunk_args = exact_binary(
+        predicate_args[0],
+        (operator.add, torch.ops.aten.add.Tensor),
+    )
+    if chunk_args is None:
+        return None
+
+    def origin(node: torch.fx.Node) -> object | None:
+        value = node.meta.get("val")
+        if not isinstance(value, torch.SymInt):
+            return None
+        info = HostFunction.current().expr_to_origin.get(value._sympy_())
+        return info.origin if info is not None else None
+
+    loop_extent_value = loop_extent.meta.get("val")
+    if not isinstance(loop_extent_value, torch.SymInt):
+        return None
+    matches: list[torch.fx.Node] = []
+    for product, local in (chunk_args, reversed(chunk_args)):
+        local_origin = origin(local) if isinstance(local, torch.fx.Node) else None
+        if (
+            not isinstance(local, torch.fx.Node)
+            or not _is_call(local, _get_symnode)
+            or len(local.args) != 1
+            or local.kwargs
+            or type(local_origin) is not GridOrigin
+            or local_origin.block_id != loop.block_ids[0]
+        ):
+            continue
+        product_args = exact_binary(
+            product,
+            (operator.mul, torch.ops.aten.mul.Tensor),
+        )
+        if product_args is None:
+            continue
+        for group, chunks_per_group in (product_args, reversed(product_args)):
+            group_origin = origin(group) if isinstance(group, torch.fx.Node) else None
+            block_size_origin = (
+                origin(group.args[0])
+                if isinstance(group, torch.fx.Node)
+                and group.args
+                and isinstance(group.args[0], torch.fx.Node)
+                else None
+            )
+            chunks_per_group_value = (
+                chunks_per_group.meta.get("val")
+                if isinstance(chunks_per_group, torch.fx.Node)
+                else None
+            )
+            if (
+                not isinstance(group, torch.fx.Node)
+                or not _is_call(group, tile_id)
+                or len(group.args) != 1
+                or group.kwargs
+                or not isinstance(group.args[0], torch.fx.Node)
+                or not isinstance(group_origin, TileIdOrigin)
+                or not isinstance(block_size_origin, BlockSizeOrigin)
+                or block_size_origin.block_id != group_origin.block_id
+                or group_origin.block_id == loop.block_ids[0]
+                or not isinstance(chunks_per_group, torch.fx.Node)
+                or not _is_call(chunks_per_group, _get_symnode)
+                or len(chunks_per_group.args) != 1
+                or chunks_per_group.kwargs
+                or not isinstance(chunks_per_group_value, torch.SymInt)
+                or chunks_per_group_value._sympy_() != loop_extent_value._sympy_()
+                or _static_extent(chunks_per_group_value) != _SEMANTIC_CPC
+            ):
+                continue
+            matches.append(group)
+    return matches[0] if len(matches) == 1 else None
+
+
+def _validate_memory_index_topology(
+    *,
+    loads: Sequence[torch.fx.Node],
+    kd_store: torch.fx.Node,
+    qd_store: torch.fx.Node,
+    ak_store: torch.fx.Node,
+    aq_store: torch.fx.Node,
+    gt_store: torch.fx.Node,
+    q: _TensorRef,
+    k: _TensorRef,
+    gate: _TensorRef,
+    beta: _TensorRef,
+    a_log: _TensorRef,
+    dt_bias: _TensorRef,
+    cu_seqlens: _TensorRef,
+    cu_chunks: _TensorRef,
+    chunk_to_seq: _TensorRef,
+    total_chunks: int,
+    heads: int,
+    loop_predicate: object,
+    factor_key_xor: int,
+) -> bool:
+    if any(len(node.args) != 4 or node.args[3] is not None for node in loads):
+        return False
+    q_load = _single_load_for_ref(loads, q)
+    k_load = _single_load_for_ref(loads, k)
+    gate_load = _single_load_for_ref(loads, gate)
+    beta_load = _single_load_for_ref(loads, beta)
+    dt_load = _single_load_for_ref(loads, dt_bias)
+    a_log_load = _single_load_for_ref(loads, a_log)
+    chunk_to_seq_load = _single_load_for_ref(loads, chunk_to_seq)
+    cu_chunks_load = _single_load_for_ref(loads, cu_chunks)
+    if any(
+        node is None
+        for node in (
+            q_load,
+            k_load,
+            gate_load,
+            beta_load,
+            dt_load,
+            a_log_load,
+            chunk_to_seq_load,
+            cu_chunks_load,
+        )
+    ):
+        return False
+    assert q_load is not None
+    assert k_load is not None
+    assert gate_load is not None
+    assert beta_load is not None
+    assert dt_load is not None
+    assert a_log_load is not None
+    assert chunk_to_seq_load is not None
+    assert cu_chunks_load is not None
+
+    q_indices = _memory_indices(q_load)
+    k_indices = _memory_indices(k_load)
+    gate_indices = _memory_indices(gate_load)
+    beta_indices = _memory_indices(beta_load)
+    dt_indices = _memory_indices(dt_load)
+    a_log_indices = _memory_indices(a_log_load)
+    if any(
+        indices is None
+        for indices in (
+            q_indices,
+            k_indices,
+            gate_indices,
+            beta_indices,
+            dt_indices,
+            a_log_indices,
+        )
+    ):
+        return False
+    assert q_indices is not None
+    assert k_indices is not None
+    assert gate_indices is not None
+    assert beta_indices is not None
+    assert dt_indices is not None
+    assert a_log_indices is not None
+    if not (
+        len(q_indices) == len(k_indices) == len(gate_indices) == 2
+        and len(beta_indices) == 1
+        and len(dt_indices) == 2
+        and len(a_log_indices) == 1
+    ):
+        return False
+    input_row = _strip_index_broadcast(q_indices[0])
+    feature = _strip_index_broadcast(q_indices[1])
+    if input_row is None or feature is None:
+        return False
+    if any(
+        _strip_index_broadcast(indices[0]) is not input_row
+        or _strip_index_broadcast(indices[1]) is not feature
+        for indices in (k_indices, gate_indices)
+    ):
+        return False
+    valid = _strip_index_broadcast(q_load.args[2])
+    if valid is None or any(
+        _strip_index_broadcast(node.args[2]) is not valid
+        for node in (k_load, gate_load)
+    ):
+        return False
+    if (
+        _strip_index_broadcast(beta_indices[0]) is not input_row
+        or _strip_index_broadcast(beta_load.args[2]) is not valid
+        or any(node.args[2] is not None for node in (dt_load, a_log_load))
+    ):
+        return False
+
+    head = _strip_index_broadcast(dt_indices[0])
+    if (
+        head is None
+        or _strip_index_broadcast(dt_indices[1]) is not feature
+        or _strip_index_broadcast(a_log_indices[0]) is not head
+    ):
+        return False
+    input_args = _binary_args(input_row, (operator.add, torch.ops.aten.add.Tensor))
+    if input_args is None:
+        return False
+    # Refuse to infer through a different head coordinate: recover the token
+    # only from the exact ``token * H + head`` form.
+    token = None
+    for product, minor in (input_args, reversed(input_args)):
+        if minor is not head or not isinstance(product, torch.fx.Node):
+            continue
+        product_args = _binary_args(product, (operator.mul, torch.ops.aten.mul.Tensor))
+        if product_args is None:
+            continue
+        for candidate, constant in (product_args, reversed(product_args)):
+            if (
+                isinstance(candidate, torch.fx.Node)
+                and _static_extent(constant) == heads
+            ):
+                token = candidate
+    if token is None:
+        return False
+    valid_args = _binary_args(valid, (operator.lt, torch.ops.aten.lt.Tensor))
+    if valid_args is None or valid_args[0] is not token:
+        return False
+    sequence_end = valid_args[1]
+    token_args = _binary_args(token, (operator.add, torch.ops.aten.add.Tensor))
+    if token_args is None:
+        return False
+    token_lane = next(
+        (
+            value
+            for value in token_args
+            if isinstance(value, torch.fx.Node)
+            and _is_call(value, torch.ops.prims.iota.default)
+            and _static_extent(value.args[0]) == _BT
+        ),
+        None,
+    )
+    if not isinstance(token_lane, torch.fx.Node):
+        return False
+    chunk_begin = token_args[0] if token_args[1] is token_lane else token_args[1]
+
+    kd_indices = _memory_indices(kd_store)
+    qd_indices = _memory_indices(qd_store)
+    ak_indices = _memory_indices(ak_store)
+    aq_indices = _memory_indices(aq_store)
+    gt_indices = _memory_indices(gt_store)
+    if any(
+        indices is None
+        for indices in (kd_indices, qd_indices, ak_indices, aq_indices, gt_indices)
+    ):
+        return False
+    assert kd_indices is not None
+    assert qd_indices is not None
+    assert ak_indices is not None
+    assert aq_indices is not None
+    assert gt_indices is not None
+    if not all(
+        len(indices) == 2
+        for indices in (kd_indices, qd_indices, ak_indices, aq_indices, gt_indices)
+    ):
+        return False
+    factor_row = _strip_index_broadcast(kd_indices[0])
+    kd_feature = _strip_index_broadcast(kd_indices[1])
+    qd_feature = _strip_index_broadcast(qd_indices[1])
+    if factor_key_xor:
+        feature_indices_match = all(
+            _binary_args(index, (torch.ops.aten.bitwise_xor.Scalar,))
+            == (feature, factor_key_xor)
+            for index in (kd_feature, qd_feature)
+        )
+    else:
+        feature_indices_match = kd_feature is feature and qd_feature is feature
+    if (
+        factor_row is None
+        or _strip_index_broadcast(qd_indices[0]) is not factor_row
+        or not feature_indices_match
+        or _strip_index_broadcast(ak_indices[1]) is not feature
+        or _strip_index_broadcast(gt_indices[1]) is not feature
+    ):
+        return False
+    chunk_head = _strip_index_broadcast(aq_indices[0])
+    if chunk_head is None or _strip_index_broadcast(gt_indices[0]) is not chunk_head:
+        return False
+    factor_args = _binary_args(factor_row, (operator.add, torch.ops.aten.add.Tensor))
+    if factor_args is None:
+        return False
+    factor_base = next(
+        (
+            value
+            for value in factor_args
+            if isinstance(value, torch.fx.Node) and _scaled_term(value, chunk_head, _BT)
+        ),
+        None,
+    )
+    if factor_base is None or token_lane not in factor_args:
+        return False
+    ak_row = _strip_index_broadcast(ak_indices[0])
+    ak_args = _binary_args(ak_row, (operator.add, torch.ops.aten.add.Tensor))
+    if ak_args is None or factor_base not in ak_args:
+        return False
+    ak_lane = ak_args[0] if ak_args[1] is factor_base else ak_args[1]
+    ak_lane_args = _binary_args(ak_lane, (torch.ops.aten.bitwise_xor.Scalar,))
+    if ak_lane_args != (token_lane, 8):
+        return False
+    if not _aq_pair_index_matches(aq_indices[1], token_lane):
+        return False
+
+    chunk_head_args = _binary_args(
+        chunk_head, (operator.add, torch.ops.aten.add.Tensor)
+    )
+    if chunk_head_args is None:
+        return False
+    chunk = None
+    for product, minor in (chunk_head_args, reversed(chunk_head_args)):
+        if not isinstance(minor, torch.fx.Node) or not isinstance(
+            product, torch.fx.Node
+        ):
+            continue
+        if _scaled_term(product, head, total_chunks):
+            chunk = minor
+    if chunk is None:
+        return False
+    chunk_indices = _memory_indices(chunk_to_seq_load)
+    if (
+        chunk_indices is None
+        or len(chunk_indices) != 1
+        or chunk_indices[0] is not chunk
+    ):
+        return False
+    sequence = _strip_value_casts(chunk_to_seq_load)
+    # ``_strip_value_casts`` starts at the load. Recover its sole widening user.
+    sequence_users = [
+        user
+        for user in chunk_to_seq_load.users
+        if user.target is torch.ops.prims.convert_element_type.default
+    ]
+    if sequence is not chunk_to_seq_load or len(sequence_users) != 1:
+        return False
+    sequence = sequence_users[0]
+    seq_loads = [
+        node
+        for node in loads
+        if (ref := _load_ref(node)) is not None
+        and _ref_key(ref) == _ref_key(cu_seqlens)
+    ]
+    if len(seq_loads) != 2:
+        return False
+    seq_indices = [_memory_indices(node) for node in seq_loads]
+    if any(indices is None or len(indices) != 1 for indices in seq_indices):
+        return False
+    checked_seq_indices = cast("list[tuple[object, ...]]", seq_indices)
+    sequence_begin_load = next(
+        (
+            node
+            for node, indices in zip(seq_loads, checked_seq_indices, strict=True)
+            if indices[0] is sequence
+        ),
+        None,
+    )
+    sequence_end_load = next(
+        (
+            node
+            for node, indices in zip(seq_loads, checked_seq_indices, strict=True)
+            if (
+                (
+                    index_args := _binary_args(
+                        indices[0], (operator.add, torch.ops.aten.add.Tensor)
+                    )
+                )
+                is not None
+                and sequence in index_args
+                and 1 in index_args
+            )
+        ),
+        None,
+    )
+    cu_chunk_indices = _memory_indices(cu_chunks_load)
+    if (
+        sequence_begin_load is None
+        or sequence_end_load is None
+        or cu_chunk_indices != (sequence,)
+        or _strip_value_casts(sequence_end) is not sequence_end_load
+    ):
+        return False
+    sequence_begin_users = [
+        user
+        for user in sequence_begin_load.users
+        if user.target is torch.ops.prims.convert_element_type.default
+    ]
+    if len(sequence_begin_users) != 1:
+        return False
+    chunk_begin_args = _binary_args(
+        chunk_begin, (operator.add, torch.ops.aten.add.Tensor)
+    )
+    if chunk_begin_args is None or sequence_begin_users[0] not in chunk_begin_args:
+        return False
+    chunk_delta = (
+        chunk_begin_args[0]
+        if chunk_begin_args[1] is sequence_begin_users[0]
+        else chunk_begin_args[1]
+    )
+    delta_args = _binary_args(chunk_delta, (operator.mul, torch.ops.aten.mul.Tensor))
+    if delta_args is None:
+        return False
+    difference = next(
+        (
+            value
+            for value, constant in (delta_args, reversed(delta_args))
+            if isinstance(value, torch.fx.Node) and _static_extent(constant) == _BT
+        ),
+        None,
+    )
+    difference_args = _binary_args(
+        difference, (operator.sub, torch.ops.aten.sub.Tensor)
+    )
+    if difference_args is None or difference_args != (chunk, cu_chunks_load):
+        return False
+
+    predicate_args = _binary_args(
+        loop_predicate, (operator.lt, torch.ops.aten.lt.Tensor)
+    )
+    if predicate_args is None or _static_extent(predicate_args[1]) != total_chunks:
+        return False
+    outer_chunk = (
+        predicate_args[0].meta.get("val")
+        if isinstance(predicate_args[0], torch.fx.Node)
+        else None
+    )
+    inner_chunk = chunk.meta.get("val")
+    return bool(
+        isinstance(outer_chunk, torch.SymInt)
+        and isinstance(inner_chunk, torch.SymInt)
+        and outer_chunk._sympy_() == inner_chunk._sympy_()
+    )
+
+
+def _packed_workspace_is_exact(
+    kd: _TensorRef,
+    qd: _TensorRef,
+    ak: _TensorRef,
+    aq: _TensorRef,
+    g_total: _TensorRef,
+) -> bool:
+    refs = (kd, qd, ak, aq, g_total)
+    storages = [ref.fake.untyped_storage() for ref in refs]
+    if any(storage is not storages[0] for storage in storages[1:]):
+        return False
+    offsets = tuple(ref.fake.storage_offset() * ref.fake.element_size() for ref in refs)
+    vector_bytes = kd.fake.numel() * kd.fake.element_size()
+    aq_bytes = aq.fake.numel() * aq.fake.element_size()
+    workspace_bytes = (
+        3 * vector_bytes + aq_bytes + g_total.fake.numel() * g_total.fake.element_size()
+    )
+    return offsets == (
+        0,
+        vector_bytes,
+        2 * vector_bytes,
+        3 * vector_bytes,
+        3 * vector_bytes + aq_bytes,
+    ) and all(storage.nbytes() >= workspace_bytes for storage in storages)
+
+
+def _packed_workspace_runtime_signature(values: Sequence[object]) -> bool:
+    if len(values) != 5 or any(not isinstance(value, torch.Tensor) for value in values):
+        return False
+    kd, qd, ak, aq, g_total = cast("tuple[torch.Tensor, ...]", tuple(values))
+    refs = tuple(_TensorRef(value, "") for value in (kd, qd, ak, aq, g_total))
+    if not _packed_workspace_is_exact(*refs):
+        return False
+    # Real launch addresses must also satisfy the descriptor's 256-byte base
+    # alignment. FakeTensor has no meaningful device address, so its structural
+    # storage proof is the strongest fact available to compile-only tests.
+    from torch._subclasses import FakeTensor
+
+    return isinstance(kd, FakeTensor) or kd.data_ptr() % 256 == 0
+
+
+def _packed_workspace_sources(
+    env: CompileEnvironment,
+    tensors: Sequence[torch.Tensor],
+) -> tuple[Source, ...] | None:
+    sources: list[Source] = []
+    for fake in tensors:
+        storage_key = fake.untyped_storage()._cdata
+        matches = [
+            source
+            for input_tensor, source in env.input_sources.items()
+            if input_tensor.untyped_storage()._cdata == storage_key
+        ]
+        if len(matches) != 1:
+            return None
+        sources.append(matches[0])
+    return tuple(sources)
+
+
+def _register_packed_workspace_specialization(
+    env: CompileEnvironment,
+    tensors: Sequence[torch.Tensor],
+) -> bool:
+    from ..compile_environment import RuntimeInputSpecialization
+
+    sources = _packed_workspace_sources(env, tensors)
+    if sources is None:
+        return False
+    env.register_runtime_input_specialization(
+        _PACKED_WORKSPACE_SPECIALIZATION_KEY,
+        RuntimeInputSpecialization(
+            sources=sources,
+            classifier_identity=("kda_packed_workspace_v1", tuple(map(repr, sources))),
+            classifier=_packed_workspace_runtime_signature,
+            reusable_tensor_properties=frozenset(("data_ptr", "storage_span")),
+        ),
+    )
+    return True
+
+
+def _packed_workspace_is_proven(env: CompileEnvironment) -> bool:
+    return env.runtime_input_specialization_matches_bound(
+        _PACKED_WORKSPACE_SPECIALIZATION_KEY,
+        True,
+    )
+
+
+def _validate_block_inverse_semantics(
+    lower: torch.fx.Node,
+    inverse: torch.fx.Node,
+    fp16_dots: Sequence[torch.fx.Node],
+) -> bool:
+    """Match the exact two-block FP16 inverse and all six contractions."""
+
+    if len(fp16_dots) != 6 or not _is_convert(
+        inverse,
+        inverse.args[0] if inverse.args else None,
+        torch.bfloat16,
+    ):
+        return False
+    diagonal2, diagonal4, correction2, correction4, first, lower_left = fp16_dots
+
+    def f16(node: object, source: object) -> bool:
+        return _is_convert(node, source, torch.float16)
+
+    def f16_transpose(node: object, source: torch.fx.Node) -> bool:
+        if not isinstance(node, torch.fx.Node) or not _is_convert(
+            node, node.args[0] if node.args else None, torch.float16
+        ):
+            return False
+        transpose = node.args[0]
+        return bool(
+            isinstance(transpose, torch.fx.Node)
+            and _is_call(transpose, torch.ops.aten.permute.default)
+            and transpose.args == (source, [1, 0])
+        )
+
+    diagonal = (
+        diagonal2.args[0].args[0]
+        if isinstance(diagonal2.args[0], torch.fx.Node) and diagonal2.args[0].args
+        else None
+    )
+    if (
+        not isinstance(diagonal, torch.fx.Node)
+        or not f16(diagonal2.args[0], diagonal)
+        or not f16_transpose(diagonal2.args[1], diagonal)
+        or diagonal2.args[2] is not None
+        or not f16(diagonal4.args[0], diagonal2)
+        or not f16_transpose(diagonal4.args[1], diagonal2)
+        or diagonal4.args[2] is not None
+    ):
+        return False
+    if (
+        not _is_call(diagonal, torch.ops.aten.where.self)
+        or diagonal.args[1] is not lower
+        or not _zero_scalar(diagonal.args[2])
+    ):
+        return False
+    same_half = diagonal.args[0]
+    same_half_args = _binary_args(same_half, (torch.ops.aten.eq.Tensor,))
+    if same_half_args is None:
+        return False
+
+    final_where = inverse.args[0]
+    if not isinstance(final_where, torch.fx.Node) or not _is_call(
+        final_where, torch.ops.aten.where.self
+    ):
+        return False
+    lower_half = final_where.args[0]
+    negated_lower_left = final_where.args[1]
+    inverse2 = final_where.args[2]
+    if (
+        not isinstance(negated_lower_left, torch.fx.Node)
+        or not _is_call(negated_lower_left, torch.ops.aten.neg.default)
+        or negated_lower_left.args != (lower_left,)
+        or not isinstance(inverse2, torch.fx.Node)
+    ):
+        return False
+    lower_half_args = _binary_args(lower_half, (torch.ops.aten.bitwise_and.Tensor,))
+    if lower_half_args is None:
+        return False
+
+    def unsqueezed_iota(node: object, dim: int) -> torch.fx.Node | None:
+        if (
+            not isinstance(node, torch.fx.Node)
+            or not _is_call(node, torch.ops.aten.unsqueeze.default)
+            or node.args[1] != dim
+            or not isinstance(node.args[0], torch.fx.Node)
+            or not _is_call(node.args[0], torch.ops.prims.iota.default)
+            or _static_extent(node.args[0].args[0]) != _BT
+        ):
+            return None
+        return node.args[0]
+
+    same_row_args = _binary_args(same_half_args[0], (torch.ops.aten.lt.Scalar,))
+    same_col_args = _binary_args(same_half_args[1], (torch.ops.aten.lt.Scalar,))
+    lower_row_args = _binary_args(lower_half_args[0], (torch.ops.aten.ge.Scalar,))
+    lower_col_args = _binary_args(lower_half_args[1], (torch.ops.aten.lt.Scalar,))
+    if any(
+        args is None or args[1] != 8
+        for args in (same_row_args, same_col_args, lower_row_args, lower_col_args)
+    ):
+        return False
+    assert same_row_args is not None
+    assert same_col_args is not None
+    assert lower_row_args is not None
+    assert lower_col_args is not None
+    inverse_iotas = (
+        unsqueezed_iota(same_row_args[0], 1),
+        unsqueezed_iota(same_col_args[0], 0),
+        unsqueezed_iota(lower_row_args[0], 1),
+        unsqueezed_iota(lower_col_args[0], 0),
+    )
+    if inverse_iotas[0] is None or any(
+        iota is not inverse_iotas[0] for iota in inverse_iotas[1:]
+    ):
+        return False
+    inverse_iota = inverse_iotas[0]
+    assert inverse_iota is not None
+
+    coupling = (
+        first.args[1].args[0].args[0]
+        if isinstance(first.args[1], torch.fx.Node)
+        and first.args[1].args
+        and isinstance(first.args[1].args[0], torch.fx.Node)
+        and first.args[1].args[0].args
+        else None
+    )
+    if (
+        not isinstance(coupling, torch.fx.Node)
+        or not _is_call(coupling, torch.ops.aten.where.self)
+        or coupling.args[0] is not lower_half
+        or coupling.args[1] is not lower
+        or not _zero_scalar(coupling.args[2])
+        or not f16_transpose(first.args[1], coupling)
+    ):
+        return False
+
+    inverse2_args = _binary_args(inverse2, (torch.ops.aten.add.Tensor,))
+    if inverse2_args is None or inverse2_args[1] is not correction4:
+        return False
+    inverse1_f32 = inverse2_args[0]
+    inverse1 = _roundtrip_source(inverse1_f32, torch.float16)
+    if inverse1 is None:
+        return False
+    inverse1_args = _binary_args(inverse1, (torch.ops.aten.add.Tensor,))
+    if inverse1_args is None or inverse1_args[1] is not correction2:
+        return False
+    inverse0_f32 = inverse1_args[0]
+    inverse0 = _roundtrip_source(inverse0_f32, torch.float16)
+    inverse0_args = _binary_args(inverse0, (torch.ops.aten.sub.Tensor,))
+    if inverse0_args is None:
+        return False
+    eye = inverse0_args[0]
+    diagonal_f32 = inverse0_args[1]
+    if (
+        not isinstance(eye, torch.fx.Node)
+        or not _is_convert(
+            eye,
+            eye.args[0] if eye.args else None,
+            torch.float32,
+        )
+        or _roundtrip_source(diagonal_f32, torch.float16) is not diagonal
+    ):
+        return False
+    eye_args = _binary_args(eye.args[0], (torch.ops.aten.eq.Tensor,))
+    if eye_args is None:
+        return False
+    if (
+        unsqueezed_iota(eye_args[0], 1) is not inverse_iota
+        or unsqueezed_iota(eye_args[1], 0) is not inverse_iota
+    ):
+        return False
+
+    if not (
+        f16(correction2.args[0], inverse0)
+        and f16_transpose(correction2.args[1], diagonal2)
+        and correction2.args[2] is None
+        and f16(correction4.args[0], inverse1)
+        and f16_transpose(correction4.args[1], diagonal4)
+        and correction4.args[2] is None
+        and f16(first.args[0], inverse2)
+        and first.args[2] is None
+        and f16(lower_left.args[0], first)
+        and f16_transpose(lower_left.args[1], inverse2)
+        and lower_left.args[2] is None
+    ):
+        return False
+    return all(
+        len(node.args) == 4 and node.args[3] is torch.float32 for node in fp16_dots
+    )
+
+
+def _validate_prepare_semantics(
+    *,
+    body_nodes: Sequence[torch.fx.Node],
+    loads: Sequence[torch.fx.Node],
+    kd_store: torch.fx.Node,
+    qd_store: torch.fx.Node,
+    ak_store: torch.fx.Node,
+    aq_store: torch.fx.Node,
+    gt_store: torch.fx.Node,
+    kk_dot: torch.fx.Node,
+    qk_dot: torch.fx.Node,
+    aq_dot: torch.fx.Node,
+    ak_dot: torch.fx.Node,
+    fp16_dots: Sequence[torch.fx.Node],
+    q: _TensorRef,
+    k: _TensorRef,
+    gate: _TensorRef,
+    beta: _TensorRef,
+    a_log: _TensorRef,
+    dt_bias: _TensorRef,
+    outputs_scaled: bool,
+) -> bool:
+    """Prove every numerically sensitive edge in the prepare carrier."""
+
+    from ...language import scan_ops
+    from ...language._tracing_ops import _get_symnode
+    from ...language._tracing_ops import _mask_to
+
+    q_load = _single_load_for_ref(loads, q)
+    k_load = _single_load_for_ref(loads, k)
+    gate_load = _single_load_for_ref(loads, gate)
+    beta_load = _single_load_for_ref(loads, beta)
+    dt_load = _single_load_for_ref(loads, dt_bias)
+    a_log_load = _single_load_for_ref(loads, a_log)
+    if any(
+        node is None
+        for node in (q_load, k_load, gate_load, beta_load, dt_load, a_log_load)
+    ):
+        return False
+    assert q_load is not None
+    assert k_load is not None
+    assert gate_load is not None
+    assert beta_load is not None
+    assert dt_load is not None
+    assert a_log_load is not None
+
+    q_raw = _single_user(q_load, lambda node: _is_convert(node, q_load, torch.float32))
+    k_raw = _single_user(k_load, lambda node: _is_convert(node, k_load, torch.float32))
+    gate_raw = (
+        gate_load
+        if gate.fake.dtype is torch.float32
+        else _single_user(
+            gate_load, lambda node: _is_convert(node, gate_load, torch.float32)
+        )
+    )
+    beta_f32 = _single_user(
+        beta_load, lambda node: _is_convert(node, beta_load, torch.float32)
+    )
+    if any(value is None for value in (q_raw, k_raw, gate_raw, beta_f32)):
+        return False
+    assert q_raw is not None
+    assert k_raw is not None
+    assert gate_raw is not None
+    assert beta_f32 is not None
+
+    # Pin token validity to every masked activation load and to the gate scan.
+    valid = _strip_index_broadcast(q_load.args[2])
+    if (
+        valid is None
+        or any(
+            _strip_index_broadcast(node.args[2]) is not valid
+            for node in (k_load, gate_load)
+        )
+        or beta_load.args[2] is not valid
+    ):
+        return False
+    valid_args = _binary_args(valid, (torch.ops.aten.lt.Tensor,))
+    if valid_args is None:
+        return False
+    token = valid_args[0]
+    token_args = _binary_args(token, (torch.ops.aten.add.Tensor,))
+    if token_args is None:
+        return False
+    token_lane = next(
+        (
+            value
+            for value in token_args
+            if isinstance(value, torch.fx.Node)
+            and _is_call(value, torch.ops.prims.iota.default)
+            and _static_extent(value.args[0]) == _BT
+        ),
+        None,
+    )
+    if token_lane is None:
+        return False
+
+    gamma = _store_value(gt_store)
+    if (
+        not isinstance(gamma, torch.fx.Node)
+        or not _is_call(gamma, torch.ops.aten.sum.dim_IntList)
+        or gamma.args[1] != [0]
+    ):
+        return False
+    masked_last = gamma.args[0]
+    if (
+        not isinstance(masked_last, torch.fx.Node)
+        or not _is_call(masked_last, _mask_to)
+        or masked_last.args[1] != 0
+    ):
+        return False
+    last_where = masked_last.args[0]
+    if (
+        not isinstance(last_where, torch.fx.Node)
+        or not _is_call(last_where, torch.ops.aten.where.self)
+        or not _zero_scalar(last_where.args[2])
+    ):
+        return False
+    last_condition = _strip_index_broadcast(last_where.args[0])
+    last_args = _binary_args(last_condition, (torch.ops.aten.eq.Scalar,))
+    exp_gate = last_where.args[1]
+    if last_args != (token_lane, _BT - 1) or not _is_call(
+        exp_gate, torch.ops.aten.exp2.default
+    ):
+        return False
+    assert isinstance(exp_gate, torch.fx.Node)
+    clamp = exp_gate.args[0]
+    if (
+        not isinstance(clamp, torch.fx.Node)
+        or not _is_call(clamp, torch.ops.aten.clamp_min.default)
+        or clamp.args[1] != -126.0
+    ):
+        return False
+    gate_prefix = clamp.args[0]
+    if not isinstance(gate_prefix, torch.fx.Node) or not _is_call(
+        gate_prefix, scan_ops._associative_scan
+    ):
+        return False
+    masked_increment = gate_prefix.args[1]
+    if (
+        not isinstance(masked_increment, torch.fx.Node)
+        or not _is_call(masked_increment, torch.ops.aten.where.self)
+        or _strip_index_broadcast(masked_increment.args[0]) is not valid
+        or not _zero_scalar(masked_increment.args[2])
+    ):
+        return False
+    gate_increment = masked_increment.args[1]
+    gate_scale_args = _binary_args(gate_increment, (torch.ops.aten.mul.Tensor,))
+    if gate_scale_args is None or not _is_call(gate_scale_args[1], _get_symnode):
+        return False
+    shifted_sigmoid = gate_scale_args[0]
+    shifted_args = _binary_args(shifted_sigmoid, (torch.ops.aten.add.Tensor,))
+    if shifted_args is None or shifted_args[1] != 0.5:
+        return False
+    tanh_half_args = _binary_args(shifted_args[0], (torch.ops.aten.mul.Tensor,))
+    if tanh_half_args is None or tanh_half_args[1] != 0.5:
+        return False
+    tanh = tanh_half_args[0]
+    if not _is_call(tanh, torch.ops.aten.tanh.default):
+        return False
+    assert isinstance(tanh, torch.fx.Node)
+    tanh_input_args = _binary_args(tanh.args[0], (torch.ops.aten.mul.Tensor,))
+    if tanh_input_args is None or tanh_input_args[1] != 0.5:
+        return False
+    alog_gate_args = _binary_args(tanh_input_args[0], (torch.ops.aten.mul.Tensor,))
+    if alog_gate_args is None:
+        return False
+    a_log_scaled = _single_user(
+        a_log_load,
+        lambda node: (
+            (args := _binary_args(node, (torch.ops.aten.mul.Tensor,))) is not None
+            and any(
+                value is a_log_load and _static_float(scale) == _LOG2_E
+                for value, scale in (args, reversed(args))
+            )
+        ),
+    )
+    if a_log_scaled is None:
+        return False
+    log_decay_scale = _single_user(
+        a_log_scaled,
+        lambda node: (
+            _is_call(node, torch.ops.aten.exp2.default) and node.args == (a_log_scaled,)
+        ),
+    )
+    if log_decay_scale is None:
+        return False
+    gate_bias = next(
+        (
+            maybe_gate_bias
+            for maybe_scale, maybe_gate_bias in (
+                alog_gate_args,
+                tuple(reversed(alog_gate_args)),
+            )
+            if maybe_scale is log_decay_scale
+        ),
+        None,
+    )
+    gate_bias_args = _binary_args(gate_bias, (torch.ops.aten.add.Tensor,))
+    if gate_bias_args is None or gate_bias_args[0] is not gate_raw:
+        return False
+    if _strip_index_broadcast(gate_bias_args[1]) is not dt_load:
+        return False
+
+    def normalized(raw: torch.fx.Node) -> torch.fx.Node | None:
+        square = _single_user(
+            raw,
+            lambda node: (
+                _binary_args(node, (torch.ops.aten.mul.Tensor,))
+                in ((raw, raw), (raw, None))
+            ),
+        )
+        if square is None:
+            return None
+        sum_squares = _single_user(
+            square,
+            lambda node: (
+                _is_call(node, torch.ops.aten.sum.dim_IntList)
+                and node.args == (square, [-1])
+            ),
+        )
+        if sum_squares is None:
+            return None
+        floor = _single_user(
+            sum_squares,
+            lambda node: (
+                _is_call(node, torch.ops.aten.clamp_min.default)
+                and node.args == (sum_squares, 1.0e-24)
+            ),
+        )
+        if floor is None:
+            return None
+        inverse = _single_user(
+            floor,
+            lambda node: (
+                _is_call(node, torch.ops.aten.rsqrt.default) and node.args == (floor,)
+            ),
+        )
+        if inverse is None:
+            return None
+        return _single_user(
+            raw,
+            lambda node: (
+                (args := _binary_args(node, (torch.ops.aten.mul.Tensor,))) is not None
+                and args[0] is raw
+                and _strip_index_broadcast(args[1]) is inverse
+            ),
+        )
+
+    q_norm_product = normalized(q_raw)
+    k_norm = normalized(k_raw)
+    if q_norm_product is None or k_norm is None:
+        return False
+    q_norm = _single_bf16_roundtrip(body_nodes, q_norm_product)
+    exp_gate_bf16 = _single_bf16_roundtrip(body_nodes, exp_gate)
+    k_norm_bf16 = _single_bf16_roundtrip(body_nodes, k_norm)
+    if q_norm is None or exp_gate_bf16 is None or k_norm_bf16 is None:
+        return False
+
+    kd_product = _single(
+        node
+        for node in body_nodes
+        if _binary_args(node, (torch.ops.aten.mul.Tensor,))
+        == (k_norm_bf16, exp_gate_bf16)
+    )
+    kd_value = (
+        _single_bf16_roundtrip(body_nodes, kd_product)
+        if isinstance(kd_product, torch.fx.Node)
+        else None
+    )
+    reciprocal = _single_user(
+        exp_gate,
+        lambda node: (
+            _is_call(node, torch.ops.aten.reciprocal.default)
+            and node.args == (exp_gate,)
+        ),
+    )
+    ki_product = (
+        _single(
+            node
+            for node in body_nodes
+            if _binary_args(node, (torch.ops.aten.mul.Tensor,)) == (k_norm, reciprocal)
+        )
+        if reciprocal is not None
+        else None
+    )
+    ki_value = (
+        _single_bf16_roundtrip(body_nodes, ki_product)
+        if isinstance(ki_product, torch.fx.Node)
+        else None
+    )
+    qd_product = _single(
+        node
+        for node in body_nodes
+        if _binary_args(node, (torch.ops.aten.mul.Tensor,)) == (q_norm, exp_gate_bf16)
+    )
+    qd_unscaled = (
+        _single_bf16_roundtrip(body_nodes, qd_product)
+        if isinstance(qd_product, torch.fx.Node)
+        else None
+    )
+    if any(value is None for value in (kd_value, ki_value, qd_unscaled)):
+        return False
+
+    qd_value = qd_unscaled
+    if outputs_scaled:
+        full_nodes = [
+            node for node in body_nodes if _is_call(node, torch.ops.aten.full.default)
+        ]
+        if (
+            len(full_nodes) != 1
+            or full_nodes[0].args[0] != [_BT]
+            or not _is_call(full_nodes[0].args[1], _get_symnode)
+        ):
+            return False
+        scale_bf16 = _single_bf16_roundtrip(body_nodes, full_nodes[0])
+        scaled_qd = (
+            _single(
+                node
+                for node in body_nodes
+                if scale_bf16 is not None
+                and (args := _binary_args(node, (torch.ops.aten.mul.Tensor,)))
+                is not None
+                and args[0] is qd_unscaled
+                and _strip_index_broadcast(args[1]) is scale_bf16
+            )
+            if scale_bf16 is not None
+            else None
+        )
+        qd_value = (
+            _single_bf16_roundtrip(body_nodes, scaled_qd)
+            if isinstance(scaled_qd, torch.fx.Node)
+            else None
+        )
+    if not isinstance(qd_value, torch.fx.Node):
+        return False
+
+    kd_stored = _store_value(kd_store)
+    qd_stored = _store_value(qd_store)
+    ak_stored = _store_value(ak_store)
+    aq_stored = _store_value(aq_store)
+    if not _is_convert(kd_stored, kd_value, torch.bfloat16) or not _is_convert(
+        qd_stored, qd_value, torch.bfloat16
+    ):
+        return False
+
+    def bf16_operand(node: object, source: object) -> bool:
+        return _is_convert(node, source, torch.bfloat16)
+
+    def bf16_transpose(node: object, source: object) -> bool:
+        if not isinstance(node, torch.fx.Node) or not _is_convert(
+            node, node.args[0] if node.args else None, torch.bfloat16
+        ):
+            return False
+        transpose = node.args[0]
+        return bool(
+            isinstance(transpose, torch.fx.Node)
+            and _is_call(transpose, torch.ops.aten.permute.default)
+            and transpose.args == (source, [1, 0])
+        )
+
+    if not (
+        bf16_operand(kk_dot.args[0], kd_value)
+        and bf16_transpose(kk_dot.args[1], ki_value)
+        and bf16_operand(qk_dot.args[0], qd_value)
+        and bf16_transpose(qk_dot.args[1], ki_value)
+        and kk_dot.args[2] is qk_dot.args[2] is None
+    ):
+        return False
+
+    beta_value = _single_user(
+        beta_f32,
+        lambda node: (
+            _is_call(node, torch.ops.aten.sigmoid.default) and node.args == (beta_f32,)
+        ),
+    )
+    if beta_value is None:
+        return False
+    kk_scaled = _single(
+        node
+        for node in body_nodes
+        if (args := _binary_args(node, (torch.ops.aten.mul.Tensor,))) is not None
+        and args[0] is kk_dot
+        and _strip_index_broadcast(args[1]) is beta_value
+    )
+    lower = (
+        _single(
+            node
+            for node in body_nodes
+            if isinstance(kk_scaled, torch.fx.Node)
+            and _is_call(node, torch.ops.aten.where.self)
+            and node.args[1] is kk_scaled
+            and _zero_scalar(node.args[2])
+        )
+        if kk_scaled is not None
+        else None
+    )
+    if not isinstance(lower, torch.fx.Node):
+        return False
+    strict = lower.args[0]
+    strict_args = _binary_args(strict, (torch.ops.aten.gt.Tensor,))
+    if (
+        strict_args is None
+        or not _is_row_broadcast_of(strict_args[0], token_lane)
+        or not _is_column_broadcast_of(strict_args[1], token_lane)
+    ):
+        return False
+
+    inverse_beta = aq_dot.args[1]
+    if not isinstance(inverse_beta, torch.fx.Node) or not _is_convert(
+        inverse_beta,
+        inverse_beta.args[0] if inverse_beta.args else None,
+        torch.bfloat16,
+    ):
+        return False
+    inverse_beta_product = inverse_beta.args[0]
+    inverse_beta_args = _binary_args(inverse_beta_product, (torch.ops.aten.mul.Tensor,))
+    if inverse_beta_args is None:
+        return False
+    inverse_f32 = inverse_beta_args[0]
+    if (
+        not isinstance(inverse_f32, torch.fx.Node)
+        or not _is_call(inverse_f32, torch.ops.prims.convert_element_type.default)
+        or inverse_f32.args[1] is not torch.float32
+    ):
+        return False
+    inverse = inverse_f32.args[0]
+    if not _is_convert(
+        inverse,
+        inverse.args[0] if isinstance(inverse, torch.fx.Node) else None,
+        torch.bfloat16,
+    ):
+        return False
+    if not isinstance(inverse, torch.fx.Node) or not _validate_block_inverse_semantics(
+        lower,
+        inverse,
+        fp16_dots,
+    ):
+        return False
+    rounded_beta = inverse_beta_args[1]
+    rounded_beta_source = _bf16_roundtrip_source(rounded_beta)
+    if (
+        rounded_beta_source is None
+        or _strip_index_broadcast(rounded_beta_source) is not beta_value
+    ):
+        return False
+
+    qk_masked = aq_dot.args[0]
+    if not isinstance(qk_masked, torch.fx.Node) or not _is_convert(
+        qk_masked, qk_masked.args[0] if qk_masked.args else None, torch.bfloat16
+    ):
+        return False
+    causal_where = qk_masked.args[0]
+    if (
+        not isinstance(causal_where, torch.fx.Node)
+        or not _is_call(causal_where, torch.ops.aten.where.self)
+        or causal_where.args[1] is not qk_dot
+        or not _zero_scalar(causal_where.args[2])
+    ):
+        return False
+    causal_args = _binary_args(causal_where.args[0], (torch.ops.aten.ge.Tensor,))
+    if (
+        causal_args is None
+        or not _is_row_broadcast_of(causal_args[0], token_lane)
+        or not _is_column_broadcast_of(causal_args[1], token_lane)
+    ):
+        return False
+    if aq_dot.args[2] is not None or not _is_convert(aq_stored, aq_dot, torch.bfloat16):
+        return False
+
+    gamma_broadcast = _single(
+        node
+        for node in body_nodes
+        if _strip_index_broadcast(node) is gamma and node is not gamma
+    )
+    gamma_bf16 = (
+        _single_bf16_roundtrip(body_nodes, gamma_broadcast)
+        if isinstance(gamma_broadcast, torch.fx.Node)
+        else None
+    )
+    kg_product = _single(
+        node
+        for node in body_nodes
+        if gamma_bf16 is not None
+        and _binary_args(node, (torch.ops.aten.mul.Tensor,)) == (ki_value, gamma_bf16)
+    )
+    kg = (
+        _single_user(
+            cast("torch.fx.Node", kg_product),
+            lambda node: _is_convert(node, kg_product, torch.bfloat16),
+        )
+        if isinstance(kg_product, torch.fx.Node)
+        else None
+    )
+    if (
+        kg is None
+        or not _is_transpose_of(ak_dot.args[0], inverse_beta)
+        or ak_dot.args[1] is not kg
+        or ak_dot.args[2] is not None
+        or not _is_convert(ak_stored, ak_dot, torch.bfloat16)
+    ):
+        return False
+    return all(
+        len(node.args) == 4 and node.args[2] is None and node.args[3] is torch.float32
+        for node in (kk_dot, qk_dot, aq_dot, ak_dot, *fp16_dots)
+    )
+
+
+def _match_chunk_prepare_graphs(
+    graphs: Sequence[GraphInfo],
+) -> _CuteChunkPrepareMatch | None:
+    import sympy
+
+    from ...language import scan_ops
+    from ...language._tracing_ops import _for_loop
+    from ...language._tracing_ops import _get_symnode
+    from ...language._tracing_ops import _if
+    from ..device_ir import ElseGraphInfo
+    from ..device_ir import ForLoopGraphInfo
+    from ..device_ir import HelperFunctionGraphInfo
+    from ..device_ir import IfGraphInfo
+    from ..device_ir import RootGraphInfo
+
+    roots = [graph for graph in graphs if isinstance(graph, RootGraphInfo)]
+    loops = [graph for graph in graphs if isinstance(graph, ForLoopGraphInfo)]
+    ifs = [graph for graph in graphs if isinstance(graph, IfGraphInfo)]
+    elses = [graph for graph in graphs if isinstance(graph, ElseGraphInfo)]
+    helpers = [graph for graph in graphs if isinstance(graph, HelperFunctionGraphInfo)]
+    if not (
+        len(graphs) == 5
+        and len(roots) == len(loops) == len(ifs) == len(elses) == len(helpers) == 1
+    ):
+        return None
+    root_info, loop_info, if_info, else_info, helper_info = (
+        roots[0],
+        loops[0],
+        ifs[0],
+        elses[0],
+        helpers[0],
+    )
+    root_calls = [node for node in root_info.graph.nodes if node.op == "call_function"]
+    if len(root_calls) != 2 or not _is_call(root_calls[1], _for_loop):
+        return None
+    loop_call = root_calls[1]
+    if (
+        not loop_call.args
+        or loop_call.args[0] != loop_info.graph_id
+        or len(loop_call.args) < 4
+        or loop_call.args[1] != [0]
+        or not isinstance(loop_call.args[2], list)
+        or len(loop_call.args[2]) != 1
+        or not isinstance(loop_call.args[2][0], torch.fx.Node)
+        or _static_extent(loop_call.args[2][0].meta.get("val")) != _SEMANTIC_CPC
+        or loop_call.args[3] != []
+        or len(loop_info.block_ids) != 1
+    ):
+        return None
+    loop_calls = [node for node in loop_info.graph.nodes if node.op == "call_function"]
+    if_calls = [node for node in loop_calls if node.target is _if]
+    if len(if_calls) != 1:
+        return None
+    if_call = if_calls[0]
+    if (
+        len(if_call.args) < 5
+        or if_call.args[1] != if_info.graph_id
+        or if_call.args[2] != else_info.graph_id
+        or if_call.args[3] != []
+        or if_call.args[4] != []
+        or list(else_info.graph.nodes)[-1].op != "output"
+        or len(list(else_info.graph.nodes)) != 1
+    ):
+        return None
+    helper_nodes = list(helper_info.graph.nodes)
+    helper_calls = [node for node in helper_nodes if node.op == "call_function"]
+    helper_placeholders = [node for node in helper_nodes if node.op == "placeholder"]
+    helper_outputs = [node for node in helper_nodes if node.op == "output"]
+    if (
+        len(helper_nodes) != 4
+        or len(helper_placeholders) != 2
+        or len(helper_calls) != 1
+        or helper_calls[0].target is not torch.ops.aten.add.Tensor
+        or helper_calls[0].args != tuple(helper_placeholders)
+        or len(helper_outputs) != 1
+        or helper_outputs[0].args != (helper_calls[0],)
+    ):
+        return None
+
+    body_nodes = list(if_info.graph.nodes)
+    stores = [node for node in body_nodes if _store_ref(node) is not None]
+    loads = [node for node in body_nodes if _load_ref(node) is not None]
+    dots = [node for node in body_nodes if _is_call(node, dot)]
+    if len(stores) != 5 or len(loads) != 10 or len(dots) != 10:
+        return None
+    if any(_store_value(store) is None for store in stores):
+        return None
+
+    # First classify outputs by their write value and physical index image.
+    gt_store = _single(
+        store
+        for store in stores
+        if (value := _store_value(store)) is not None
+        and (meta := _tensor_meta(value)) is not None
+        and _shape(meta) == (_DK,)
+        and meta.dtype is torch.float32
+    )
+    aq_store = _single(
+        store
+        for store in stores
+        if (ref := _store_ref(store)) is not None
+        and ref.fake.dtype is torch.bfloat16
+        and (shape := _shape(ref.fake)) is not None
+        and len(shape) == 2
+        and shape[-1] == _BT * _BT
+        and (value := _store_value(store)) is not None
+        and (meta := _tensor_meta(value)) is not None
+        and _shape(meta) == (_BT, _BT)
+        and _has_scalar_xor(store.args[1], 8)
+    )
+    vector_stores = [
+        store
+        for store in stores
+        if (ref := _store_ref(store)) is not None
+        and ref.fake.dtype is torch.bfloat16
+        and (shape := _shape(ref.fake)) is not None
+        and len(shape) == 2
+        and shape[-1] == _DK
+        and (value := _store_value(store)) is not None
+        and (meta := _tensor_meta(value)) is not None
+        and _shape(meta) == (_BT, _DK)
+    ]
+    if not isinstance(gt_store, torch.fx.Node) or not isinstance(
+        aq_store, torch.fx.Node
+    ):
+        return None
+    if len(vector_stores) != 3:
+        return None
+    ak_store = _single(
+        store
+        for store in vector_stores
+        if (indices := _memory_indices(store)) is not None
+        and _has_scalar_xor(indices[0], 8)
+    )
+    regular_vector_stores = [store for store in vector_stores if store is not ak_store]
+    if not isinstance(ak_store, torch.fx.Node) or len(regular_vector_stores) != 2:
+        return None
+
+    long_dots = [
+        node
+        for node in dots
+        if _dot_signature(node)
+        == (
+            (_BT, _DK),
+            torch.bfloat16,
+            (_DK, _BT),
+            torch.bfloat16,
+            (_BT, _BT),
+            torch.float32,
+        )
+    ]
+    fp16_dots = [
+        node
+        for node in dots
+        if _dot_signature(node)
+        == (
+            (_BT, _BT),
+            torch.float16,
+            (_BT, _BT),
+            torch.float16,
+            (_BT, _BT),
+            torch.float32,
+        )
+    ]
+    aq_dots = [
+        node
+        for node in dots
+        if _dot_signature(node)
+        == (
+            (_BT, _BT),
+            torch.bfloat16,
+            (_BT, _BT),
+            torch.bfloat16,
+            (_BT, _BT),
+            torch.float32,
+        )
+    ]
+    ak_dots = [
+        node
+        for node in dots
+        if _dot_signature(node)
+        == (
+            (_BT, _BT),
+            torch.bfloat16,
+            (_BT, _DK),
+            torch.bfloat16,
+            (_BT, _DK),
+            torch.float32,
+        )
+    ]
+    if not (
+        len(long_dots) == 2
+        and len(fp16_dots) == 6
+        and len(aq_dots) == 1
+        and len(ak_dots) == 1
+    ):
+        return None
+    if any(len(node.args) < 4 or node.args[3] is not torch.float32 for node in dots):
+        return None
+    aq_dot, ak_dot = aq_dots[0], ak_dots[0]
+    aq_value = _store_value(aq_store)
+    ak_value = _store_value(ak_store)
+    if (
+        _strip_value_casts(aq_value) is not aq_dot
+        or _strip_value_casts(ak_value) is not ak_dot
+        or not isinstance(aq_dot.args[1], torch.fx.Node)
+        or not _is_transpose_of(ak_dot.args[0], aq_dot.args[1])
+    ):
+        return None
+
+    store_to_dot: dict[torch.fx.Node, torch.fx.Node] = {}
+    for store in regular_vector_stores:
+        value_root = _strip_value_casts(_store_value(store))
+        matched = [
+            candidate
+            for candidate in long_dots
+            if _strip_value_casts(candidate.args[0]) is value_root
+        ]
+        if len(matched) != 1:
+            return None
+        store_to_dot[store] = matched[0]
+    kd_store = _single(
+        store
+        for store, candidate in store_to_dot.items()
+        if any(user.target is torch.ops.aten.mul.Tensor for user in candidate.users)
+    )
+    qd_store = _single(
+        store
+        for store, candidate in store_to_dot.items()
+        if any(user.target is torch.ops.aten.where.self for user in candidate.users)
+    )
+    if not isinstance(kd_store, torch.fx.Node) or not isinstance(
+        qd_store, torch.fx.Node
+    ):
+        return None
+    kk_dot, qk_dot = store_to_dot[kd_store], store_to_dot[qd_store]
+    kk_mul = _single(
+        user for user in kk_dot.users if user.target is torch.ops.aten.mul.Tensor
+    )
+    qk_where = _single(
+        user for user in qk_dot.users if user.target is torch.ops.aten.where.self
+    )
+    if not isinstance(kk_mul, torch.fx.Node) or not isinstance(qk_where, torch.fx.Node):
+        return None
+    kk_lower = _single(
+        user for user in kk_mul.users if user.target is torch.ops.aten.where.self
+    )
+    if (
+        not isinstance(kk_lower, torch.fx.Node)
+        or not _is_call(kk_lower.args[0], torch.ops.aten.gt.Tensor)
+        or not _is_call(qk_where.args[0], torch.ops.aten.ge.Tensor)
+        or _strip_value_casts(aq_dot.args[0]) is not qk_where
+    ):
+        return None
+
+    kd = cast("_TensorRef", _store_ref(kd_store))
+    qd = cast("_TensorRef", _store_ref(qd_store))
+    ak = cast("_TensorRef", _store_ref(ak_store))
+    aq = cast("_TensorRef", _store_ref(aq_store))
+    g_total = cast("_TensorRef", _store_ref(gt_store))
+
+    load_refs = _unique_refs(cast("_TensorRef", _load_ref(node)) for node in loads)
+    a_log = cast(
+        "_TensorRef | None",
+        _single(
+            ref
+            for ref in load_refs
+            if ref.fake.dtype is torch.float32
+            and (shape := _shape(ref.fake)) is not None
+            and len(shape) == 1
+        ),
+    )
+    if a_log is None or (a_shape := _shape(a_log.fake)) is None:
+        return None
+    heads = a_shape[0]
+    dt_bias = cast(
+        "_TensorRef | None",
+        _single(
+            ref
+            for ref in load_refs
+            if ref.fake.dtype is torch.float32 and _shape(ref.fake) == (heads, _DK)
+        ),
+    )
+    beta = cast(
+        "_TensorRef | None",
+        _single(
+            ref
+            for ref in load_refs
+            if ref.fake.dtype is torch.bfloat16
+            and (shape := _shape(ref.fake)) is not None
+            and len(shape) == 1
+        ),
+    )
+    if dt_bias is None or beta is None or (beta_shape := _shape(beta.fake)) is None:
+        return None
+    if heads <= 0 or beta_shape[0] % heads:
+        return None
+    total_tokens = beta_shape[0] // heads
+    activation_refs = [
+        ref
+        for ref in load_refs
+        if ref.fake.dtype in (torch.bfloat16, torch.float32)
+        and _shape(ref.fake) == (total_tokens * heads, _DK)
+        and _ref_key(ref) != _ref_key(dt_bias)
+    ]
+    if len(activation_refs) != 3:
+        return None
+    activation_keys = {_ref_key(ref): ref for ref in activation_refs}
+    gt_deps = _ancestor_ref_keys(_store_value(gt_store)) & activation_keys.keys()
+    kd_deps = _ancestor_ref_keys(_store_value(kd_store)) & activation_keys.keys()
+    qd_deps = _ancestor_ref_keys(_store_value(qd_store)) & activation_keys.keys()
+    if len(gt_deps) != 1 or len(kd_deps) != 2 or len(qd_deps) != 2:
+        return None
+    gate_key = next(iter(gt_deps))
+    if gate_key not in kd_deps or gate_key not in qd_deps:
+        return None
+    k_keys = kd_deps - {gate_key}
+    q_keys = qd_deps - {gate_key}
+    if len(k_keys) != 1 or len(q_keys) != 1 or k_keys == q_keys:
+        return None
+    gate = activation_keys[gate_key]
+    k = activation_keys[next(iter(k_keys))]
+    q = activation_keys[next(iter(q_keys))]
+    if q.fake.dtype is not torch.bfloat16 or k.fake.dtype is not torch.bfloat16:
+        return None
+    gate_is_fp32 = gate.fake.dtype is torch.float32
+    if gate.fake.dtype not in (torch.bfloat16, torch.float32):
+        return None
+
+    # The full target multiset makes every rounding/cast operation part of the
+    # accepted contract while remaining independent of source/node names.
+    target_counts = Counter(
+        node.target for node in body_nodes if node.op == "call_function"
+    )
+    if target_counts == _body_target_counts(gate_is_fp32):
+        outputs_scaled = True
+    elif target_counts == _body_target_counts(gate_is_fp32, outputs_scaled=False):
+        outputs_scaled = False
+    else:
+        return None
+    factor_key_xor = 0 if outputs_scaled else 8
+    iota_extents = [
+        _static_extent(node.args[0])
+        for node in body_nodes
+        if _is_call(node, torch.ops.prims.iota.default) and node.args
+    ]
+    if any(extent is None for extent in iota_extents) or sorted(
+        cast("list[int]", iota_extents)
+    ) != [_BT, _BT, _DK]:
+        return None
+    scans = [node for node in body_nodes if _is_call(node, scan_ops._associative_scan)]
+    if (
+        len(scans) != 1
+        or len(scans[0].args) < 5
+        or scans[0].args[0] != helper_info.graph_id
+        or scans[0].args[2:] != (0, False, False)
+    ):
+        return None
+
+    gt_shape = _shape(g_total.fake)
+    if (
+        gt_shape is None
+        or len(gt_shape) != 2
+        or gt_shape[1] != _DK
+        or gt_shape[0] % heads
+    ):
+        return None
+    total_chunks = gt_shape[0] // heads
+    chunk_group_coord = _match_chunk_group_coordinate(
+        loop_info,
+        if_call.args[0],
+        loop_call.args[2][0],
+        total_chunks,
+    )
+    if chunk_group_coord is None:
+        return None
+    rows = total_chunks * _BT
+    if not all(
+        (
+            _tensor_is_exact_contiguous(ref, (heads * rows, _DK))
+            and ref.fake.dtype is torch.bfloat16
+        )
+        for ref in (kd, qd, ak)
+    ):
+        return None
+    if not (
+        _tensor_is_exact_contiguous(aq, (heads * total_chunks, _BT * _BT))
+        and aq.fake.dtype is torch.bfloat16
+        and _tensor_is_exact_contiguous(g_total, (heads * total_chunks, _DK))
+        and g_total.fake.dtype is torch.float32
+    ):
+        return None
+
+    int_refs = [ref for ref in load_refs if ref.fake.dtype is torch.int32]
+    if len(int_refs) != 3 or any(
+        ref.fake.ndim != 1 or not ref.fake.is_contiguous() for ref in int_refs
+    ):
+        return None
+    chunk_to_seq = cast(
+        "_TensorRef | None",
+        _single(ref for ref in int_refs if _shape(ref.fake) == (total_chunks,)),
+    )
+    if chunk_to_seq is None:
+        return None
+    remaining_int = [ref for ref in int_refs if ref is not chunk_to_seq]
+    load_counts = Counter(
+        _ref_key(cast("_TensorRef", _load_ref(node))) for node in loads
+    )
+    cu_seqlens = cast(
+        "_TensorRef | None",
+        _single(ref for ref in remaining_int if load_counts[_ref_key(ref)] == 2),
+    )
+    cu_chunks = cast(
+        "_TensorRef | None",
+        _single(ref for ref in remaining_int if load_counts[_ref_key(ref)] == 1),
+    )
+    if (
+        cu_seqlens is None
+        or cu_chunks is None
+        or _shape(cu_seqlens.fake) != _shape(cu_chunks.fake)
+    ):
+        return None
+    if not _validate_memory_index_topology(
+        loads=loads,
+        kd_store=kd_store,
+        qd_store=qd_store,
+        ak_store=ak_store,
+        aq_store=aq_store,
+        gt_store=gt_store,
+        q=q,
+        k=k,
+        gate=gate,
+        beta=beta,
+        a_log=a_log,
+        dt_bias=dt_bias,
+        cu_seqlens=cu_seqlens,
+        cu_chunks=cu_chunks,
+        chunk_to_seq=chunk_to_seq,
+        total_chunks=total_chunks,
+        heads=heads,
+        loop_predicate=if_call.args[0],
+        factor_key_xor=factor_key_xor,
+    ):
+        return None
+    if not _validate_prepare_semantics(
+        body_nodes=body_nodes,
+        loads=loads,
+        kd_store=kd_store,
+        qd_store=qd_store,
+        ak_store=ak_store,
+        aq_store=aq_store,
+        gt_store=gt_store,
+        kk_dot=kk_dot,
+        qk_dot=qk_dot,
+        aq_dot=aq_dot,
+        ak_dot=ak_dot,
+        fp16_dots=fp16_dots,
+        q=q,
+        k=k,
+        gate=gate,
+        beta=beta,
+        a_log=a_log,
+        dt_bias=dt_bias,
+        outputs_scaled=outputs_scaled,
+    ):
+        return None
+
+    dt_load = _single_load_for_ref(loads, dt_bias)
+    dt_indices = _memory_indices(dt_load) if dt_load is not None else None
+    head_coord = (
+        _strip_index_broadcast(dt_indices[0])
+        if dt_indices is not None and len(dt_indices) == 2
+        else None
+    )
+    if not isinstance(head_coord, torch.fx.Node):
+        return None
+
+    if any(
+        not ref.fake.is_contiguous() or ref.fake.device.type != "cuda"
+        for ref in (
+            q,
+            k,
+            gate,
+            beta,
+            a_log,
+            dt_bias,
+            cu_seqlens,
+            cu_chunks,
+            chunk_to_seq,
+        )
+    ):
+        return None
+    output_storage = kd.fake.untyped_storage()
+    if any(
+        ref.fake.untyped_storage() is output_storage
+        for ref in (
+            q,
+            k,
+            gate,
+            beta,
+            a_log,
+            dt_bias,
+            cu_seqlens,
+            cu_chunks,
+            chunk_to_seq,
+        )
+    ):
+        return None
+
+    symfloat_nodes = [
+        node
+        for node in body_nodes
+        if _is_call(node, _get_symnode)
+        and isinstance(node.meta.get("val"), torch.SymFloat)
+    ]
+    log2_e_nodes = [node for node in symfloat_nodes if _static_float(node) == _LOG2_E]
+    if len(log2_e_nodes) != 1:
+        return None
+    symfloat_nodes.remove(log2_e_nodes[0])
+    expected_symfloat_nodes = 2 if outputs_scaled else 1
+    if len(symfloat_nodes) != expected_symfloat_nodes:
+        return None
+    gt_ancestors = _ancestors(_store_value(gt_store))
+    qd_ancestors = _ancestors(_store_value(qd_store))
+    gate_scale_node = cast(
+        "torch.fx.Node | None",
+        _single(node for node in symfloat_nodes if node in gt_ancestors),
+    )
+    scale_node = cast(
+        "torch.fx.Node | None",
+        _single(
+            node
+            for node in symfloat_nodes
+            if node in qd_ancestors and node not in gt_ancestors
+        ),
+    )
+    if gate_scale_node is None or (outputs_scaled and scale_node is None):
+        return None
+    scale_value = (
+        cast("torch.SymFloat", scale_node.meta["val"])._sympy_()
+        if scale_node is not None
+        else sympy.Float(1.0)
+    )
+    gate_scale_value = cast("torch.SymFloat", gate_scale_node.meta["val"])._sympy_()
+    if not isinstance(scale_value, sympy.Expr) or not isinstance(
+        gate_scale_value, sympy.Expr
+    ):
+        return None
+
+    return _CuteChunkPrepareMatch(
+        root_graph_id=root_info.graph_id,
+        root_phase_index=root_info.phase_index,
+        heads=heads,
+        total_tokens=total_tokens,
+        total_chunks=total_chunks,
+        gate_is_fp32=gate_is_fp32,
+        outputs_scaled=outputs_scaled,
+        factor_key_xor=factor_key_xor,
+        q=q,
+        k=k,
+        gate=gate,
+        beta=beta,
+        a_log=a_log,
+        dt_bias=dt_bias,
+        cu_seqlens=cu_seqlens,
+        cu_chunks=cu_chunks,
+        chunk_to_seq=chunk_to_seq,
+        kd=kd,
+        qd=qd,
+        ak=ak,
+        aq=aq,
+        g_total=g_total,
+        chunk_group_coord=chunk_group_coord,
+        head_coord=head_coord,
+        scale=scale_value,
+        gate_scale_log2=gate_scale_value,
+    )
+
+
+def preferred_chunk_prepare_schedule(
+    graphs: Sequence[GraphInfo],
+    *,
+    env: CompileEnvironment | None = None,
+    num_sm: int,
+) -> str | None:
+    """Choose a geometry-derived seed while leaving all schedules searchable."""
+
+    if env is None:
+        env = CompileEnvironment.current()
+    if not env.settings.fast_math:
+        return None
+    match = _match_chunk_prepare_graphs(graphs)
+    if match is None:
+        return None
+    if not _register_packed_workspace_specialization(
+        env,
+        tuple(
+            ref.fake for ref in (match.kd, match.qd, match.ak, match.aq, match.g_total)
+        ),
+    ):
+        return None
+    chunks_per_cta = _preferred_split_alias_chunks_per_cta(
+        total_chunks=match.total_chunks,
+        heads=match.heads,
+        num_sm=num_sm,
+    )
+    return f"split_alias_cpc{chunks_per_cta}"
+
+
+def _plan_chunk_prepare(
+    graphs: Sequence[GraphInfo],
+    _tile_strategy: TileStrategyDispatch,
+) -> CuteChunkPreparePlan | None:
+    from ..device_function import DeviceFunction
+    from ..host_function import HostFunction
+
+    device_function = DeviceFunction.current()
+    env = CompileEnvironment.current()
+    if not env.settings.fast_math or device_function.config.pid_type != "flat":
+        return None
+    match = _match_chunk_prepare_graphs(graphs)
+    if match is None:
+        return None
+
+    device_ir = HostFunction.current().device_ir
+    if not _packed_workspace_is_proven(env):
+        return None
+    grid_ids = _canonical_root_axis_ids(
+        device_ir,
+        root_phase_index=match.root_phase_index,
+        coordinates=(match.chunk_group_coord, match.head_coord),
+        expected_extents=(
+            (match.total_chunks + _SEMANTIC_CPC - 1) // _SEMANTIC_CPC,
+            match.heads,
+        ),
+    )
+    if grid_ids is None:
+        return None
+    if any(device_function.resolved_block_size(index) != 1 for index in grid_ids):
+        return None
+    target = env.config_spec.target_device_capability
+    if target is None or target < (9, 0):
+        return None
+
+    schedule = device_function.config.get(
+        CUTE_CHUNK_PREPARE_SCHEDULE_KEY,
+        preferred_chunk_prepare_schedule(
+            graphs,
+            env=env,
+            num_sm=env.config_spec.num_sm,
+        ),
+    )
+    if type(schedule) is not str or schedule not in _VALID_PREPARE_SCHEDULES:
+        return None
+    chunks_per_cta = int(schedule.removeprefix("split_alias_cpc"))
+    refs = (
+        match.q,
+        match.k,
+        match.gate,
+        match.beta,
+        match.a_log,
+        match.dt_bias,
+        match.cu_seqlens,
+        match.cu_chunks,
+        match.chunk_to_seq,
+        match.kd,
+        match.qd,
+        match.ak,
+        match.aq,
+        match.g_total,
+    )
+    grid = (
+        (match.total_chunks + chunks_per_cta - 1) // chunks_per_cta,
+        match.heads,
+        1,
+    )
+    if not _linear_offsets_fit_i32(
+        match.total_chunks * match.heads,
+        tuple(ref.fake.numel() for ref in refs),
+    ) or not _xyz_grid_fits(grid):
+        return None
+    return CuteChunkPreparePlan(
+        root_graph_id=match.root_graph_id,
+        chunk_size=_BT,
+        key_size=_DK,
+        chunks_per_cta=chunks_per_cta,
+        schedule=schedule,
+        heads=match.heads,
+        total_tokens=match.total_tokens,
+        total_chunks=match.total_chunks,
+        gate_is_fp32=match.gate_is_fp32,
+        outputs_scaled=match.outputs_scaled,
+        factor_key_xor=match.factor_key_xor,
+        q=match.q,
+        k=match.k,
+        gate=match.gate,
+        beta=match.beta,
+        a_log=match.a_log,
+        dt_bias=match.dt_bias,
+        cu_seqlens=match.cu_seqlens,
+        cu_chunks=match.cu_chunks,
+        chunk_to_seq=match.chunk_to_seq,
+        kd=match.kd,
+        qd=match.qd,
+        ak=match.ak,
+        aq=match.aq,
+        g_total=match.g_total,
+        scale=match.scale,
+        gate_scale_log2=match.gate_scale_log2,
+        smem_bytes=_SPLIT_ALIAS_SMEM_BYTES,
+        device_abi=(
+            _SCALED_DEVICE_ABI if match.outputs_scaled else _UNSCALED_DEVICE_ABI
+        ),
+    )
+
+
+def plan_chunk_prepare(
+    graphs: Sequence[GraphInfo],
+    tile_strategy: TileStrategyDispatch,
+) -> None:
+    """Install a complete whole-root prepare plan, or leave no partial state."""
+
+    from ..device_function import DeviceFunction
+
+    DeviceFunction.current().cute_state.chunk_prepare_plan = _plan_chunk_prepare(
+        graphs, tile_strategy
+    )
+
+
+def _tensor_arg(cg: GenerateAST, ref: _TensorRef) -> str:
+    return cg.device_function.tensor_arg(ref.fake, prefer_name=ref.name).name
+
+
+def _flat_tensor(name: str, elements: int) -> str:
+    return (
+        f"cute.make_tensor({name}.iterator, "
+        f"cute.make_layout(({elements},), stride=(1,)))"
+    )
+
+
+def _emit_module_imports(cg: GenerateAST, helper_name: str) -> None:
+    if getattr(cg, "_helion_chunk_prepare_module_emitted", False):
+        return
+    cg._helion_chunk_prepare_module_emitted = True  # type: ignore[attr-defined]
+    alias = "" if helper_name == "emit_bt16_prepare" else f" as {helper_name}"
+    source = (
+        "from helion._compiler.cute.chunk_prepare_split_alias_device "
+        f"import emit_bt16_prepare{alias}"
+    )
+    cg.module_statements.extend(ast.parse(source).body)
+
+
+def codegen_chunk_prepare(cg: GenerateAST) -> bool:
+    """Replace the matched root with the exact imported device schedule."""
+
+    df = cg.device_function
+    plan = df.cute_state.chunk_prepare_plan
+    root = cg.current_root_graph_info
+    if (
+        plan is None
+        or root is None
+        or root.graph_id != plan.root_graph_id
+        or plan.chunk_size != _BT
+        or plan.key_size != _DK
+        or plan.chunks_per_cta not in _SCHEDULE_CPC_CHOICES
+        or plan.schedule not in _VALID_PREPARE_SCHEDULES
+        or (
+            plan.schedule in _SPLIT_ALIAS_SCHEDULES
+            and plan.schedule != f"split_alias_cpc{plan.chunks_per_cta}"
+        )
+        or plan.threads != _THREADS
+        or plan.smem_bytes != _SPLIT_ALIAS_SMEM_BYTES
+        or plan.bf16_mma_count + plan.fp16_mma_count != 192
+        or plan.device_abi
+        != (_SCALED_DEVICE_ABI if plan.outputs_scaled else _UNSCALED_DEVICE_ABI)
+        or plan.factor_key_xor != (0 if plan.outputs_scaled else 8)
+    ):
+        return False
+
+    refs = (
+        plan.q,
+        plan.k,
+        plan.gate,
+        plan.beta,
+        plan.a_log,
+        plan.dt_bias,
+        plan.cu_seqlens,
+        plan.cu_chunks,
+        plan.chunk_to_seq,
+        plan.kd,
+        plan.qd,
+        plan.ak,
+        plan.aq,
+        plan.g_total,
+    )
+    names = tuple(_tensor_arg(cg, ref) for ref in refs)
+    (
+        q,
+        k,
+        gate,
+        beta,
+        a_log,
+        dt_bias,
+        cu_seqlens,
+        cu_chunks,
+        chunk_to_seq,
+        kd,
+        qd,
+        ak,
+        aq,
+        g_total,
+    ) = names
+    scale = df.literal_expr(plan.scale)
+    gate_scale_log2 = df.literal_expr(plan.gate_scale_log2)
+    desc_names = tuple(
+        df.new_var(name)
+        for name in (
+            "_chunk_prepare_desc_q",
+            "_chunk_prepare_desc_k",
+            "_chunk_prepare_desc_g",
+            "_chunk_prepare_desc_factor",
+        )
+    )
+    helper_name = df.new_var("emit_bt16_prepare")
+
+    _emit_module_imports(cg, helper_name)
+    wrapper_plan: dict[str, object] = {
+        "kind": "chunk_prepare_tma",
+        "q_name": q,
+        "k_name": k,
+        "g_name": gate,
+        "beta_name": beta,
+        "a_log_name": a_log,
+        "dt_name": dt_bias,
+        "cu_seqlens_name": cu_seqlens,
+        "cu_chunks_name": cu_chunks,
+        "chunk_to_seq_name": chunk_to_seq,
+        "kd_name": kd,
+        "qd_name": qd,
+        "ak_name": ak,
+        "aq_name": aq,
+        "gt_name": g_total,
+        "desc_args": desc_names,
+        "total_tokens": plan.total_tokens,
+        "total_chunks": plan.total_chunks,
+        "heads": plan.heads,
+        "chunk_size": plan.chunk_size,
+        "key_size": plan.key_size,
+        "chunks_per_cta": plan.chunks_per_cta,
+        "schedule": plan.schedule,
+        "gate_is_fp32": plan.gate_is_fp32,
+        "outputs_scaled": plan.outputs_scaled,
+        "factor_key_xor": plan.factor_key_xor,
+        "device_abi": plan.device_abi,
+        "smem_bytes": plan.smem_bytes,
+        "bf16_mma_count": plan.bf16_mma_count,
+        "fp16_mma_count": plan.fp16_mma_count,
+    }
+    cg.cute_wrapper_plans.append(wrapper_plan)
+    df.wrapper_only_params.extend(desc_names)
+    df.placeholder_args.update(names)
+
+    flat_names = tuple(
+        df.new_var(f"_chunk_prepare_arg_{index}") for index in range(len(names))
+    )
+    numels = tuple(ref.fake.numel() for ref in refs)
+    preamble = "\n".join(
+        f"{flat} = {_flat_tensor(name, numel)}"
+        for flat, name, numel in zip(flat_names, names, numels, strict=True)
+    )
+    args = ",\n    ".join(
+        [
+            *flat_names,
+            *desc_names,
+            f"cutlass.Float32({scale})",
+            f"cutlass.Float32({gate_scale_log2})",
+            f"cutlass.Int32({plan.total_chunks})",
+            f"cutlass.Int32({plan.heads})",
+            str(plan.outputs_scaled),
+            str(plan.factor_key_xor),
+            str(plan.chunks_per_cta),
+            str(plan.gate_is_fp32),
+        ]
+    )
+    df.preamble = cast("list[ast.AST]", ast.parse(preamble).body)
+    df.body = cast(
+        "list[ast.AST]",
+        ast.parse(f"{helper_name}(\n    {args},\n)").body,
+    )
+    cg.cute_uses_matmul = True
+    return True

--- a/helion/_compiler/cute/chunk_prepare_split_alias_device.py
+++ b/helion/_compiler/cute/chunk_prepare_split_alias_device.py
@@ -1,0 +1,1284 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# The CuTe DSL intentionally leaves its compile-time value types implicit.
+# ruff: noqa: ANN001, ANN202
+
+"""Exact BT16/K128 warp-specialized prepare device schedule.
+
+This is a backend schedule implementation. Admission and argument binding live
+in `helion._compiler.cute.chunk_prepare`; no source or kernel name is a
+match predicate.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import cast
+
+import cutlass
+from cutlass._mlir.dialects import llvm
+import cutlass.cute as cute
+from cutlass.cutlass_dsl import dsl_user_op
+import cutlass.utils
+
+from .kda_device_primitives import _mma_m16n8k16
+from .kda_device_primitives import mma_m16n8k16_bf16
+from .kda_device_primitives import movmatrix_b16
+from .kda_device_primitives import pack_bf16x2
+from .kda_device_primitives import store_vec8_bf16
+from .kda_device_primitives import tma_store_3d
+from .kda_device_primitives import tma_store_commit_group
+from .kda_device_primitives import tma_store_wait_read
+from .kda_device_primitives import vec4_f32
+from .kda_device_primitives import vec8_bf16
+from .kda_device_primitives import vec_at
+from .kda_device_primitives import warp_arrive
+
+BT = 16
+DK = 128
+make_rmem_tensor = cute.make_rmem_tensor
+_LLVM_STRUCT_TYPE = cast("Any", llvm).StructType
+
+PREPARE_DEVICE_THREADS = 128
+PREPARE_DEVICE_WARPS = 4
+BF16_SEG_ELEMS = 64
+BF16_SEG_STRIDE = 1024
+F32_SEG_ELEMS = 32
+F32_SEG_STRIDE = 512
+TMA_TX_BYTES_QK = 8192
+TMA_TX_BYTES_G_FP32 = 8192
+TMA_TX_BYTES_G_BF16 = 4096
+MBAR_SLOT_GATE0 = 0
+MBAR_SLOT_GATE1 = 1
+MBAR_SLOT_QK0 = 2
+MBAR_SLOT_QK1 = 3
+MBAR_SLOT_K_HALF_READY = 4
+MBAR_SLOT_K_FULL_READY = 5
+MBAR_SLOT_RAW_RELEASED = 6
+MBAR_SLOT_PAIRWISE_READY = 7
+MBAR_SLOT_Q_RELEASED = 8
+MBAR_SLOT_K_RELEASED = 9
+PREFIX_FLOOR = -126.0
+NORM_SS_FLOOR = 1.0e-24
+LOG2_E = 1.4426950408889634
+
+
+def ldmatrix_x4(smem_ptr, *, loc=None, ip=None):
+    """``ldmatrix.sync.aligned.m8n8.x4.shared.b16`` -> four b32 registers."""
+    from cutlass._mlir.extras import types as _T
+
+    struct = llvm.inline_asm(
+        _LLVM_STRUCT_TYPE.get_literal([_T.IntegerType.get_signless(32)] * 4),
+        [smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)],
+        "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {$0, $1, $2, $3}, [$4];",
+        "=r,=r,=r,=r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        cutlass.Int32(
+            llvm.extractvalue(
+                _T.IntegerType.get_signless(32), struct, [i], loc=loc, ip=ip
+            )
+        )
+        for i in range(4)
+    )
+
+
+@dsl_user_op
+def stmatrix_x4(smem_ptr, r0, r1, r2, r3, *, loc=None, ip=None):
+    """``stmatrix.sync.aligned.m8n8.x4.shared.b16`` from four b32 registers."""
+
+    llvm.inline_asm(
+        None,
+        [
+            smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(r0).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(r1).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(r2).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(r3).ir_value(loc=loc, ip=ip),
+        ],
+        "stmatrix.sync.aligned.m8n8.x4.shared.b16 [$0], {$1, $2, $3, $4};",
+        "r,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def mma_m16n8k16_f16(a0, a1, a2, a3, b0, b1, c0, c1, c2, c3, *, loc=None, ip=None):
+    """``mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32``."""
+
+    return _mma_m16n8k16("f16", a0, a1, a2, a3, b0, b1, c0, c1, c2, c3, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def pack_f16x2(lo: cutlass.Float32, hi: cutlass.Float32, *, loc=None, ip=None):
+    """Round two FP32 values to FP16 and pack them into one b32 register.
+
+    The FP16 twin of :func:`pack_bf16x2`, with the same half ordering:
+    ``cvt.rn.f16x2.f32 d, hi, lo`` places ``lo`` in the low half.  Used by the
+    inverse chain, whose operands are FP16 regardless of the kernel's input
+    dtype -- FP16's 10-bit significand against BF16's 7 is worth 4-8x there,
+    and the chain is the one stage where the extra bits survive.
+    """
+    from cutlass._mlir.extras import types as _T
+
+    return cutlass.Int32(
+        llvm.inline_asm(
+            _T.IntegerType.get_signless(32),
+            [
+                cutlass.Float32(hi).ir_value(loc=loc, ip=ip),
+                cutlass.Float32(lo).ir_value(loc=loc, ip=ip),
+            ],
+            "cvt.rn.f16x2.f32 $0, $1, $2;",
+            "=r,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def mul_bf16x2(a, b, *, loc=None, ip=None):
+    """Packed BF16 multiply of two b32 registers, rounding each product."""
+    from cutlass._mlir.extras import types as _T
+
+    return cutlass.Int32(
+        llvm.inline_asm(
+            _T.IntegerType.get_signless(32),
+            [
+                cutlass.Int32(a).ir_value(loc=loc, ip=ip),
+                cutlass.Int32(b).ir_value(loc=loc, ip=ip),
+            ],
+            "mul.rn.bf16x2 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+def fence_tensormap_acquire(desc_addr, *, loc=None, ip=None):
+    """Publish a host-written tensor map to the tensormap proxy.
+
+    The descriptor is written by the host and read by the TMA unit through a
+    different proxy, so the kernel has to acquire it before first use.
+    """
+    llvm.inline_asm(
+        None,
+        [cutlass.Int64(desc_addr).ir_value(loc=loc, ip=ip)],
+        "fence.proxy.tensormap::generic.acquire.gpu [$0], 128;",
+        "l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def tma_load_4d(smem_ptr, desc_addr, mbar_ptr, c0, c1, c2, c3, *, loc=None, ip=None):
+    """One ``cp.async.bulk.tensor.4d`` box, global to shared."""
+    llvm.inline_asm(
+        None,
+        [
+            smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            cutlass.Int64(desc_addr).ir_value(loc=loc, ip=ip),
+            mbar_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c0).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c1).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c2).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c3).ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes"
+        " [$0], [$1, {$3, $4, $5, $6}], [$2];",
+        "r,l,r,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+def mbar_spin_wait(
+    mbar_ptr: object, phase: object, wait_hint: int = 10_000_000
+) -> None:
+    """Busy-spin until an mbarrier reaches ``phase`` without sleep backoff.
+
+    ``cute.arch.mbarrier_wait`` inserts ``NANOSLEEP`` between phase checks.
+    Prepare's producer/consumer handoffs are short, so that wake-up latency is
+    larger than the useful wait.  This matches FlashInfer's tight TRY-wait
+    loop and preserves acquire semantics on the successful probe.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            cutlass.Int32(mbar_ptr.toint()).ir_value(),  # pyrefly: ignore[missing-attribute]
+            cutlass.Int32(phase).ir_value(),  # pyrefly: ignore[bad-argument-type]
+        ],
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT:\n\t"
+        f"mbarrier.try_wait.parity.shared::cta.b64 P1, [$0], $1, {wait_hint};\n\t"
+        "@P1 bra DONE;\n\t"
+        "bra LAB_WAIT;\n\t"
+        "DONE:\n\t"
+        "}\n",
+        "r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+def raw_bf16_idx(token, dim):
+    seg = dim // BF16_SEG_ELEMS
+    local = dim - seg * BF16_SEG_ELEMS
+    group = local // 8
+    inner = local - group * 8
+    return (
+        seg * BF16_SEG_STRIDE
+        + token * BF16_SEG_ELEMS
+        + (group ^ (token & 7)) * 8
+        + inner
+    )
+
+
+@cute.jit
+def raw_f32_idx(token, dim):
+    seg = dim // F32_SEG_ELEMS
+    local = dim - seg * F32_SEG_ELEMS
+    group = local // 4
+    inner = local - group * 4
+    return (
+        seg * F32_SEG_STRIDE + token * F32_SEG_ELEMS + (group ^ (token & 7)) * 4 + inner
+    )
+
+
+@cute.jit
+def kr_ak_idx(token, dim):
+    return raw_bf16_idx(token ^ 8, dim)
+
+
+@cute.jit
+def prepare_pair_idx(row, col):
+    storage_col = col ^ 8
+    byte_offset = 2 * (row * 16 + storage_col)
+    return (byte_offset ^ (((byte_offset >> 7) & 1) << 4)) // 2
+
+
+@cute.jit
+def warp_row_sum_8(value: cutlass.Float32) -> cutlass.Float32:
+    """Reduce the eight lanes that cooperate on one token row."""
+    value = value + cutlass.Float32(cute.arch.shuffle_sync_bfly(value, offset=4))
+    value = value + cutlass.Float32(cute.arch.shuffle_sync_bfly(value, offset=2))
+    return value + cutlass.Float32(cute.arch.shuffle_sync_bfly(value, offset=1))
+
+
+@cute.jit
+def bf16_round(x: cutlass.Float32):
+    return x.to(cutlass.BFloat16).to(cutlass.Float32)
+
+
+def f16_round(x: cutlass.Float32):
+    """Round through FP16, the inverse chain's operand dtype (Section 8.2)."""
+    return x.to(cutlass.Float16).to(cutlass.Float32)
+
+
+# ---------------------------------------------------------------------------
+# Fragment helpers
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def load_a_fragment(
+    smem,
+    token_base,
+    dim_base,
+    lane,
+    KEY_XOR: cutlass.Constexpr,
+):
+    """A-operand ``ldmatrix.x4``, undoing any storage-key permutation."""
+    matrix_id = lane // 8
+    row = token_base + (lane % 8) + 8 * (matrix_id % 2)
+    col = (dim_base + 8 * (matrix_id // 2)) ^ KEY_XOR
+    return ldmatrix_x4(smem + raw_bf16_idx(row, col))
+
+
+@cute.jit
+def load_b_fragment(smem, dim_base, lane):
+    """B-operand ``ldmatrix.x4``.
+
+    The row half is keyed on bit 4 of the lane, not bit 3.
+    """
+    matrix_id = lane // 8
+    row = (lane % 8) + 8 * (lane // 16)
+    col = dim_base + 8 * (matrix_id % 2)
+    return ldmatrix_x4(smem + raw_bf16_idx(row, col))
+
+
+@cute.jit
+def load_pairwise_a_fragment(smem, lane):
+    """Load a 16x16 pairwise tile in A layout."""
+    matrix_id = lane // 8
+    row = (lane % 8) + 8 * (matrix_id % 2)
+    col = 8 * (matrix_id // 2)
+    return ldmatrix_x4(smem + prepare_pair_idx(row, col))
+
+
+@cute.jit
+def a_to_b(a0, a1, a2, a3):
+    """A layout -> B layout of the same matrix; identity register order."""
+    return (
+        movmatrix_b16(a0),
+        movmatrix_b16(a1),
+        movmatrix_b16(a2),
+        movmatrix_b16(a3),
+    )
+
+
+@cute.jit
+def a_to_a_transposed(a0, a1, a2, a3):
+    """A layout -> A layout of the transpose; registers 1 and 2 swap."""
+    return (
+        movmatrix_b16(a0),
+        movmatrix_b16(a2),
+        movmatrix_b16(a1),
+        movmatrix_b16(a3),
+    )
+
+
+@cute.jit
+def mma_16x16(a0, a1, a2, a3, b0, b1, b2, b3, c):
+    """One logical m16n16k16 step: two native N=8 MMAs."""
+    n0 = mma_m16n8k16_bf16(a0, a1, a2, a3, b0, b1, c[0], c[1], c[2], c[3])
+    n1 = mma_m16n8k16_bf16(a0, a1, a2, a3, b2, b3, c[4], c[5], c[6], c[7])
+    return (n0[0], n0[1], n0[2], n0[3], n1[0], n1[1], n1[2], n1[3])
+
+
+@cute.jit
+def mma_blockdiag_8x8_f16(a0, a3, b0, b3):
+    """Multiply two packed 8x8 block diagonals with one native MMA.
+
+    ``a0``/``b0`` carry the upper-left block and ``a3``/``b3`` the
+    lower-right block. Packing both right-hand blocks into the same N=8
+    operand lets one m16n8 instruction compute the two independent 8x8
+    products: accumulator slots 0:2 are the upper block and 2:4 the lower.
+    """
+    zero_i32 = cutlass.Int32(0)
+    zero_f32 = cutlass.Float32(0.0)
+    return mma_m16n8k16_f16(
+        a0,
+        zero_i32,
+        zero_i32,
+        a3,
+        movmatrix_b16(b0),
+        movmatrix_b16(b3),
+        zero_f32,
+        zero_f32,
+        zero_f32,
+        zero_f32,
+    )
+
+
+@cute.jit
+def acc_to_a_fragment(c):
+    """Register-local accumulator -> A-layout pack."""
+    return (
+        pack_bf16x2(c[0], c[1]),
+        pack_bf16x2(c[2], c[3]),
+        pack_bf16x2(c[4], c[5]),
+        pack_bf16x2(c[6], c[7]),
+    )
+
+
+@cute.jit
+def ZERO8():
+    """Eight zeroed FP32 accumulator slots."""
+    z = cutlass.Float32(0.0)
+    return (z, z, z, z, z, z, z, z)
+
+
+@cute.jit
+def kk_half(lhs_ptr, ki_ptr, lane, half, c, FACTOR_KEY_XOR: cutlass.Constexpr):
+    """``lhs @ Ki.T`` over the four K=16 phases of head-dimension half ``half``.
+
+    Split so warp 0 can start K blocks 0-3 on ``k_half_ready`` and only wait
+    for ``k_full_ready`` before blocks 4-7 (step 5 of the design).
+    """
+    for j in cutlass.range_constexpr(4):
+        d0 = (half * 4 + j) * 16
+        a0, a1, a2, a3 = load_a_fragment(lhs_ptr, 0, d0, lane, FACTOR_KEY_XOR)
+        b0, b1, b2, b3 = load_b_fragment(ki_ptr, d0, lane)
+        c = mma_16x16(a0, a1, a2, a3, b0, b1, b2, b3, c)
+    return c
+
+
+@cute.jit
+def kk_over_dk(lhs_ptr, ki_ptr, lane, FACTOR_KEY_XOR: cutlass.Constexpr):
+    """``lhs @ Ki.T`` over all eight K=16 phases of the head dimension."""
+    return kk_half(
+        lhs_ptr,
+        ki_ptr,
+        lane,
+        1,
+        kk_half(lhs_ptr, ki_ptr, lane, 0, ZERO8(), FACTOR_KEY_XOR),
+        FACTOR_KEY_XOR,
+    )
+
+
+@cute.jit
+def prepare_stmatrix_coord(lane):
+    """Row/col of the 16-byte row segment lane ``lane`` feeds to stmatrix.x4.
+
+    Same quadrant order as the A fragment.
+    """
+    matrix_id = lane // 8
+    row = (lane - matrix_id * 8) + 8 * (matrix_id - (matrix_id // 2) * 2)
+    col = 8 * (matrix_id // 2)
+    return row, col
+
+
+@cute.jit
+def acc_coord(lane, slot):
+    """``(row, col)`` of accumulator slot ``slot`` in ``[0, 8)``."""
+    n_block = slot // 4
+    reg = slot - n_block * 4
+    row = (lane // 4) + 8 * (reg // 2)
+    col = 8 * n_block + 2 * (lane % 4) + (reg % 2)
+    return row, col
+
+
+@cute.jit
+def issue_chunk_tma(
+    desc_q,
+    desc_k,
+    desc_g,
+    p_q,
+    p_k,
+    p_g,
+    mbar_gate,
+    mbar_qk,
+    token_base,
+    head,
+    G_FP32: cutlass.Constexpr,
+):
+    """Issue the first chunk's G, Q, and K full-tile TMA operations.
+
+    Rank-4 descriptors fold the 64-element BF16 (or 32-element FP32) swizzle
+    segments into their fourth box dimension.  Gate completion is tracked
+    separately so prefix work can overlap the still-in-flight Q/K copies.  Q
+    and K share one expected-byte transaction barrier even though later chunks
+    issue them at different lifetime-safe points.
+    """
+    tma_load_4d(p_g, desc_g, mbar_gate, 0, token_base, head, 0)
+    tma_load_4d(p_q, desc_q, mbar_qk, 0, token_base, head, 0)
+    tma_load_4d(p_k, desc_k, mbar_qk, 0, token_base, head, 0)
+
+
+@cute.jit
+def clear_tail_rows(p_q, p_k, p_g, valid_rows, tidx, G_FP32: cutlass.Constexpr):
+    """Zero the invalid rows of the raw stages.
+
+    TMA only zero-fills coordinates outside the *tensor*, and a short chunk sits
+    mid-tensor: the rows past ``valid_rows`` belong to the next sequence in the
+    packed layout, so TMA faithfully loads real data there.  The ``cp.async``
+    version this replaces got the zeros for free by passing src-size 0.
+
+    Same 16-byte task map as the loads, so the writes stay one vector wide.
+    """
+    for rep in cutlass.range_constexpr(2):
+        slot = tidx + rep * PREPARE_DEVICE_THREADS
+        row = slot // 16
+        d0 = (slot - row * 16) * 8
+        if row >= valid_rows:
+            zero8 = make_rmem_tensor(8, cutlass.BFloat16)
+            for i in cutlass.range_constexpr(8):
+                zero8[i] = cutlass.BFloat16(0.0)
+            bidx = raw_bf16_idx(row, d0)
+            store_vec8_bf16(p_q, bidx, zero8)
+            store_vec8_bf16(p_k, bidx, zero8)
+
+    if cutlass.const_expr(G_FP32):
+        for rep in cutlass.range_constexpr(4):
+            slot = tidx + rep * PREPARE_DEVICE_THREADS
+            row = slot // 32
+            d0 = (slot - row * 32) * 4
+            if row >= valid_rows:
+                zero4 = make_rmem_tensor(4, cutlass.Float32)
+                for i in cutlass.range_constexpr(4):
+                    zero4[i] = cutlass.Float32(0.0)
+                cute.autovec_copy(zero4, vec_at(p_g, raw_f32_idx(row, d0), 4))
+    else:
+        # BF16 G is the same 4096-byte image as Q and K, so it takes the same
+        # two-rep, 16-byte task map rather than the FP32 four-rep one.
+        for rep in cutlass.range_constexpr(2):
+            slot = tidx + rep * PREPARE_DEVICE_THREADS
+            row = slot // 16
+            d0 = (slot - row * 16) * 8
+            if row >= valid_rows:
+                zero8 = make_rmem_tensor(8, cutlass.BFloat16)
+                for i in cutlass.range_constexpr(8):
+                    zero8[i] = cutlass.BFloat16(0.0)
+                store_vec8_bf16(p_g, raw_bf16_idx(row, d0), zero8)
+
+
+@cute.jit
+def load_beta_stage(gbeta, smem_beta, stage, token_base, valid_rows, head, lane, heads):
+    """Activate one chunk's 16 beta logits into beta stage ``stage``.
+
+    the design double-buffers ``smem_beta_act`` so that this strided
+    column read out of ``[T, H]`` -- which cannot coalesce, one sector per
+    token -- is issued a full chunk before the values are needed, instead of
+    stalling the whole CTA at a barrier behind its DRAM latency.
+    """
+    if lane < BT:
+        bv = cutlass.Float32(0.0)
+        if lane < valid_rows:
+            logit = cutlass.Float32(gbeta[(token_base + lane) * heads + head])
+            half = cutlass.Float32(0.5)
+            # Stored as FP32, unrounded.  The activated value has exactly two
+            # consumers: the strict-lower scale, which is an FP32 multiply, and
+            # the AINV column scale, which packs to BF16 itself.  Rounding here
+            # is invisible to the second and only lossy to the first, at the
+            # cost of two F2F conversions per lane (measured).
+            bv = (
+                cutlass.Float32(cute.math.tanh(logit * half, fastmath=True)) * half
+                + half
+            )
+        smem_beta[stage * BT + lane] = bv
+
+
+# ---------------------------------------------------------------------------
+# Kernel
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def emit_bt16_prepare(
+    gq: cute.Tensor,
+    gk: cute.Tensor,
+    gg: cute.Tensor,
+    gbeta: cute.Tensor,
+    ga_log: cute.Tensor,
+    gdt: cute.Tensor,
+    gcu_seqlens: cute.Tensor,
+    gcu_chunks: cute.Tensor,
+    gchunk_to_seq: cute.Tensor,
+    ws_kd: cute.Tensor,
+    ws_qd: cute.Tensor,
+    ws_ak: cute.Tensor,
+    ws_aq: cute.Tensor,
+    ws_gt: cute.Tensor,
+    desc_q: cutlass.Int64,
+    desc_k: cutlass.Int64,
+    desc_g: cutlass.Int64,
+    desc_factor: cutlass.Int64,
+    SCALE: cutlass.Float32,
+    GATE_SCALE_LOG2: cutlass.Float32,
+    TOTAL_CHUNKS: cutlass.Int32,
+    heads: cutlass.Int32,
+    SCALE_OUTPUTS: cutlass.Constexpr,
+    FACTOR_KEY_XOR: cutlass.Constexpr,
+    CPC: cutlass.Constexpr,
+    G_FP32: cutlass.Constexpr,
+) -> None:
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, bidy, _ = cute.arch.block_idx()
+    warp_id = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    lane = tidx % 32
+    head = bidy
+
+    alloc = cutlass.utils.SmemAllocator()
+    p_kd = alloc.allocate_array(cutlass.BFloat16, BT * DK)
+    # Qd overwrites raw Q and Ki overwrites raw K.  The first use is safe
+    # warp-locally because every converged vector load precedes its vector
+    # store (the unscaled layout's key-^8 Qd map only swaps source lanes). For
+    # CPC>1 the next
+    # Q/K TMAs are split below: Q waits for QK plus the outbound Qd store, and K
+    # waits for both Ak producer warps to finish reading Ki.  G remains separate
+    # and keeps its early prefetch overlap.
+    p_q = alloc.allocate_array(cutlass.BFloat16, BT * DK)
+    p_k = alloc.allocate_array(cutlass.BFloat16, BT * DK)
+    p_g = alloc.allocate_array(cutlass.Float32, BT * DK)
+    p_qd = p_q
+    p_ki = p_k
+    p_ainv = alloc.allocate_array(cutlass.BFloat16, BT * BT)
+    p_gamma = alloc.allocate_array(cutlass.BFloat16, DK)
+    # the design gives smem_beta_act 128 bytes: two 16-float stages, so a
+    # chunk's beta is loaded and activated one chunk ahead of its use.
+    p_beta = alloc.allocate_array(cutlass.Float32, 2 * BT)
+    p_bar = alloc.allocate_array(cutlass.Int64, 10)
+    p_qk = alloc.allocate_array(cutlass.BFloat16, BT * BT)
+
+    # Pointers feed ldmatrix; the flat tensor views give dynamic scalar access.
+    smem_g = cute.make_tensor(p_g, cute.make_layout(BT * DK))
+    # A BF16 view of the same 8192-byte stage. With BF16 ``G`` the raw input
+    # is the 4096-byte Q/K image living in its first half; the stage is then
+    # overwritten in full by FP32 ``exp_g``. Unused when ``G`` is FP32.
+    p_g_bf16 = cute.recast_ptr(p_g, dtype=cutlass.BFloat16)
+    smem_g_bf16 = cute.make_tensor(p_g_bf16, cute.make_layout(BT * DK))
+    # Trace-time selection: which view the raw G load and tail-clear address.
+    p_g_raw = p_g if cutlass.const_expr(G_FP32) else p_g_bf16
+    G_TX = TMA_TX_BYTES_G_FP32 if cutlass.const_expr(G_FP32) else TMA_TX_BYTES_G_BF16
+    smem_ainv = cute.make_tensor(p_ainv, cute.make_layout(BT * BT))
+    smem_gamma = cute.make_tensor(p_gamma, cute.make_layout(DK))
+    smem_beta = cute.make_tensor(p_beta, cute.make_layout(2 * BT))
+    smem_qk = cute.make_tensor(p_qk, cute.make_layout(BT * BT))
+
+    # Gate and Q/K completion have independent two-stage barriers.  This lets
+    # all warps consume the gate and run its prefix while the Q/K transactions
+    # are still in flight.  Each pair alternates by chunk parity, so reuse two
+    # chunks later toggles its phase.
+    mbar_gate0 = p_bar + MBAR_SLOT_GATE0
+    mbar_gate1 = p_bar + MBAR_SLOT_GATE1
+    mbar_qk0 = p_bar + MBAR_SLOT_QK0
+    mbar_qk1 = p_bar + MBAR_SLOT_QK1
+    mbar_k_half = p_bar + MBAR_SLOT_K_HALF_READY
+    mbar_k_full = p_bar + MBAR_SLOT_K_FULL_READY
+    mbar_raw_released = p_bar + MBAR_SLOT_RAW_RELEASED
+    mbar_pairwise = p_bar + MBAR_SLOT_PAIRWISE_READY
+    mbar_q_released = p_bar + MBAR_SLOT_Q_RELEASED
+    mbar_k_released = p_bar + MBAR_SLOT_K_RELEASED
+    if warp_id == 0:
+        if lane == 0:
+            cute.arch.mbarrier_init(mbar_gate0, 1)
+            cute.arch.mbarrier_init(mbar_gate1, 1)
+            cute.arch.mbarrier_init(mbar_qk0, 1)
+            cute.arch.mbarrier_init(mbar_qk1, 1)
+            cute.arch.mbarrier_init(mbar_k_half, PREPARE_DEVICE_WARPS)
+            cute.arch.mbarrier_init(mbar_k_full, PREPARE_DEVICE_WARPS)
+            cute.arch.mbarrier_init(mbar_raw_released, PREPARE_DEVICE_WARPS)
+            cute.arch.mbarrier_init(mbar_pairwise, 1)
+            cute.arch.mbarrier_init(mbar_q_released, 2)
+            cute.arch.mbarrier_init(mbar_k_released, 2)
+            cute.arch.mbarrier_init_fence()
+            fence_tensormap_acquire(desc_q)
+            fence_tensormap_acquire(desc_k)
+            fence_tensormap_acquire(desc_g)
+            # One acquire, not three: Kd/Qd/Ak are 3H planes of one map.
+            fence_tensormap_acquire(desc_factor)
+    # step 1 of the design: nothing may arrive or wait before the
+    # initialized state is published.
+    cute.arch.barrier()
+
+    cta_chunk_base = bidx * CPC
+    my_chunks = TOTAL_CHUNKS - cta_chunk_base
+    if my_chunks > CPC:
+        my_chunks = cutlass.Int32(CPC)
+
+    dt_value = cutlass.Float32(gdt[head * DK + tidx])
+    a_log_value = cute.math.exp2(
+        cutlass.Float32(ga_log[head]) * cutlass.Float32(LOG2_E), fastmath=True
+    )
+    row_in_warp = lane // 8
+    lane_in_row = lane % 8
+    my_token = warp_id * 4 + row_in_warp
+    q4 = lane % 4
+
+    # Prologue: start the first chunk's copies before entering the loop.
+    seq0 = cutlass.Int32(gchunk_to_seq[cta_chunk_base])
+    lc0 = cta_chunk_base - cutlass.Int32(gcu_chunks[seq0])
+    tb0 = cutlass.Int32(gcu_seqlens[seq0]) + lc0 * BT
+    vr0 = cutlass.Int32(gcu_seqlens[seq0 + 1]) - tb0
+    if vr0 > BT:
+        vr0 = cutlass.Int32(BT)
+    if warp_id == 0:
+        if lane == 0:
+            cute.arch.mbarrier_arrive_and_expect_tx(mbar_gate0, G_TX)
+            cute.arch.mbarrier_arrive_and_expect_tx(mbar_qk0, TMA_TX_BYTES_QK)
+            issue_chunk_tma(
+                desc_q,
+                desc_k,
+                desc_g,
+                p_q,
+                p_k,
+                p_g_raw,
+                mbar_gate0,
+                mbar_qk0,
+                tb0,
+                head,
+                G_FP32,
+            )
+        load_beta_stage(gbeta, smem_beta, 0, tb0, vr0, head, lane, heads)
+
+    for lc in cutlass.range_constexpr(CPC):
+        if lc < my_chunks:
+            gchunk = cta_chunk_base + lc
+            seq = cutlass.Int32(gchunk_to_seq[gchunk])
+            local_c = gchunk - cutlass.Int32(gcu_chunks[seq])
+            seq_start = cutlass.Int32(gcu_seqlens[seq])
+            seq_end = cutlass.Int32(gcu_seqlens[seq + 1])
+            token_base = seq_start + local_c * BT
+            valid_rows = seq_end - token_base
+            if valid_rows > BT:
+                valid_rows = cutlass.Int32(BT)
+
+            # ---- wait for the gate, overlap its prefix with Q/K TMA ------
+            beta_stage = lc & 1
+            tma_wait_phase = (lc >> 1) & 1
+            if cutlass.const_expr(lc & 1):
+                mbar_spin_wait(mbar_gate1, tma_wait_phase)
+            else:
+                mbar_spin_wait(mbar_gate0, tma_wait_phase)
+
+            # Section 7.3: a short chunk sits mid-tensor, so TMA loaded the
+            # next sequence's rows rather than zeros.  Clear them before the
+            # gate is consumed.  Tail clearing also writes Q/K, so it must
+            # first wait for their independent transaction barrier.
+            if valid_rows < BT:
+                if cutlass.const_expr(lc & 1):
+                    mbar_spin_wait(mbar_qk1, tma_wait_phase)
+                else:
+                    mbar_spin_wait(mbar_qk0, tma_wait_phase)
+                clear_tail_rows(p_q, p_k, p_g_raw, valid_rows, tidx, G_FP32)
+                cute.arch.barrier()
+
+            # ---- gate prefix --------------------------
+            gate_regs = [cutlass.Float32(0.0) for _ in range(BT)]
+            for r in cutlass.range_constexpr(BT):
+                if cutlass.const_expr(G_FP32):
+                    raw = smem_g[raw_f32_idx(r, tidx)]
+                else:
+                    raw = cutlass.Float32(smem_g_bf16[raw_bf16_idx(r, tidx)])
+                inc = cutlass.Float32(0.0)
+                if r < valid_rows:
+                    x = raw + dt_value
+                    half = cutlass.Float32(0.5)
+                    sig = (
+                        cutlass.Float32(
+                            cute.math.tanh(a_log_value * x * half, fastmath=True)
+                        )
+                        * half
+                        + half
+                    )
+                    inc = GATE_SCALE_LOG2 * sig
+                gate_regs[r] = inc
+
+            acc = cutlass.Float32(0.0)
+            for p in cutlass.range_constexpr(BT // 2):
+                r0 = p * 2
+                g0 = gate_regs[r0]
+                g1 = gate_regs[r0 + 1]
+                prefix0 = acc + g0
+                prefix1 = acc + (g0 + g1)
+                gate_regs[r0] = prefix0
+                gate_regs[r0 + 1] = prefix1
+                acc = prefix1
+
+            for r in cutlass.range_constexpr(BT):
+                pv = gate_regs[r]
+                if pv < cutlass.Float32(PREFIX_FLOOR):
+                    pv = cutlass.Float32(PREFIX_FLOOR)
+                gate_regs[r] = cutlass.Float32(cute.math.exp2(pv, fastmath=True))
+
+            gamma = gate_regs[BT - 1]
+            ws_gt[(head * TOTAL_CHUNKS + gchunk) * DK + tidx] = gamma
+            smem_gamma[tidx] = gamma.to(cutlass.BFloat16)
+            if cutlass.const_expr(not G_FP32):
+                # The FP32 exp_g image about to be written spans all 8192 bytes
+                # of the stage; the BF16 raw G it overwrites occupied only the
+                # first 4096, in a different index map. A thread's write can
+                # therefore land on a raw element another thread has not read
+                # yet, so the read loop above must be complete CTA-wide first.
+                # With FP32 G the two maps coincide and each thread rewrites
+                # exactly the addresses it read, so no barrier is needed.
+                cute.arch.barrier()
+            for r in cutlass.range_constexpr(BT):
+                smem_g[raw_f32_idx(r, tidx)] = gate_regs[r]
+            cute.arch.barrier()
+
+            # Q/K were launched after G but did not gate prefix evaluation.
+            # Full chunks wait here; short chunks already waited before their
+            # invalid rows were cleared.
+            if valid_rows == BT:
+                if cutlass.const_expr(lc & 1):
+                    mbar_spin_wait(mbar_qk1, tma_wait_phase)
+                else:
+                    mbar_spin_wait(mbar_qk0, tma_wait_phase)
+
+            # ---- norm + Kd/Ki/Qd --------------------
+            # Every SMEM and global access below is 16 bytes wide.  The 8
+            # features a lane owns are contiguous and 16-byte aligned under
+            # raw_bf16_s128, and exp_g is read as 2 x float4 because 8
+            # consecutive FP32 are two separate 4-element runs whose order
+            # depends on the token parity.
+            q_ss = cutlass.Float32(0.0)
+            k_ss = cutlass.Float32(0.0)
+            for h in cutlass.range_constexpr(2):
+                d0 = 64 * h + 8 * lane_in_row
+                fq = vec8_bf16(p_q, raw_bf16_idx(my_token, d0))
+                fk = vec8_bf16(p_k, raw_bf16_idx(my_token, d0))
+                for i in cutlass.range_constexpr(8):
+                    qv = cutlass.Float32(fq[i])
+                    kv = cutlass.Float32(fk[i])
+                    q_ss = q_ss + qv * qv
+                    k_ss = k_ss + kv * kv
+            q_ss = warp_row_sum_8(q_ss)
+            k_ss = warp_row_sum_8(k_ss)
+
+            q_inv = cutlass.Float32(0.0)
+            k_inv = cutlass.Float32(0.0)
+            if my_token < valid_rows:
+                qf = q_ss
+                if qf < cutlass.Float32(NORM_SS_FLOOR):
+                    qf = cutlass.Float32(NORM_SS_FLOOR)
+                kf = k_ss
+                if kf < cutlass.Float32(NORM_SS_FLOOR):
+                    kf = cutlass.Float32(NORM_SS_FLOOR)
+                q_inv = cutlass.Float32(cute.math.rsqrt(qf, fastmath=True))
+                k_inv = cutlass.Float32(cute.math.rsqrt(kf, fastmath=True))
+
+            s16 = (
+                bf16_round(SCALE)
+                if cutlass.const_expr(SCALE_OUTPUTS)
+                else bf16_round(cutlass.Float32(1.0))
+            )
+            for h in cutlass.range_constexpr(2):
+                d0 = 64 * h + 8 * lane_in_row
+                bidx = raw_bf16_idx(my_token, d0)
+                fq = vec8_bf16(p_q, bidx)
+                fk = vec8_bf16(p_k, bidx)
+                fg0 = vec4_f32(p_g, raw_f32_idx(my_token, d0))
+                fg1 = vec4_f32(p_g, raw_f32_idx(my_token, d0 + 4))
+
+                o_kd = make_rmem_tensor(8, cutlass.BFloat16)
+                o_ki = make_rmem_tensor(8, cutlass.BFloat16)
+                o_qd = make_rmem_tensor(8, cutlass.BFloat16)
+                for j in cutlass.range_constexpr(4):
+                    i = 0 + j
+                    eg = fg0[j]
+                    kv = cutlass.Float32(fk[i]) * k_inv
+                    kd_v = bf16_round(bf16_round(kv) * bf16_round(eg))
+                    ki_v = bf16_round(kv * cutlass.Float32(cute.arch.rcp_approx(eg)))
+                    qv = bf16_round(cutlass.Float32(fq[i]) * q_inv)
+                    qd_v = bf16_round(bf16_round(qv * bf16_round(eg)) * s16)
+                    o_kd[i] = kd_v.to(cutlass.BFloat16)
+                    o_ki[i] = ki_v.to(cutlass.BFloat16)
+                    o_qd[i] = qd_v.to(cutlass.BFloat16)
+
+                for j in cutlass.range_constexpr(4):
+                    i = 4 + j
+                    eg = fg1[j]
+                    kv = cutlass.Float32(fk[i]) * k_inv
+                    kd_v = bf16_round(bf16_round(kv) * bf16_round(eg))
+                    ki_v = bf16_round(kv * cutlass.Float32(cute.arch.rcp_approx(eg)))
+                    qv = bf16_round(cutlass.Float32(fq[i]) * q_inv)
+                    qd_v = bf16_round(bf16_round(qv * bf16_round(eg)) * s16)
+                    o_kd[i] = kd_v.to(cutlass.BFloat16)
+                    o_ki[i] = ki_v.to(cutlass.BFloat16)
+                    o_qd[i] = qd_v.to(cutlass.BFloat16)
+
+                factor_bidx = raw_bf16_idx(my_token, d0 ^ FACTOR_KEY_XOR)
+                store_vec8_bf16(p_kd, factor_bidx, o_kd)
+                store_vec8_bf16(p_ki, bidx, o_ki)
+                store_vec8_bf16(p_qd, factor_bidx, o_qd)
+                # step 5 of the design: signal each Kd/Ki half the moment it
+                # is in SMEM.  Kd and Qd leave for global by TMA later, read
+                # straight out of these same images (Section 7.4), so there is
+                # no separate global store here any more.
+                if cutlass.const_expr(h == 0):
+                    warp_arrive(mbar_k_half, lane)
+                else:
+                    warp_arrive(mbar_k_full, lane)
+
+            # This warp is done with raw Q/K/exp-g and with Qd (Section 12.3
+            # step 5); the raw stages may be overwritten once all four arrive.
+            warp_arrive(mbar_raw_released, lane)
+            phase = lc & 1
+
+            # ---- warp 0: KK -> L -> AINV ------------------------------
+            if warp_id == 0:
+                mbar_spin_wait(mbar_k_half, phase)
+                c = kk_half(p_kd, p_ki, lane, 0, ZERO8(), FACTOR_KEY_XOR)
+                mbar_spin_wait(mbar_k_full, phase)
+                c = kk_half(p_kd, p_ki, lane, 1, c, FACTOR_KEY_XOR)
+                masked = [cutlass.Float32(0.0) for _ in range(8)]
+                for slot in cutlass.range_constexpr(8):
+                    row, col = acc_coord(lane, slot)
+                    v = cutlass.Float32(0.0)
+                    if row > col:
+                        v = c[slot] * smem_beta[beta_stage * BT + row]
+                    masked[slot] = v
+
+                # Blockwise 8x8 inverse.  With D the block
+                # diagonal of L and A21 its one off-diagonal block:
+                #
+                #   Binv = (I - D)(I + D^2)(I + D^4)   exact, blocks nilpotent
+                #                                      at 8, so 3 factors
+                #   AINV = Binv - Binv @ A21 @ Binv    exact, (Binv @ A21)^2 = 0
+                #
+                # The two diagonal 8x8 blocks share one native m16n8 issue:
+                # its top eight rows carry the first block and its bottom
+                # eight rows carry the second. This is the native CAKE
+                # block-sparse formulation: two squares, two inverse updates,
+                # and two lower-left coupling products are exactly six FP16
+                # MMA issues, rather than six logical m16n16 operations.
+                diagonal = [cutlass.Float32(0.0) for _ in range(4)]
+                diagonal_slots = (0, 1, 6, 7)
+                for index in cutlass.range_constexpr(4):
+                    slot = diagonal_slots[index]
+                    row, col = acc_coord(lane, slot)
+                    eye = cutlass.Float32(0.0)
+                    if row == col:
+                        eye = cutlass.Float32(1.0)
+                    diagonal[index] = eye - f16_round(masked[slot])
+
+                d0 = pack_f16x2(masked[0], masked[1])
+                d3 = pack_f16x2(masked[6], masked[7])
+                d2 = mma_blockdiag_8x8_f16(d0, d3, d0, d3)
+                d2_0 = pack_f16x2(d2[0], d2[1])
+                d2_3 = pack_f16x2(d2[2], d2[3])
+
+                diagonal_0 = pack_f16x2(diagonal[0], diagonal[1])
+                diagonal_3 = pack_f16x2(diagonal[2], diagonal[3])
+                product = mma_blockdiag_8x8_f16(diagonal_0, diagonal_3, d2_0, d2_3)
+                for index in cutlass.range_constexpr(4):
+                    diagonal[index] = f16_round(diagonal[index]) + product[index]
+
+                d4 = mma_blockdiag_8x8_f16(d2_0, d2_3, d2_0, d2_3)
+                d4_0 = pack_f16x2(d4[0], d4[1])
+                d4_3 = pack_f16x2(d4[2], d4[3])
+                diagonal_0 = pack_f16x2(diagonal[0], diagonal[1])
+                diagonal_3 = pack_f16x2(diagonal[2], diagonal[3])
+                product = mma_blockdiag_8x8_f16(diagonal_0, diagonal_3, d4_0, d4_3)
+                for index in cutlass.range_constexpr(4):
+                    diagonal[index] = f16_round(diagonal[index]) + product[index]
+
+                # T1 = Binv @ A21 and X21 = -T1 @ Binv each have only the
+                # lower-left output quadrant live, so each needs one N=8 MMA.
+                zero_i32 = cutlass.Int32(0)
+                zero_f32 = cutlass.Float32(0.0)
+                binv_0 = pack_f16x2(diagonal[0], diagonal[1])
+                binv_3 = pack_f16x2(diagonal[2], diagonal[3])
+                a21_1 = pack_f16x2(masked[2], masked[3])
+                t1 = mma_m16n8k16_f16(
+                    binv_0,
+                    zero_i32,
+                    zero_i32,
+                    binv_3,
+                    zero_i32,
+                    movmatrix_b16(a21_1),
+                    zero_f32,
+                    zero_f32,
+                    zero_f32,
+                    zero_f32,
+                )
+                correction_1 = pack_f16x2(t1[2], t1[3])
+                correction = mma_m16n8k16_f16(
+                    zero_i32,
+                    correction_1,
+                    zero_i32,
+                    zero_i32,
+                    movmatrix_b16(binv_0),
+                    zero_i32,
+                    zero_f32,
+                    zero_f32,
+                    zero_f32,
+                    zero_f32,
+                )
+
+                inverse = (
+                    diagonal[0],
+                    diagonal[1],
+                    -correction[2],
+                    -correction[3],
+                    zero_f32,
+                    zero_f32,
+                    diagonal[2],
+                    diagonal[3],
+                )
+                for slot in cutlass.range_constexpr(8):
+                    row, col = acc_coord(lane, slot)
+                    smem_ainv[prepare_pair_idx(row, col)] = bf16_round(
+                        inverse[slot]
+                    ).to(cutlass.BFloat16)
+                # step 7 of the design.  This arrival publishes AINV and
+                # also proves warp 0 is done reading smem_kd_then_ak, which is
+                # what lets warps 1 and 3 overwrite their Kd half with Ak.
+                warp_arrive(mbar_pairwise, lane)
+                if lc + 1 < CPC:
+                    if lc + 1 < my_chunks:
+                        # Qd aliases raw Q.  Its image becomes reusable only
+                        # after warp 2 has consumed it for QK and warp 3's Qd
+                        # TMA store has finished reading both segments.
+                        mbar_spin_wait(mbar_q_released, phase)
+                        nchunk = gchunk + 1
+                        nseq = cutlass.Int32(gchunk_to_seq[nchunk])
+                        nlc = nchunk - cutlass.Int32(gcu_chunks[nseq])
+                        ntb = cutlass.Int32(gcu_seqlens[nseq]) + nlc * BT
+                        if lane == 0:
+                            if cutlass.const_expr((lc + 1) & 1):
+                                cute.arch.mbarrier_arrive_and_expect_tx(
+                                    mbar_qk1, TMA_TX_BYTES_QK
+                                )
+                                tma_load_4d(p_q, desc_q, mbar_qk1, 0, ntb, head, 0)
+                            else:
+                                cute.arch.mbarrier_arrive_and_expect_tx(
+                                    mbar_qk0, TMA_TX_BYTES_QK
+                                )
+                                tma_load_4d(p_q, desc_q, mbar_qk0, 0, ntb, head, 0)
+
+            # ---- warp 2: causal QK, staged through SMEM ---------------
+            if warp_id == 2:
+                mbar_spin_wait(mbar_k_full, phase)
+                c = kk_over_dk(p_qd, p_ki, lane, FACTOR_KEY_XOR)
+                for slot in cutlass.range_constexpr(8):
+                    row, col = acc_coord(lane, slot)
+                    v = cutlass.Float32(0.0)
+                    if row >= col:
+                        v = c[slot]
+                    smem_qk[prepare_pair_idx(row, col)] = bf16_round(v).to(
+                        cutlass.BFloat16
+                    )
+                # smem_qk is produced and consumed by this warp alone.
+                cute.arch.sync_warp()
+                if lc + 1 < CPC:
+                    if lc + 1 < my_chunks:
+                        warp_arrive(mbar_q_released, lane)
+
+            # ---- warp 1: release raw G, then prefetch the next gate ------
+            if warp_id == 1:
+                mbar_spin_wait(mbar_raw_released, phase)
+                # publish the ordinary Kd stores to the async
+                # shared proxy before the TMA engine reads them, and converge
+                # the warp so lane 0 speaks for all 32 lanes' writes.
+                cute.arch.fence_view_async_shared()
+                cute.arch.sync_warp()
+                if lane == 0:
+                    tma_store_3d(desc_factor, p_kd, 0, gchunk * BT, head)
+                    tma_store_commit_group()
+                if lc + 1 < CPC:
+                    if lc + 1 < my_chunks:
+                        nchunk = gchunk + 1
+                        nseq = cutlass.Int32(gchunk_to_seq[nchunk])
+                        nlc = nchunk - cutlass.Int32(gcu_chunks[nseq])
+                        ntb = cutlass.Int32(gcu_seqlens[nseq]) + nlc * BT
+                        nvr = cutlass.Int32(gcu_seqlens[nseq + 1]) - ntb
+                        if nvr > BT:
+                            nvr = cutlass.Int32(BT)
+                        if lane == 0:
+                            if cutlass.const_expr((lc + 1) & 1):
+                                cute.arch.mbarrier_arrive_and_expect_tx(
+                                    mbar_gate1, G_TX
+                                )
+                                tma_load_4d(
+                                    p_g_raw, desc_g, mbar_gate1, 0, ntb, head, 0
+                                )
+                            else:
+                                cute.arch.mbarrier_arrive_and_expect_tx(
+                                    mbar_gate0, G_TX
+                                )
+                                tma_load_4d(
+                                    p_g_raw, desc_g, mbar_gate0, 0, ntb, head, 0
+                                )
+                        load_beta_stage(
+                            gbeta,
+                            smem_beta,
+                            (lc + 1) & 1,
+                            ntb,
+                            nvr,
+                            head,
+                            lane,
+                            heads,
+                        )
+            elif warp_id == 3:
+                # Warp 3 no longer issues any of the prefetch, but it still
+                # acquires raw_operands_released: that is what makes the other
+                # warps' Ki stores visible to its Ak path below, without
+                # relying on a chained release/acquire through warp 0.
+                mbar_spin_wait(mbar_raw_released, phase)
+                cute.arch.fence_view_async_shared()
+                cute.arch.sync_warp()
+                if lane == 0:
+                    # Section 7.4: Kd segment 1 plus both Qd segments, one group.
+                    tma_store_3d(
+                        desc_factor,
+                        p_kd + BF16_SEG_STRIDE,
+                        BF16_SEG_ELEMS,
+                        gchunk * BT,
+                        head,
+                    )
+                    tma_store_3d(desc_factor, p_qd, 0, gchunk * BT, heads + head)
+                    tma_store_3d(
+                        desc_factor,
+                        p_qd + BF16_SEG_STRIDE,
+                        BF16_SEG_ELEMS,
+                        gchunk * BT,
+                        heads + head,
+                    )
+                    tma_store_commit_group()
+
+            # ---- AINV_beta, then Aq (warp 2) and Ak (warps 1 and 3) ---
+            # pairwise_ready is a plain release/acquire pair on smem_ainv, whose
+            # only writer is warp 0.  The Ki that warps 1 and 3 read below is
+            # covered without leaning on chained visibility: warp 2 acquired
+            # k_full_ready directly, and warps 1 and 3 acquired
+            # raw_operands_released, on which every warp arrives after its
+            # k_full_ready arrival and therefore after its Ki stores.
+            if warp_id != 0:
+                mbar_spin_wait(mbar_pairwise, phase)
+                ai = load_pairwise_a_fragment(p_ainv, lane)
+                bst = beta_stage * BT
+                blo = pack_bf16x2(smem_beta[bst + 2 * q4], smem_beta[bst + 2 * q4 + 1])
+                bhi = pack_bf16x2(
+                    smem_beta[bst + 2 * q4 + 8], smem_beta[bst + 2 * q4 + 9]
+                )
+                ab0 = mul_bf16x2(ai[0], blo)
+                ab1 = mul_bf16x2(ai[1], blo)
+                ab2 = mul_bf16x2(ai[2], bhi)
+                ab3 = mul_bf16x2(ai[3], bhi)
+
+                if warp_id == 2:
+                    bb = a_to_b(ab0, ab1, ab2, ab3)
+                    qk_a = load_pairwise_a_fragment(p_qk, lane)
+                    aq = mma_16x16(
+                        qk_a[0],
+                        qk_a[1],
+                        qk_a[2],
+                        qk_a[3],
+                        bb[0],
+                        bb[1],
+                        bb[2],
+                        bb[3],
+                        ZERO8(),
+                    )
+                    base = (head * TOTAL_CHUNKS + gchunk) * (BT * BT)
+                    # Stage through SMEM so the global store is one contiguous
+                    # 16-byte run per lane. Direct stores cannot be:
+                    # prepare_pair_idx swaps the column halves
+                    # (col ^ 8), so one store instruction only ever fills half
+                    # of each row's 32 bytes, spraying 128 B over 8 sectors.
+                    # The four instructions tile the 512 B exactly, but L1 does
+                    # not merge across instructions, so 32 sectors leave the SM
+                    # where 16 suffice. Staging reduces this to five store
+                    # instructions and 32 sectors per chunk.
+                    #
+                    # smem_qk is free here: warp 2 owns it alone and has just
+                    # consumed it into qk_a, so this costs no shared memory.
+                    cute.arch.sync_warp()
+                    aqf = acc_to_a_fragment(aq)
+                    srow, scol = prepare_stmatrix_coord(lane)
+                    stmatrix_x4(
+                        p_qk + prepare_pair_idx(srow, scol),
+                        aqf[0],
+                        aqf[1],
+                        aqf[2],
+                        aqf[3],
+                    )
+                    cute.arch.sync_warp()
+                    cute.autovec_copy(
+                        vec8_bf16(p_qk, lane * 8),
+                        vec_at(ws_aq.iterator, base + lane * 8, 8),
+                    )
+
+                else:
+                    # Section 12.3 step 8: pairwise_ready above proved warp 0 is
+                    # done reading smem_kd_then_ak; this waits for the warp's own
+                    # Kd TMA store to have finished *reading* its half, which is
+                    # the other half of the condition for overwriting it.  The
+                    # warp synchronization joins the two before any lane writes.
+                    if lane == 0:
+                        tma_store_wait_read(0)
+                    cute.arch.sync_warp()
+                    if warp_id == 3:
+                        if lc + 1 < CPC:
+                            if lc + 1 < my_chunks:
+                                warp_arrive(mbar_q_released, lane)
+
+                    at0, at1, at2, at3 = a_to_a_transposed(ab0, ab1, ab2, ab3)
+                    tile_base = 0
+                    if warp_id == 3:
+                        tile_base = 4
+                    for t in cutlass.range_constexpr(4):
+                        d0 = (tile_base + t) * 16
+                        ki0, ki1, ki2, ki3 = load_a_fragment(p_ki, 0, d0, lane, 0)
+                        gl = pack_bf16x2(
+                            cutlass.Float32(smem_gamma[d0 + 2 * q4]),
+                            cutlass.Float32(smem_gamma[d0 + 2 * q4 + 1]),
+                        )
+                        gh = pack_bf16x2(
+                            cutlass.Float32(smem_gamma[d0 + 2 * q4 + 8]),
+                            cutlass.Float32(smem_gamma[d0 + 2 * q4 + 9]),
+                        )
+                        kb = a_to_b(
+                            mul_bf16x2(ki0, gl),
+                            mul_bf16x2(ki1, gl),
+                            mul_bf16x2(ki2, gh),
+                            mul_bf16x2(ki3, gh),
+                        )
+                        akc = mma_16x16(
+                            at0, at1, at2, at3, kb[0], kb[1], kb[2], kb[3], ZERO8()
+                        )
+                        # publish Ak.T with stmatrix.x4 through
+                        # the row-^8 image, into the Kd stage that is now dead.
+                        # Warp 1 owns d < 64 -> bytes [0,2048), warp 3 the rest.
+                        akf = acc_to_a_fragment(akc)
+                        srow, scol = prepare_stmatrix_coord(lane)
+                        stmatrix_x4(
+                            p_kd + kr_ak_idx(srow, d0 + scol),
+                            akf[0],
+                            akf[1],
+                            akf[2],
+                            akf[3],
+                        )
+
+                    if lc + 1 < CPC:
+                        if lc + 1 < my_chunks:
+                            # Ki aliases raw K.  Both Ak producer warps arrive
+                            # only after their final Ki fragment load.
+                            warp_arrive(mbar_k_released, lane)
+                            if warp_id == 1:
+                                mbar_spin_wait(mbar_k_released, phase)
+                                nchunk = gchunk + 1
+                                nseq = cutlass.Int32(gchunk_to_seq[nchunk])
+                                nlc = nchunk - cutlass.Int32(gcu_chunks[nseq])
+                                ntb = cutlass.Int32(gcu_seqlens[nseq]) + nlc * BT
+                                if lane == 0:
+                                    if cutlass.const_expr((lc + 1) & 1):
+                                        tma_load_4d(
+                                            p_k, desc_k, mbar_qk1, 0, ntb, head, 0
+                                        )
+                                    else:
+                                        tma_load_4d(
+                                            p_k, desc_k, mbar_qk0, 0, ntb, head, 0
+                                        )
+
+                    # Section 7.4: each store warp moves its own Ak segment.
+                    # This is what removes the CTA barrier and the 128-thread
+                    # re-read the vector-store version needed -- the warp that
+                    # produced the half is the warp that ships it.
+                    cute.arch.fence_view_async_shared()
+                    cute.arch.sync_warp()
+                    if lane == 0:
+                        seg = tile_base // 4
+                        tma_store_3d(
+                            desc_factor,
+                            p_kd + seg * BF16_SEG_STRIDE,
+                            seg * BF16_SEG_ELEMS,
+                            gchunk * BT,
+                            2 * heads + head,  # Ak is plane region 2
+                        )
+                        tma_store_commit_group()
+                        # Section 12.3 step 8: the source stage cannot be reused
+                        # until the store has read it.
+                        tma_store_wait_read(0)
+
+            # Chunk recycle (Section 12.3 step 9).
+            cute.arch.barrier()

--- a/helion/_compiler/cute/chunk_recurrence.py
+++ b/helion/_compiler/cute/chunk_recurrence.py
@@ -1,0 +1,1630 @@
+"""Whole-root lowering for the resident BT16 KDA chain.
+
+This is deliberately a narrow schedule specialization.  It recognizes a
+semantic four-contraction recurrence over the five-factor workspace written by
+``chunk_prepare`` and replaces the complete root with a capability-selected
+CuTe schedule: a 512-thread SM100 TMEM DV2 path (device ABI 2) or a 192-thread
+SM100 warp-MMA DV4 path (device ABI 3). Both consume workspace layout v2;
+mismatches leave no partial lowering behind.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+import dataclasses
+import operator
+from typing import TYPE_CHECKING
+from typing import cast
+
+import sympy
+import torch
+
+from ...autotuner.config_spec import CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY
+from ...language.matmul_ops import dot
+from ..compile_environment import CompileEnvironment
+from .chunk_prepare import _packed_workspace_is_proven
+from .chunk_prepare import _register_packed_workspace_specialization
+from .fx_matcher import _canonical_root_axis_ids
+from .fx_matcher import _is_call
+from .fx_matcher import _is_matrix_transpose_of
+from .fx_matcher import _linear_offsets_fit_i32
+from .fx_matcher import _load_ref
+from .fx_matcher import _memory_indices
+from .fx_matcher import _same_ref
+from .fx_matcher import _store_ref
+from .fx_matcher import _strip_value_casts
+from .fx_matcher import _TensorRef
+from .fx_matcher import _xyz_grid_fits
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from ..device_ir import GraphInfo
+    from ..generate_ast import GenerateAST
+    from ..tile_dispatch import TileStrategyDispatch
+
+
+_BT = 16
+_DK = 128
+_DV = 128
+_SM100_TMEM_THREADS = 512
+_SM100_TMEM_SMEM_BYTES = 138_240
+_SM100_TMEM_DEVICE_ABI = 2
+_SM100_WARP_DV4_THREADS = 192
+_SM100_WARP_DV4_SMEM_BYTES = 97_536
+_SM100_WARP_DV4_DEVICE_ABI = 3
+_SM100_WARP_DV4_INPUT_STAGES = 6
+_SM100_WARP_DV4_MAX_CHUNKS = 32
+
+
+def _select_sm100_dv_partitions(
+    *, total_chunks: int, sequences: int, heads: int, num_sm: int
+) -> int:
+    """Select DV4 only inside its measured short, underfilled envelope.
+
+    DV2 launches two CTAs per ``(sequence, head)``.  Splitting into four DV
+    partitions is useful when doubling that grid fills at most one machine
+    wave; once DV2 already fills half a wave, the duplicated factor traffic of
+    warp HMMA loses to the resident tcgen05 schedule.  Because only aggregate
+    chunk count is statically known, multi-sequence inputs conservatively stay
+    on DV2 rather than assuming their individual lengths are balanced.
+    """
+
+    if min(total_chunks, sequences, heads, num_sm) <= 0:
+        raise ValueError("recurrence geometry must be positive")
+    dv2_ctas = 2 * sequences * heads
+    short_single_sequence = (
+        sequences == 1 and total_chunks <= _SM100_WARP_DV4_MAX_CHUNKS
+    )
+    underfilled = 2 * dv2_ctas <= num_sm
+    return 4 if short_single_sequence and underfilled else 2
+
+
+@dataclasses.dataclass(frozen=True)
+class CuteChunkRecurrencePlan:
+    """Compile-time contract for the BT16 resident recurrence chain root."""
+
+    root_graph_id: int
+    heads: int
+    sequences: int
+    total_tokens: int
+    total_chunks: int
+    kd: _TensorRef
+    qd: _TensorRef
+    ak: _TensorRef
+    aq: _TensorRef
+    g_total: _TensorRef
+    values: _TensorRef
+    output: _TensorRef
+    state: _TensorRef
+    cu_seqlens: _TensorRef
+    cu_chunks: _TensorRef
+    output_scale: sympy.Expr
+    workspace_layout_version: int
+    schedule: str
+    threads: int
+    smem_bytes: int
+    device_abi: int
+    input_stages: int
+    tma_stages: int
+    factor_tma_value_splits: int
+    output_acc_stages: int
+    output_smem_stages: int
+    output_store_wait_groups: int
+    tmem_cols: int
+    dv_partitions: int
+
+
+@dataclasses.dataclass(frozen=True)
+class CuteChunkRecurrenceSearchGeometry:
+    """Static geometry exposed to the recurrence autotuner heuristic."""
+
+    total_chunks: int
+    sequences: int
+    heads: int
+
+
+@dataclasses.dataclass(frozen=True)
+class _CuteChunkRecurrenceMatch:
+    """Exact semantic/storage match shared by planning and autotune gating."""
+
+    root_graph_id: int
+    root_phase_index: int
+    heads: int
+    sequences: int
+    total_tokens: int
+    total_chunks: int
+    kd: _TensorRef
+    qd: _TensorRef
+    ak: _TensorRef
+    aq: _TensorRef
+    g_total: _TensorRef
+    values: _TensorRef
+    output: _TensorRef
+    state: _TensorRef
+    cu_seqlens: _TensorRef
+    cu_chunks: _TensorRef
+    sequence_coord: torch.fx.Node
+    head_coord: torch.fx.Node
+    value_coord: torch.fx.Node
+    output_scale: sympy.Expr | None
+
+
+def detect_chunk_recurrence_search_geometry(
+    graphs: Sequence[GraphInfo],
+) -> CuteChunkRecurrenceSearchGeometry | None:
+    """Recognize the exact BT16 recurrence before config codegen."""
+
+    match = _match_chunk_recurrence_graphs(graphs)
+    if (
+        match is None
+        or match.output_scale is None
+        or min(match.total_tokens, match.total_chunks, match.sequences, match.heads)
+        <= 0
+    ):
+        return None
+    env = CompileEnvironment.current()
+    if not _register_packed_workspace_specialization(
+        env,
+        tuple(
+            ref.fake for ref in (match.kd, match.qd, match.ak, match.aq, match.g_total)
+        ),
+    ):
+        return None
+    return CuteChunkRecurrenceSearchGeometry(
+        match.total_chunks,
+        match.sequences,
+        match.heads,
+    )
+
+
+def _tensor_refs(
+    nodes: Sequence[torch.fx.Node],
+) -> list[tuple[torch.fx.Node, _TensorRef]]:
+    result: list[tuple[torch.fx.Node, _TensorRef]] = []
+    for node in nodes:
+        ref = _load_ref(node)
+        if ref is not None:
+            result.append((node, ref))
+    return result
+
+
+def _single_ref_load(node: object) -> tuple[torch.fx.Node, _TensorRef] | None:
+    current = _strip_value_casts(node)
+    if current is None:
+        return None
+    ref = _load_ref(current)
+    return (current, ref) if ref is not None else None
+
+
+def _ancestors(node: object) -> set[torch.fx.Node]:
+    if not isinstance(node, torch.fx.Node):
+        return set()
+    pending = [node]
+    seen: set[torch.fx.Node] = set()
+    while pending:
+        current = pending.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        pending.extend(current.all_input_nodes)
+    return seen
+
+
+def _contains_target(node: object, targets: set[object]) -> bool:
+    return any(
+        current.op == "call_function" and current.target in targets
+        for current in _ancestors(node)
+    )
+
+
+def _output_store_contract(
+    nodes: Sequence[torch.fx.Node], output_value: torch.fx.Node
+) -> tuple[torch.fx.Node, sympy.Expr | None] | None:
+    """Match either ABI-v1 direct output or ABI-v2 post-accumulator scaling."""
+
+    from ...language._tracing_ops import _get_symnode
+
+    matches: list[tuple[torch.fx.Node, sympy.Expr | None]] = []
+    multiply_targets = {operator.mul, torch.ops.aten.mul.Tensor}
+    for node in nodes:
+        if _store_ref(node) is None or len(node.args) < 3:
+            continue
+        stored = _strip_value_casts(node.args[2])
+        if stored is output_value:
+            matches.append((node, None))
+            continue
+        if (
+            not isinstance(stored, torch.fx.Node)
+            or stored.op != "call_function"
+            or stored.target not in multiply_targets
+        ):
+            continue
+        operands = tuple(_strip_value_casts(value) for value in stored.args[:2])
+        if operands[0] is output_value:
+            scale_node = operands[1]
+        elif operands[1] is output_value:
+            scale_node = operands[0]
+        else:
+            continue
+        if not _is_call(scale_node, _get_symnode):
+            continue
+        assert isinstance(scale_node, torch.fx.Node)
+        value = scale_node.meta.get("val")
+        if not isinstance(value, torch.SymFloat):
+            continue
+        scale = value._sympy_()
+        if isinstance(scale, sympy.Expr):
+            matches.append((node, scale))
+    return matches[0] if len(matches) == 1 else None
+
+
+def _is_bf16_roundtrip(node: object) -> bool:
+    if not isinstance(node, torch.fx.Node):
+        return False
+    convert = torch.ops.prims.convert_element_type.default
+    if (
+        not _is_call(node, convert)
+        or len(node.args) < 2
+        or node.args[1] is not torch.float32
+    ):
+        return False
+    inner = node.args[0]
+    return (
+        isinstance(inner, torch.fx.Node)
+        and _is_call(inner, convert)
+        and len(inner.args) >= 2
+        and inner.args[1] is torch.bfloat16
+    )
+
+
+def _binary_args(
+    node: object, targets: tuple[object, ...]
+) -> tuple[object, object] | None:
+    if (
+        not isinstance(node, torch.fx.Node)
+        or node.op != "call_function"
+        or node.target not in targets
+        or len(node.args) != 2
+    ):
+        return None
+    return node.args[0], node.args[1]
+
+
+def _is_convert(node: object, source: object, dtype: torch.dtype) -> bool:
+    return bool(
+        isinstance(node, torch.fx.Node)
+        and _is_call(node, torch.ops.prims.convert_element_type.default)
+        and len(node.args) == 2
+        and node.args == (source, dtype)
+    )
+
+
+def _is_full_slice(value: object) -> bool:
+    return isinstance(value, slice) and value == slice(None)
+
+
+def _subscript_source(
+    node: object, indices: tuple[object, ...]
+) -> torch.fx.Node | None:
+    from ...language import view_ops
+
+    if (
+        not isinstance(node, torch.fx.Node)
+        or not _is_call(node, view_ops.subscript)
+        or len(node.args) != 2
+        or not isinstance(node.args[0], torch.fx.Node)
+        or not isinstance(node.args[1], (list, tuple))
+        or len(node.args[1]) != len(indices)
+    ):
+        return None
+    for actual, expected in zip(node.args[1], indices, strict=True):
+        if expected == "full":
+            if not _is_full_slice(actual):
+                return None
+        elif actual is not expected:
+            return None
+    return node.args[0]
+
+
+def _static_int(value: object) -> int | None:
+    if type(value) is int:
+        return value
+    if isinstance(value, torch.SymInt):
+        try:
+            return int(value)
+        except TypeError:
+            return None
+    if isinstance(value, torch.fx.Node):
+        return _static_int(value.meta.get("val"))
+    return None
+
+
+def _same_scalar_index(lhs: object, rhs: object) -> bool:
+    if lhs is rhs:
+        return True
+    if not isinstance(lhs, torch.fx.Node) or not isinstance(rhs, torch.fx.Node):
+        return False
+    lhs_value = lhs.meta.get("val")
+    rhs_value = rhs.meta.get("val")
+    if isinstance(lhs_value, torch.SymInt) and isinstance(rhs_value, torch.SymInt):
+        return lhs_value._sympy_() == rhs_value._sympy_()
+    return bool(
+        lhs.op == rhs.op == "call_function"
+        and lhs.target is rhs.target
+        and len(lhs.args) == len(rhs.args)
+        and all(
+            left is right or left == right
+            for left, right in zip(lhs.args, rhs.args, strict=True)
+        )
+        and lhs.kwargs == rhs.kwargs
+    )
+
+
+def _same_tile_index(lhs: object, rhs: object) -> bool:
+    from ...language.tile_ops import tile_index
+
+    return bool(
+        isinstance(lhs, torch.fx.Node)
+        and isinstance(rhs, torch.fx.Node)
+        and _is_call(lhs, tile_index)
+        and _is_call(rhs, tile_index)
+        and len(lhs.args) == len(rhs.args) == 1
+        and lhs.args[0] is rhs.args[0]
+    )
+
+
+def _recurrence_target_counts() -> tuple[Counter[object], Counter[object]]:
+    from ...language import memory_ops
+    from ...language import view_ops
+    from ...language._tracing_ops import _for_loop
+    from ...language._tracing_ops import _get_symnode
+    from ...language._tracing_ops import _host_tensor
+    from ...language._tracing_ops import _new_var
+    from ...language._tracing_ops import _phi
+    from ...language.tile_ops import tile_id
+    from ...language.tile_ops import tile_index
+
+    inner: Counter[object] = Counter(
+        {
+            _new_var: 4,
+            _get_symnode: 4,
+            tile_id: 2,
+            torch.ops.aten.add.Tensor: 10,
+            tile_index: 4,
+            torch.ops.aten.lt.Tensor: 1,
+            torch.ops.aten.mul.Tensor: 6,
+            operator.mul: 1,
+            torch.ops.prims.iota.default: 2,
+            torch.ops.aten.bitwise_xor.Scalar: 3,
+            view_ops.subscript: 11,
+            _host_tensor: 7,
+            memory_ops.load: 6,
+            torch.ops.aten.permute.default: 3,
+            torch.ops.prims.convert_element_type.default: 10,
+            dot: 4,
+            torch.ops.aten.sym_size.int: 1,
+            torch.ops.aten.sub.Tensor: 1,
+            torch.ops.aten.__rshift__.Scalar: 1,
+            torch.ops.aten.bitwise_and.Scalar: 1,
+            torch.ops.aten.__lshift__.Scalar: 1,
+            torch.ops.aten.bitwise_xor.Tensor: 1,
+            torch.ops.aten.div.Tensor_mode: 1,
+            memory_ops.store: 1,
+        }
+    )
+    root: Counter[object] = Counter(
+        {
+            _get_symnode: 3,
+            tile_id: 2,
+            _host_tensor: 3,
+            memory_ops.load: 4,
+            torch.ops.prims.convert_element_type.default: 5,
+            operator.add: 1,
+            torch.ops.aten.sub.Tensor: 1,
+            _for_loop: 1,
+            operator.getitem: 1,
+            _phi: 1,
+            memory_ops.store: 1,
+        }
+    )
+    return inner, root
+
+
+def _validate_recurrence_semantics(
+    *,
+    root: object,
+    loop: object,
+    projection: torch.fx.Node,
+    output_state: torch.fx.Node,
+    output_residual: torch.fx.Node,
+    update: torch.fx.Node,
+    state_phi: torch.fx.Node,
+    kd_load: torch.fx.Node,
+    qd_load: torch.fx.Node,
+    ak_load: torch.fx.Node,
+    aq_load: torch.fx.Node,
+    value_load: torch.fx.Node,
+    decay_load: torch.fx.Node,
+    output_store: torch.fx.Node,
+    state: _TensorRef,
+    cu_seqlens: _TensorRef,
+    cu_chunks: _TensorRef,
+    heads: int,
+    total_chunks: int,
+) -> bool:
+    """Validate the complete carrier dataflow, not merely its op multiset."""
+
+    from ...language._tracing_ops import _for_loop
+    from ...language._tracing_ops import _get_symnode
+    from ...language._tracing_ops import _new_var
+    from ...language._tracing_ops import _phi
+    from ...language.tile_ops import tile_id
+    from ...language.tile_ops import tile_index
+
+    inner_nodes = list(loop.graph.nodes)  # type: ignore[attr-defined]
+    root_nodes = list(root.graph.nodes)  # type: ignore[attr-defined]
+    expected_inner, expected_root = _recurrence_target_counts()
+    if (
+        Counter(node.target for node in inner_nodes if node.op == "call_function")
+        != expected_inner
+        or Counter(node.target for node in root_nodes if node.op == "call_function")
+        != expected_root
+    ):
+        return False
+
+    # The four contractions and every precision boundary are positional parts
+    # of the ABI implemented by the external schedule.
+    if any(
+        len(node.args) != 4 or node.args[3] is not torch.float32
+        for node in (
+            projection,
+            output_state,
+            output_residual,
+            update,
+        )
+    ):
+        return False
+    if projection.args[2] is not None or output_state.args[2] is not None:
+        return False
+    if output_residual.args[2] is not output_state or update.args[2] is not None:
+        return False
+
+    def bf16_transpose_of(node: object, source: torch.fx.Node) -> bool:
+        if not isinstance(node, torch.fx.Node) or not _is_convert(
+            node, node.args[0] if node.args else None, torch.bfloat16
+        ):
+            return False
+        transpose = node.args[0]
+        return bool(
+            isinstance(transpose, torch.fx.Node)
+            and _is_call(transpose, torch.ops.aten.permute.default)
+            and transpose.args == (source, [1, 0])
+        )
+
+    if not bf16_transpose_of(projection.args[1], state_phi) or not bf16_transpose_of(
+        output_state.args[1], state_phi
+    ):
+        return False
+
+    residual_to_bf16 = output_residual.args[1]
+    if not isinstance(residual_to_bf16, torch.fx.Node) or not _is_convert(
+        residual_to_bf16,
+        residual_to_bf16.args[0] if residual_to_bf16.args else None,
+        torch.bfloat16,
+    ):
+        return False
+    residual = residual_to_bf16.args[0]
+    if not isinstance(residual, torch.fx.Node) or not _is_convert(
+        residual, residual.args[0] if residual.args else None, torch.float32
+    ):
+        return False
+    rounded_residual = residual.args[0]
+    if not isinstance(rounded_residual, torch.fx.Node) or not _is_convert(
+        rounded_residual,
+        rounded_residual.args[0] if rounded_residual.args else None,
+        torch.bfloat16,
+    ):
+        return False
+    residual_sub = rounded_residual.args[0]
+    residual_args = _binary_args(residual_sub, (torch.ops.aten.sub.Tensor,))
+    if residual_args is None or residual_args[1] is not projection:
+        return False
+    value_f32 = residual_args[0]
+    if not _is_convert(value_f32, value_load, torch.float32):
+        return False
+    if not bf16_transpose_of(update.args[0], residual) or update.args[1] is not ak_load:
+        return False
+    if projection.args[0] is not kd_load or output_state.args[0] is not qd_load:
+        return False
+    if output_residual.args[0] is not aq_load:
+        return False
+
+    carried = next(iter(loop.graph.find_nodes(op="output"))).args[0]  # type: ignore[attr-defined]
+    if not isinstance(carried, (list, tuple)) or len(carried) != 1:
+        return False
+    next_state = carried[0]
+    if not isinstance(next_state, torch.fx.Node) or not _is_convert(
+        next_state, next_state.args[0] if next_state.args else None, torch.float32
+    ):
+        return False
+    next_state_bf16 = next_state.args[0]
+    if not isinstance(next_state_bf16, torch.fx.Node) or not _is_convert(
+        next_state_bf16,
+        next_state_bf16.args[0] if next_state_bf16.args else None,
+        torch.bfloat16,
+    ):
+        return False
+    state_add = next_state_bf16.args[0]
+    state_add_args = _binary_args(state_add, (torch.ops.aten.add.Tensor,))
+    if state_add_args is None or state_add_args[1] is not update:
+        return False
+    state_decay = state_add_args[0]
+    state_decay_args = _binary_args(state_decay, (torch.ops.aten.mul.Tensor,))
+    if state_decay_args is None or state_decay_args[0] is not state_phi:
+        return False
+    decay_broadcast = state_decay_args[1]
+    if _subscript_source(decay_broadcast, (None, "full")) is not decay_load:
+        return False
+
+    # Recover the root loop values, then pin the loop extent and carry order.
+    root_loads = _tensor_refs(root_nodes)
+    state_loads = [node for node, ref in root_loads if _same_ref(ref, state)]
+    seq_loads = [node for node, ref in root_loads if _same_ref(ref, cu_seqlens)]
+    chunk_loads = [node for node, ref in root_loads if _same_ref(ref, cu_chunks)]
+    root_stores = [node for node in root_nodes if _store_ref(node) is not None]
+    loop_calls = [node for node in root_nodes if _is_call(node, _for_loop)]
+    if not (
+        len(state_loads) == 1
+        and len(seq_loads) == 2
+        and len(chunk_loads) == 1
+        and len(root_stores) == 1
+        and len(loop_calls) == 1
+    ):
+        return False
+    state_load = state_loads[0]
+    chunk_load = chunk_loads[0]
+    loop_call = loop_calls[0]
+    state_indices = _memory_indices(state_load)
+    state_store_indices = _memory_indices(root_stores[0])
+    if (
+        state_indices is None
+        or state_store_indices is None
+        or len(state_indices) != 4
+        or len(state_store_indices) != 4
+        or any(
+            (not _is_full_slice(lhs) if _is_full_slice(rhs) else lhs is not rhs)
+            for lhs, rhs in zip(state_indices, state_store_indices, strict=True)
+        )
+        or not _is_full_slice(state_indices[3])
+        or any(
+            len(node.args) != 4 or node.args[2:] != (None, None)
+            for node in (
+                state_load,
+                *seq_loads,
+                chunk_load,
+            )
+        )
+    ):
+        return False
+    sequence_index = state_indices[0]
+    head_index = state_indices[1]
+    value_index = state_indices[2]
+    if (
+        not _is_call(sequence_index, tile_id)
+        or not _is_call(head_index, tile_id)
+        or not _is_call(value_index, _get_symnode)
+        or _same_scalar_index(sequence_index, head_index)
+    ):
+        return False
+
+    begin_load = next(
+        (node for node in seq_loads if _memory_indices(node) == (sequence_index,)),
+        None,
+    )
+    end_load = next(
+        (
+            node
+            for node in seq_loads
+            if (
+                (indices := _memory_indices(node)) is not None
+                and len(indices) == 1
+                and _binary_args(indices[0], (operator.add,)) == (sequence_index, 1)
+            )
+        ),
+        None,
+    )
+    if (
+        begin_load is None
+        or end_load is None
+        or _memory_indices(chunk_load) != (sequence_index,)
+    ):
+        return False
+    begin = next(
+        (
+            node
+            for node in begin_load.users
+            if _is_convert(node, begin_load, torch.int64)
+        ),
+        None,
+    )
+    end = next(
+        (node for node in end_load.users if _is_convert(node, end_load, torch.int64)),
+        None,
+    )
+    chunk_begin = next(
+        (
+            node
+            for node in chunk_load.users
+            if _is_convert(node, chunk_load, torch.int64)
+        ),
+        None,
+    )
+    initial_state = next(
+        (
+            node
+            for node in state_load.users
+            if _is_convert(node, state_load, torch.float32)
+        ),
+        None,
+    )
+    if any(value is None for value in (begin, end, chunk_begin, initial_state)):
+        return False
+    extent = loop_call.args[2] if len(loop_call.args) > 2 else None
+    initial = loop_call.args[3] if len(loop_call.args) > 3 else None
+    if (
+        loop_call.args[0] != loop.graph_id  # type: ignore[attr-defined]
+        or loop_call.args[1] != [0]
+        or not isinstance(extent, (list, tuple))
+        or len(extent) != 1
+        or _binary_args(extent[0], (torch.ops.aten.sub.Tensor,)) != (end, begin)
+        or initial != [end, begin, chunk_begin, initial_state]
+    ):
+        return False
+    placeholders = [node for node in inner_nodes if node.op == "placeholder"]
+    new_vars = [node for node in inner_nodes if _is_call(node, _new_var)]
+    if (
+        len(placeholders) != 4
+        or len(new_vars) != 4
+        or any(
+            node.args != (placeholder,)
+            for node, placeholder in zip(new_vars, placeholders, strict=True)
+        )
+        or state_phi is not new_vars[3]
+    ):
+        return False
+    end_phi, begin_phi, chunk_phi, _ = new_vars
+
+    value_size_nodes = [
+        node for node in inner_nodes if _is_call(node, torch.ops.aten.sym_size.int)
+    ]
+    if (
+        len(value_size_nodes) != 1
+        or value_size_nodes[0].args != (placeholders[3], 0)
+        or not _same_scalar_index(value_index, value_size_nodes[0])
+    ):
+        return False
+    value_size = value_size_nodes[0]
+
+    tile_indices = [node for node in inner_nodes if _is_call(node, tile_index)]
+    tile_ids = [node for node in inner_nodes if _is_call(node, tile_id)]
+    iotas = [
+        node for node in inner_nodes if _is_call(node, torch.ops.prims.iota.default)
+    ]
+    if len(tile_indices) != 4 or len(tile_ids) != 2 or len(iotas) != 2:
+        return False
+    token_tile_id = tile_ids[0]
+    inner_head = tile_ids[1]
+    token_lane = tile_indices[0]
+    if (
+        not _same_scalar_index(inner_head, head_index)
+        or len(token_tile_id.args) != 1
+        or len(token_lane.args) != 1
+        or token_tile_id.args[0] is not token_lane.args[0]
+    ):
+        return False
+    feature = next((node for node in iotas if _static_int(node.args[0]) == _DK), None)
+    logical_col_iota = next(
+        (node for node in iotas if _static_int(node.args[0]) == _BT), None
+    )
+    if feature is None or logical_col_iota is None:
+        return False
+    global_chunk = next(
+        (
+            node
+            for node in inner_nodes
+            if _binary_args(node, (torch.ops.aten.add.Tensor,))
+            == (chunk_phi, token_tile_id)
+        ),
+        None,
+    )
+    token = next(
+        (
+            node
+            for node in inner_nodes
+            if _binary_args(node, (torch.ops.aten.add.Tensor,))
+            == (begin_phi, token_lane)
+        ),
+        None,
+    )
+    if global_chunk is None or token is None:
+        return False
+    valid = next(
+        (
+            node
+            for node in inner_nodes
+            if _binary_args(node, (torch.ops.aten.lt.Tensor,)) == (token, end_phi)
+        ),
+        None,
+    )
+    row_mul = next(
+        (
+            node
+            for node in inner_nodes
+            if _binary_args(node, (torch.ops.aten.mul.Tensor,)) == (token, heads)
+        ),
+        None,
+    )
+    row = next(
+        (
+            node
+            for node in inner_nodes
+            if row_mul is not None
+            and _binary_args(node, (torch.ops.aten.add.Tensor,))
+            == (row_mul, inner_head)
+        ),
+        None,
+    )
+    head_chunks = next(
+        (
+            node
+            for node in inner_nodes
+            if _binary_args(node, (operator.mul,)) == (inner_head, total_chunks)
+        ),
+        None,
+    )
+    chunk_head = next(
+        (
+            node
+            for node in inner_nodes
+            if head_chunks is not None
+            and _binary_args(node, (torch.ops.aten.add.Tensor,))
+            == (global_chunk, head_chunks)
+        ),
+        None,
+    )
+    factor_base = next(
+        (
+            node
+            for node in inner_nodes
+            if chunk_head is not None
+            and (args := _binary_args(node, (torch.ops.aten.mul.Tensor,))) is not None
+            and args[0] is chunk_head
+            and _static_int(args[1]) == _BT
+        ),
+        None,
+    )
+    factor_row = next(
+        (
+            node
+            for node in inner_nodes
+            if factor_base is not None
+            and (args := _binary_args(node, (torch.ops.aten.add.Tensor,))) is not None
+            and args[0] is factor_base
+            and _same_tile_index(args[1], token_lane)
+        ),
+        None,
+    )
+    if any(
+        value is None for value in (valid, row, chunk_head, factor_base, factor_row)
+    ):
+        return False
+
+    kd_indices = _memory_indices(kd_load)
+    qd_indices = _memory_indices(qd_load)
+    ak_indices = _memory_indices(ak_load)
+    aq_indices = _memory_indices(aq_load)
+    decay_indices = _memory_indices(decay_load)
+    value_indices = _memory_indices(value_load)
+    if any(
+        indices is None
+        for indices in (
+            kd_indices,
+            qd_indices,
+            ak_indices,
+            aq_indices,
+            decay_indices,
+            value_indices,
+        )
+    ):
+        return False
+    assert kd_indices is not None
+    assert qd_indices is not None
+    assert ak_indices is not None
+    assert aq_indices is not None
+    assert decay_indices is not None
+    assert value_indices is not None
+    if (
+        not all(
+            len(indices) == 2
+            for indices in (
+                kd_indices,
+                qd_indices,
+                ak_indices,
+                aq_indices,
+                value_indices,
+            )
+        )
+        or len(decay_indices) != 2
+    ):
+        return False
+    kd_row = _subscript_source(kd_indices[0], ("full", None))
+    qd_row = _subscript_source(qd_indices[0], ("full", None))
+    kd_feature = _subscript_source(kd_indices[1], (None, "full"))
+    qd_feature = _subscript_source(qd_indices[1], (None, "full"))
+    physical_feature_args = _binary_args(
+        kd_feature, (torch.ops.aten.bitwise_xor.Scalar,)
+    )
+    if not (
+        kd_row is factor_row
+        and qd_row is factor_row
+        and kd_feature is qd_feature
+        and physical_feature_args == (feature, 8)
+    ):
+        return False
+    if not all(
+        len(node.args) == 4 and node.args[2:] == (None, None)
+        for node in (kd_load, qd_load, aq_load, ak_load, decay_load)
+    ):
+        return False
+    value_mask = _subscript_source(value_load.args[2], ("full", None))
+    if (
+        value_indices[0] is not row
+        or value_indices[1] is not value_size
+        or value_mask is not valid
+        or len(value_load.args) != 4
+        or value_load.args[3] is not None
+    ):
+        return False
+
+    ak_row = _subscript_source(ak_indices[0], ("full", None))
+    ak_feature = _subscript_source(ak_indices[1], (None, "full"))
+    ak_row_args = _binary_args(ak_row, (torch.ops.aten.add.Tensor,))
+    if (
+        ak_row_args is None
+        or ak_row_args[0] is not factor_base
+        or ak_feature is not feature
+    ):
+        return False
+    ak_lane_args = _binary_args(ak_row_args[1], (torch.ops.aten.bitwise_xor.Scalar,))
+    if (
+        ak_lane_args is None
+        or not _same_tile_index(ak_lane_args[0], token_lane)
+        or ak_lane_args[1] != 8
+    ):
+        return False
+    if (
+        not _same_scalar_index(aq_indices[0], chunk_head)
+        or not _same_scalar_index(decay_indices[0], chunk_head)
+        or not _is_full_slice(decay_indices[1])
+    ):
+        return False
+
+    pair_index = aq_indices[1]
+    pair_args = _binary_args(pair_index, (torch.ops.aten.div.Tensor_mode,))
+    if (
+        pair_args is None
+        or pair_args[1] != 2
+        or not isinstance(pair_index, torch.fx.Node)
+        or pair_index.kwargs != {"rounding_mode": "floor"}
+    ):
+        return False
+    pair_xor_args = _binary_args(pair_args[0], (torch.ops.aten.bitwise_xor.Tensor,))
+    if pair_xor_args is None:
+        return False
+    byte_offset, shifted = pair_xor_args
+    byte_args = _binary_args(byte_offset, (torch.ops.aten.mul.Tensor,))
+    shifted_args = _binary_args(shifted, (torch.ops.aten.__lshift__.Scalar,))
+    if (
+        byte_args is None
+        or byte_args[1] != 2
+        or shifted_args is None
+        or shifted_args[1] != 4
+    ):
+        return False
+    offset_args = _binary_args(byte_args[0], (torch.ops.aten.add.Tensor,))
+    masked_args = _binary_args(shifted_args[0], (torch.ops.aten.bitwise_and.Scalar,))
+    if offset_args is None or masked_args is None or masked_args[1] != 1:
+        return False
+    row_offset_args = _binary_args(offset_args[0], (torch.ops.aten.mul.Tensor,))
+    storage_col_args = _binary_args(
+        offset_args[1], (torch.ops.aten.bitwise_xor.Scalar,)
+    )
+    shifted_byte_args = _binary_args(
+        masked_args[0], (torch.ops.aten.__rshift__.Scalar,)
+    )
+    logical_row = (
+        _subscript_source(row_offset_args[0], ("full", None))
+        if row_offset_args is not None
+        else None
+    )
+    logical_col = (
+        _subscript_source(storage_col_args[0], (None, "full"))
+        if storage_col_args is not None
+        else None
+    )
+    if not (
+        row_offset_args is not None
+        and _static_int(row_offset_args[1]) == _BT
+        and storage_col_args is not None
+        and storage_col_args[1] == 8
+        and shifted_byte_args == (byte_offset, 7)
+        and logical_row is not None
+        and _same_tile_index(logical_row, token_lane)
+        and logical_col is logical_col_iota
+    ):
+        return False
+
+    stored = output_store.args[2]
+    if (
+        len(output_store.args) != 4
+        or not isinstance(stored, torch.fx.Node)
+        or not _is_convert(
+            stored, stored.args[0] if stored.args else None, torch.bfloat16
+        )
+    ):
+        return False
+    scaled_output = stored.args[0]
+    scale_args = _binary_args(scaled_output, (torch.ops.aten.mul.Tensor,))
+    output_indices = _memory_indices(output_store)
+    output_mask = _subscript_source(output_store.args[3], ("full", None))
+    if (
+        scale_args is None
+        or scale_args[0] is not output_residual
+        or not _is_call(scale_args[1], _get_symnode)
+        or output_indices != value_indices
+        or output_mask is not valid
+    ):
+        return False
+
+    # Pin root writeback to the loop-carried value and preserve operand order.
+    getitems = [node for node in root_nodes if _is_call(node, operator.getitem)]
+    phis = [node for node in root_nodes if _is_call(node, _phi)]
+    if len(getitems) != 1 or len(phis) != 1:
+        return False
+    if getitems[0].args != (loop_call, 0) or phis[0].args != (
+        initial_state,
+        getitems[0],
+    ):
+        return False
+    stored_state = root_stores[0].args[2]
+    return bool(
+        _is_convert(stored_state, phis[0], torch.bfloat16)
+        and len(root_stores[0].args) == 4
+        and root_stores[0].args[3] is None
+    )
+
+
+def _match_chunk_recurrence_graphs(
+    graphs: Sequence[GraphInfo],
+) -> _CuteChunkRecurrenceMatch | None:
+    """Recognize only the supported semantic and storage contract."""
+
+    from ...language._tracing_ops import _for_loop
+    from ...language._tracing_ops import _new_var
+    from ..device_ir import ForLoopGraphInfo
+    from ..device_ir import RootGraphInfo
+
+    roots = [graph for graph in graphs if isinstance(graph, RootGraphInfo)]
+    loops = [graph for graph in graphs if isinstance(graph, ForLoopGraphInfo)]
+    if len(graphs) != 2 or len(roots) != 1 or len(loops) != 1:
+        return None
+    root, loop = roots[0], loops[0]
+    if len(loop.block_ids) != 1:
+        return None
+
+    inner = list(loop.graph.nodes)
+    dots = [node for node in inner if _is_call(node, dot)]
+    if len(dots) != 4:
+        return None
+    projection, output_state, output_residual, update = dots
+    if any(
+        not isinstance(node.meta.get("val"), torch.Tensor)
+        or cast("torch.Tensor", node.meta["val"]).dtype is not torch.float32
+        for node in dots
+    ):
+        return None
+
+    projection_lhs = _single_ref_load(projection.args[0])
+    output_state_lhs = _single_ref_load(output_state.args[0])
+    output_residual_lhs = _single_ref_load(output_residual.args[0])
+    update_rhs = _single_ref_load(update.args[1])
+    if any(
+        item is None
+        for item in (
+            projection_lhs,
+            output_state_lhs,
+            output_residual_lhs,
+            update_rhs,
+        )
+    ):
+        return None
+    assert projection_lhs is not None
+    assert output_state_lhs is not None
+    assert output_residual_lhs is not None
+    assert update_rhs is not None
+    kd_load, kd = projection_lhs
+    qd_load, qd = output_state_lhs
+    aq_load, aq = output_residual_lhs
+    ak_load, ak = update_rhs
+
+    projection_state = _strip_value_casts(projection.args[1])
+    state_phi = (
+        _strip_value_casts(projection_state.args[0])
+        if isinstance(projection_state, torch.fx.Node) and projection_state.args
+        else None
+    )
+    if (
+        not _is_call(state_phi, _new_var)
+        or not _is_matrix_transpose_of(
+            projection.args[1], cast("torch.fx.Node", state_phi)
+        )
+        or not _is_matrix_transpose_of(
+            output_state.args[1], cast("torch.fx.Node", state_phi)
+        )
+    ):
+        return None
+    assert isinstance(state_phi, torch.fx.Node)
+
+    # Both residual consumers must see the same explicit BF16-rounded value.
+    residual_operand = output_residual.args[1]
+    residual = (
+        residual_operand.args[0]
+        if isinstance(residual_operand, torch.fx.Node)
+        and _is_call(residual_operand, torch.ops.prims.convert_element_type.default)
+        and len(residual_operand.args) >= 2
+        and residual_operand.args[1] is torch.bfloat16
+        else None
+    )
+    if (
+        len(output_residual.args) < 3
+        or output_residual.args[2] is not output_state
+        or not isinstance(residual, torch.fx.Node)
+        or not _is_bf16_roundtrip(residual)
+        or not _is_matrix_transpose_of(update.args[0], residual)
+    ):
+        return None
+    residual_source = cast("torch.fx.Node", residual.args[0]).args[0]
+    if not isinstance(residual_source, torch.fx.Node):
+        return None
+    # The source contains exactly V plus GTotal after removing the four factors;
+    # choose V by ancestry of the rounded residual rather than by source name.
+    ancestors = _ancestors(residual_source)
+    if projection not in ancestors or not _contains_target(
+        residual_source, {operator.sub, torch.ops.aten.sub.Tensor}
+    ):
+        return None
+    candidate_value_loads = [
+        node
+        for node in ancestors
+        if _load_ref(node) is not None and node is not kd_load
+    ]
+    if len(candidate_value_loads) != 1:
+        return None
+    value_load = candidate_value_loads[0]
+    values = _load_ref(value_load)
+    if values is None:
+        return None
+
+    output_contract = _output_store_contract(inner, output_residual)
+    if output_contract is None:
+        return None
+    output_store, output_scale = output_contract
+    output = _store_ref(output_store)
+    if output_store is None or output is None:
+        return None
+
+    # The only remaining inner load is GTotal.  Its value must feed the state
+    # update together with the fourth dot, and that result must round via BF16.
+    all_loads = _tensor_refs(inner)
+    factor_and_value_nodes = {kd_load, qd_load, aq_load, ak_load, value_load}
+    remaining = [
+        (node, ref) for node, ref in all_loads if node not in factor_and_value_nodes
+    ]
+    if len(remaining) != 1:
+        return None
+    decay_load, g_total = remaining[0]
+    loop_outputs = list(loop.graph.find_nodes(op="output"))
+    if len(loop_outputs) != 1 or len(loop_outputs[0].args) != 1:
+        return None
+    carried = loop_outputs[0].args[0]
+    if (
+        not isinstance(carried, (list, tuple))
+        or len(carried) != 1
+        or not _is_bf16_roundtrip(carried[0])
+        or not _contains_target(carried[0], {operator.add, torch.ops.aten.add.Tensor})
+    ):
+        return None
+    carried_ancestors = _ancestors(carried[0])
+    if not {update, decay_load, state_phi}.issubset(carried_ancestors):
+        return None
+
+    inner_load_nodes = {node for node, _ref in all_loads}
+    inner_stores = {node for node in inner if _store_ref(node) is not None}
+    if inner_load_nodes != {
+        kd_load,
+        qd_load,
+        aq_load,
+        ak_load,
+        value_load,
+        decay_load,
+    } or inner_stores != {output_store}:
+        return None
+    if any(
+        len(node.args) >= 3 and node.args[2] is not None
+        for node in (kd_load, qd_load, aq_load, ak_load, decay_load)
+    ):
+        return None
+    ak_indices = _memory_indices(ak_load)
+    aq_indices = _memory_indices(aq_load)
+    if not ak_indices or not _contains_target(
+        ak_indices[0], {torch.ops.aten.bitwise_xor.Scalar}
+    ):
+        return None
+    if (
+        not aq_indices
+        or len(aq_indices) < 2
+        or not _contains_target(
+            aq_indices[1],
+            {
+                torch.ops.aten.bitwise_xor.Scalar,
+                torch.ops.aten.bitwise_xor.Tensor,
+            },
+        )
+    ):
+        return None
+
+    root_nodes = list(root.graph.nodes)
+    loop_calls = [node for node in root_nodes if _is_call(node, _for_loop)]
+    root_stores = [node for node in root_nodes if _store_ref(node) is not None]
+    root_loads = _tensor_refs(root_nodes)
+    if len(loop_calls) != 1 or len(root_stores) != 1 or len(root_loads) != 4:
+        return None
+    state = _store_ref(root_stores[0])
+    state_loads = [(node, ref) for node, ref in root_loads if _same_ref(ref, state)]
+    if state is None or len(state_loads) != 1:
+        return None
+    metadata = [(node, ref) for node, ref in root_loads if not _same_ref(ref, state)]
+    by_ref: dict[tuple[str, int], list[tuple[torch.fx.Node, _TensorRef]]] = {}
+    for node, ref in metadata:
+        by_ref.setdefault((ref.name, id(ref.fake)), []).append((node, ref))
+    groups = sorted(by_ref.values(), key=len, reverse=True)
+    if len(groups) != 2 or tuple(map(len, groups)) != (2, 1):
+        return None
+    cu_seqlens = groups[0][0][1]
+    cu_chunks = groups[1][0][1]
+
+    refs = (kd, qd, ak, aq, g_total, values, output, state, cu_seqlens, cu_chunks)
+    if any(ref.fake.device.type != "cuda" for ref in refs):
+        return None
+    if any(not ref.fake.is_contiguous() for ref in refs):
+        return None
+    if any(
+        ref.fake.dtype is not torch.bfloat16
+        for ref in (kd, qd, ak, aq, values, output, state)
+    ):
+        return None
+    if g_total.fake.dtype is not torch.float32:
+        return None
+    if (
+        cu_seqlens.fake.dtype is not torch.int32
+        or cu_chunks.fake.dtype is not torch.int32
+    ):
+        return None
+
+    if state.fake.ndim != 4:
+        return None
+    sequences, heads, value_size, key_size = map(int, state.fake.shape)
+    if key_size != _DK or value_size != _DV or sequences <= 0 or heads <= 0:
+        return None
+    if values.fake.ndim != 2 or output.fake.ndim != 2:
+        return None
+    if tuple(values.fake.shape) != tuple(output.fake.shape):
+        return None
+    total_tokens_times_heads, activation_width = map(int, values.fake.shape)
+    if activation_width != _DV or total_tokens_times_heads % heads:
+        return None
+    total_tokens = total_tokens_times_heads // heads
+    if aq.fake.ndim != 2 or aq.fake.shape[1] != _BT * _BT:
+        return None
+    total_chunk_heads = int(aq.fake.shape[0])
+    if total_chunk_heads % heads:
+        return None
+    total_chunks = total_chunk_heads // heads
+    rows = heads * total_chunks * _BT
+    if any(tuple(ref.fake.shape) != (rows, _DK) for ref in (kd, qd, ak)):
+        return None
+    if tuple(g_total.fake.shape) != (heads * total_chunks, _DK):
+        return None
+    if tuple(cu_seqlens.fake.shape) != (sequences + 1,) or tuple(
+        cu_chunks.fake.shape
+    ) != (sequences + 1,):
+        return None
+    if not _validate_recurrence_semantics(
+        root=root,
+        loop=loop,
+        projection=projection,
+        output_state=output_state,
+        output_residual=output_residual,
+        update=update,
+        state_phi=state_phi,
+        kd_load=kd_load,
+        qd_load=qd_load,
+        ak_load=ak_load,
+        aq_load=aq_load,
+        value_load=value_load,
+        decay_load=decay_load,
+        output_store=output_store,
+        state=state,
+        cu_seqlens=cu_seqlens,
+        cu_chunks=cu_chunks,
+        heads=heads,
+        total_chunks=total_chunks,
+    ):
+        return None
+    state_indices = _memory_indices(state_loads[0][0])
+    if (
+        state_indices is None
+        or len(state_indices) != 4
+        or not all(isinstance(index, torch.fx.Node) for index in state_indices[:3])
+    ):
+        return None
+    return _CuteChunkRecurrenceMatch(
+        root_graph_id=root.graph_id,
+        root_phase_index=root.phase_index,
+        heads=heads,
+        sequences=sequences,
+        total_tokens=total_tokens,
+        total_chunks=total_chunks,
+        kd=kd,
+        qd=qd,
+        ak=ak,
+        aq=aq,
+        g_total=g_total,
+        values=values,
+        output=output,
+        state=state,
+        cu_seqlens=cu_seqlens,
+        cu_chunks=cu_chunks,
+        sequence_coord=cast("torch.fx.Node", state_indices[0]),
+        head_coord=cast("torch.fx.Node", state_indices[1]),
+        value_coord=cast("torch.fx.Node", state_indices[2]),
+        output_scale=output_scale,
+    )
+
+
+def _plan_chunk_recurrence(
+    graphs: Sequence[GraphInfo],
+    _tile_strategy: TileStrategyDispatch,
+) -> CuteChunkRecurrencePlan | None:
+    from ..device_function import DeviceFunction
+    from ..host_function import HostFunction
+
+    if DeviceFunction.current().config.pid_type != "flat":
+        return None
+    match = _match_chunk_recurrence_graphs(graphs)
+    if (
+        match is None
+        or match.output_scale is None
+        or min(match.total_tokens, match.total_chunks, match.sequences, match.heads)
+        <= 0
+    ):
+        return None
+    env = CompileEnvironment.current()
+    if not _packed_workspace_is_proven(env):
+        return None
+    target = env.config_spec.target_device_capability
+    if target is None or target[0] != 10:
+        return None
+
+    # The exact body owns a DV64 CTA.  Confirm the carrier has exactly the three
+    # semantic outer axes and that only the value axis is split.
+    device_ir = HostFunction.current().device_ir
+    grid_ids = _canonical_root_axis_ids(
+        device_ir,
+        root_phase_index=match.root_phase_index,
+        coordinates=(
+            match.sequence_coord,
+            match.head_coord,
+            match.value_coord,
+        ),
+        expected_extents=(match.sequences, match.heads, _DV),
+    )
+    if grid_ids is None or [
+        DeviceFunction.current().resolved_block_size(block_id) for block_id in grid_ids
+    ] != [1, 1, 64]:
+        return None
+
+    preferred_dv_partitions = _select_sm100_dv_partitions(
+        total_chunks=match.total_chunks,
+        sequences=match.sequences,
+        heads=match.heads,
+        num_sm=env.config_spec.num_sm,
+    )
+    configured_dv_partitions = DeviceFunction.current().config.get(
+        CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY,
+        preferred_dv_partitions,
+    )
+    if type(configured_dv_partitions) is not int or configured_dv_partitions not in (
+        2,
+        4,
+    ):
+        return None
+    dv_partitions = configured_dv_partitions
+    use_sm100_warp_dv4 = dv_partitions == 4
+    schedule = "sm100_warp_dv4" if use_sm100_warp_dv4 else "sm100_tmem"
+    refs = (
+        match.kd,
+        match.qd,
+        match.ak,
+        match.aq,
+        match.g_total,
+        match.values,
+        match.output,
+        match.state,
+        match.cu_seqlens,
+        match.cu_chunks,
+    )
+    grid = (
+        (match.sequences * 4, match.heads, 1)
+        if use_sm100_warp_dv4
+        else (match.sequences, match.heads * 2, 1)
+    )
+    if not _linear_offsets_fit_i32(
+        match.sequences * match.heads * dv_partitions,
+        tuple(ref.fake.numel() for ref in refs),
+    ) or not _xyz_grid_fits(grid):
+        return None
+    return CuteChunkRecurrencePlan(
+        root_graph_id=match.root_graph_id,
+        heads=match.heads,
+        sequences=match.sequences,
+        total_tokens=match.total_tokens,
+        total_chunks=match.total_chunks,
+        kd=match.kd,
+        qd=match.qd,
+        ak=match.ak,
+        aq=match.aq,
+        g_total=match.g_total,
+        values=match.values,
+        output=match.output,
+        state=match.state,
+        cu_seqlens=match.cu_seqlens,
+        cu_chunks=match.cu_chunks,
+        output_scale=match.output_scale,
+        workspace_layout_version=2,
+        schedule=schedule,
+        threads=(
+            _SM100_WARP_DV4_THREADS if use_sm100_warp_dv4 else _SM100_TMEM_THREADS
+        ),
+        smem_bytes=(
+            _SM100_WARP_DV4_SMEM_BYTES if use_sm100_warp_dv4 else _SM100_TMEM_SMEM_BYTES
+        ),
+        device_abi=(
+            _SM100_WARP_DV4_DEVICE_ABI if use_sm100_warp_dv4 else _SM100_TMEM_DEVICE_ABI
+        ),
+        input_stages=(_SM100_WARP_DV4_INPUT_STAGES if use_sm100_warp_dv4 else 8),
+        tma_stages=6,
+        factor_tma_value_splits=(1 if use_sm100_warp_dv4 else 2),
+        output_acc_stages=2,
+        output_smem_stages=(3 if use_sm100_warp_dv4 else 7),
+        output_store_wait_groups=(0 if use_sm100_warp_dv4 else 6),
+        tmem_cols=(0 if use_sm100_warp_dv4 else 512),
+        dv_partitions=dv_partitions,
+    )
+
+
+def plan_chunk_recurrence(
+    graphs: Sequence[GraphInfo], tile_strategy: TileStrategyDispatch
+) -> None:
+    from ..device_function import DeviceFunction
+
+    DeviceFunction.current().cute_state.chunk_recurrence_plan = _plan_chunk_recurrence(
+        graphs, tile_strategy
+    )
+
+
+def _tensor_arg(cg: GenerateAST, ref: _TensorRef) -> str:
+    return cg.device_function.tensor_arg(ref.fake, prefer_name=ref.name).name
+
+
+def _emit_module_imports(cg: GenerateAST, schedule: str) -> None:
+    if getattr(cg, "_helion_chunk_recurrence_module_emitted", False):
+        return
+    cg._helion_chunk_recurrence_module_emitted = True  # type: ignore[attr-defined]
+    if schedule == "sm100_tmem":
+        helper_name = cg.device_function.new_var("_helion_sm100_chain_host")
+        source = (
+            "from helion._compiler.cute.chunk_recurrence_sm100 "
+            f"import host_chain_dv2 as {helper_name}"
+        )
+    elif schedule == "sm100_warp_dv4":
+        helper_name = cg.device_function.new_var("_helion_sm100_warp_dv4_host")
+        source = (
+            "from helion._compiler.cute.chunk_recurrence_dv4_sm100 "
+            f"import _recurrence_entry as {helper_name}"
+        )
+    else:
+        raise ValueError(f"unsupported chunk-recurrence schedule {schedule!r}")
+    cg.module_statements.extend(ast.parse(source).body)
+
+
+def codegen_chunk_recurrence(cg: GenerateAST) -> bool:
+    """Replace the matched root with the vendored exact device body."""
+
+    df = cg.device_function
+    plan = df.cute_state.chunk_recurrence_plan
+    root = cg.current_root_graph_info
+    if plan is None or root is None or root.graph_id != plan.root_graph_id:
+        return False
+
+    refs = (
+        plan.kd,
+        plan.qd,
+        plan.ak,
+        plan.aq,
+        plan.g_total,
+        plan.values,
+        plan.output,
+        plan.state,
+        plan.cu_seqlens,
+        plan.cu_chunks,
+    )
+    names = tuple(_tensor_arg(cg, ref) for ref in refs)
+    kd, qd, ak, aq, gt, values, output, state, cu_seqlens, cu_chunks = names
+    _emit_module_imports(cg, plan.schedule)
+    if plan.schedule == "sm100_tmem":
+        output_scale = df.literal_expr(plan.output_scale)
+        if not output_scale.isidentifier():
+            return False
+        if (
+            plan.threads != _SM100_TMEM_THREADS
+            or plan.device_abi != _SM100_TMEM_DEVICE_ABI
+            or plan.input_stages != 8
+            or plan.tma_stages != 6
+            or plan.factor_tma_value_splits != 2
+            or plan.output_acc_stages != 2
+            or plan.output_smem_stages != 7
+            or plan.output_store_wait_groups != 6
+            or plan.tmem_cols != 512
+        ):
+            return False
+        cg.cute_wrapper_plans.append(
+            {
+                "kind": "chunk_recurrence_sm100",
+                "kd_name": kd,
+                "qd_name": qd,
+                "ak_name": ak,
+                "aq_name": aq,
+                "gt_name": gt,
+                "v_name": values,
+                "out_name": output,
+                "state_name": state,
+                "cu_seqlens_name": cu_seqlens,
+                "cu_chunks_name": cu_chunks,
+                "heads": plan.heads,
+                "sequences": plan.sequences,
+                "total_tokens": plan.total_tokens,
+                "total_chunks": plan.total_chunks,
+                "chunk_size": _BT,
+                "key_size": _DK,
+                "value_size": _DV,
+                "threads": plan.threads,
+                "smem_bytes": plan.smem_bytes,
+                "workspace_layout_version": plan.workspace_layout_version,
+                "factor_key_xor": 8,
+                "outputs_scaled": False,
+                "scale_name": output_scale,
+                "device_abi": plan.device_abi,
+                "input_stages": plan.input_stages,
+                "tma_stages": plan.tma_stages,
+                "factor_tma_value_splits": plan.factor_tma_value_splits,
+                "output_acc_stages": plan.output_acc_stages,
+                "output_smem_stages": plan.output_smem_stages,
+                "output_store_wait_groups": plan.output_store_wait_groups,
+                "tmem_cols": plan.tmem_cols,
+                "dv_partitions": plan.dv_partitions,
+            }
+        )
+        df.placeholder_args.update((*names, output_scale))
+        df.preamble = []
+        df.body = [ast.Pass()]
+        cg.cute_uses_matmul = True
+        return True
+
+    if plan.schedule == "sm100_warp_dv4":
+        output_scale = df.literal_expr(plan.output_scale)
+        if not output_scale.isidentifier():
+            return False
+        if (
+            plan.threads != _SM100_WARP_DV4_THREADS
+            or plan.smem_bytes != _SM100_WARP_DV4_SMEM_BYTES
+            or plan.device_abi != _SM100_WARP_DV4_DEVICE_ABI
+            or plan.input_stages != _SM100_WARP_DV4_INPUT_STAGES
+            or plan.tma_stages != 6
+            or plan.factor_tma_value_splits != 1
+            or plan.output_acc_stages != 2
+            or plan.output_smem_stages != 3
+            or plan.output_store_wait_groups != 0
+            or plan.tmem_cols != 0
+            or plan.dv_partitions != 4
+        ):
+            return False
+        desc_names = tuple(
+            df.new_var(name)
+            for name in (
+                "_chunk_recurrence_desc_factor",
+                "_chunk_recurrence_desc_aq",
+                "_chunk_recurrence_desc_gt",
+                "_chunk_recurrence_desc_v",
+                "_chunk_recurrence_desc_out",
+                "_chunk_recurrence_desc_state_in",
+                "_chunk_recurrence_desc_state_out",
+            )
+        )
+        cg.cute_wrapper_plans.append(
+            {
+                "kind": "chunk_recurrence_warp_dv4",
+                "kd_name": kd,
+                "qd_name": qd,
+                "ak_name": ak,
+                "aq_name": aq,
+                "gt_name": gt,
+                "v_name": values,
+                "out_name": output,
+                "state_name": state,
+                "cu_seqlens_name": cu_seqlens,
+                "cu_chunks_name": cu_chunks,
+                "desc_args": desc_names,
+                "heads": plan.heads,
+                "sequences": plan.sequences,
+                "total_tokens": plan.total_tokens,
+                "total_chunks": plan.total_chunks,
+                "chunk_size": _BT,
+                "key_size": _DK,
+                "value_size": _DV,
+                "threads": plan.threads,
+                "smem_bytes": plan.smem_bytes,
+                "workspace_layout_version": plan.workspace_layout_version,
+                "factor_key_xor": 8,
+                "outputs_scaled": False,
+                "scale_name": output_scale,
+                "device_abi": plan.device_abi,
+                "input_stages": plan.input_stages,
+                "tma_stages": plan.tma_stages,
+                "factor_tma_value_splits": plan.factor_tma_value_splits,
+                "output_acc_stages": plan.output_acc_stages,
+                "output_smem_stages": plan.output_smem_stages,
+                "output_store_wait_groups": plan.output_store_wait_groups,
+                "tmem_cols": plan.tmem_cols,
+                "dv_partitions": plan.dv_partitions,
+            }
+        )
+        df.wrapper_only_params.extend(desc_names)
+        df.placeholder_args.update((*names, output_scale))
+        df.preamble = []
+        df.body = [ast.Pass()]
+        cg.cute_uses_matmul = True
+        return True
+
+    return False
+
+
+__all__ = [
+    "CuteChunkRecurrencePlan",
+    "_select_sm100_dv_partitions",
+    "codegen_chunk_recurrence",
+    "detect_chunk_recurrence_search_geometry",
+    "plan_chunk_recurrence",
+]

--- a/helion/_compiler/cute/chunk_recurrence_dv4_sm100.py
+++ b/helion/_compiler/cute/chunk_recurrence_dv4_sm100.py
@@ -1,0 +1,1138 @@
+# ruff: noqa: ANN001, ANN202, C408, RUF005
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""SM100 warp-MMA DV4 schedule for the v2 workspace layout."""
+
+from __future__ import annotations
+
+import ctypes
+from dataclasses import dataclass
+import importlib
+from typing import Any
+from typing import cast
+
+import cutlass
+from cutlass._mlir.dialects import llvm
+import cutlass.cute as cute
+from cutlass.cutlass_dsl import dsl_user_op
+import cutlass.utils
+import torch
+
+from .kda_device_primitives import ldmatrix_x2
+from .kda_device_primitives import ldmatrix_x2_trans
+from .kda_device_primitives import ldmatrix_x4_trans
+from .kda_device_primitives import mma_m16n8k16_bf16
+from .kda_device_primitives import movmatrix_b16
+from .kda_device_primitives import pack_bf16x2
+from .kda_device_primitives import stmatrix_x2
+from .kda_device_primitives import stmatrix_x2_trans
+from .kda_device_primitives import store_vec8_bf16
+from .kda_device_primitives import tma_load_3d
+from .kda_device_primitives import tma_store_3d
+from .kda_device_primitives import tma_store_commit_group
+from .kda_device_primitives import tma_store_wait_read
+from .kda_device_primitives import vec8_bf16
+from .kda_device_primitives import warp_arrive
+
+
+def _upload_tensor_map_bytes(
+    payload: bytes | bytearray, device: torch.device
+) -> torch.Tensor:
+    """Upload descriptor bytes before graph capture; the launcher owns reuse."""
+
+    return torch.frombuffer(bytearray(payload), dtype=torch.uint8).clone().to(device)
+
+
+BT = 16
+DK = 128
+DV = 128
+RECURRENCE_DV_PARTITIONS = 4
+DV_HALF = DV // RECURRENCE_DV_PARTITIONS
+BF16_SEGMENT_ELEMS = 64
+BF16_GROUP_ELEMS = 8
+BF16_SEGMENTS = DK // BF16_SEGMENT_ELEMS
+BF16_SEGMENT_STRIDE = BT * BF16_SEGMENT_ELEMS  # 1024 elements
+BF16_ROW_XOR_MASK = BF16_SEGMENT_ELEMS // BF16_GROUP_ELEMS - 1  # 7
+KR_AK_TOKEN_XOR = BT // 2  # 8, token-row permutation for the Ak.T image
+FACTOR_KEY_XOR = 8
+PAIRWISE_COL_XOR = 8  # column permutation of the 16x16 pairwise image
+PAIRWISE_ROW_STRIDE = 16
+
+
+def raw_bf16_s128(token, dim):
+    """Physical BF16 element index of logical ``(token, dim)``.
+
+    Used for raw Q, raw K, ``Ki``, ``Kd`` and ``Qd``.  ``Kd``/``Qd`` carry no
+    feature permutation, so they share this image with the
+    raw stages and with ``Ki``.
+    """
+    segment = dim // BF16_SEGMENT_ELEMS
+    local = dim - segment * BF16_SEGMENT_ELEMS
+    group = local // BF16_GROUP_ELEMS
+    inner = local - group * BF16_GROUP_ELEMS
+    return (
+        segment * BF16_SEGMENT_STRIDE
+        + token * BF16_SEGMENT_ELEMS
+        + (group ^ (token & BF16_ROW_XOR_MASK)) * BF16_GROUP_ELEMS
+        + inner
+    )
+
+
+def pairwise_sw32(row, col):
+    """Physical BF16 element index of a 16x16 pairwise tile element."""
+    storage_col = col ^ PAIRWISE_COL_XOR
+    byte_offset = 2 * (row * PAIRWISE_ROW_STRIDE + storage_col)
+    return (byte_offset ^ (((byte_offset >> 7) & 1) << 4)) // 2
+
+
+factor_idx = raw_bf16_s128
+VO_ROW_ELEMS = DV_HALF
+VO_STAGE_ELEMS = BT * VO_ROW_ELEMS
+VO_SWIZZLE = "128B" if DV_HALF == 64 else "NONE"
+VO_VECTORS_PER_ROW = DV_HALF // 8
+OUTPUT_TAIL_TASKS = BT * VO_VECTORS_PER_ROW
+OUTPUT_TAIL_ROUNDS = (OUTPUT_TAIL_TASKS + 31) // 32
+STATE_BF16_ROWS_PER_VALUE = DK // BF16_SEGMENT_ELEMS  # 2
+
+
+def _s128_index(row, column, segment_elems, group_elems):
+    """S128 element index of ``column`` within 128-byte row ``row``.
+
+    ``row`` here is the *segment* row -- the unit the swizzle XOR keys on -- not
+    a logical matrix row.  The three recurrence images differ only in what they
+    call a segment row and how they split a logical coordinate into one.
+    """
+    group = column // group_elems
+    inner = column - group * group_elems
+    return (
+        row * segment_elems
+        + (group ^ (row & (segment_elems // group_elems - 1))) * group_elems
+        + inner
+    )
+
+
+def vo_idx(row, v_local):
+    """Physical BF16 index of ``(token row, value)`` in a V/output half stage.
+
+    ``v_local`` is in ``[0, 64)`` and is the CTA-local value, so the two DV
+    halves address byte-identical stages at different global coordinates.
+    """
+    if VO_ROW_ELEMS == 32:
+        return row * VO_ROW_ELEMS + v_local
+    return _s128_index(row, v_local, VO_ROW_ELEMS, BF16_GROUP_ELEMS)
+
+
+def state_bf16_idx(v_local, k):
+    """Physical BF16 index of logical ``H[k][v]`` in the persistent state.
+
+    The unswizzled address function is ``state_idx(k, v) = v * 128 + k`` (plan
+    Section 12.2 Q1): physical ``[V, K]`` row-major *and* logical ``[K, V]``
+    column-major at once, which is what lets an external ``[V, K]`` state half
+    land by TMA with no transpose and still be read as ``H[K, V]`` by the MMA.
+    """
+    segment = k // BF16_SEGMENT_ELEMS
+    local = k - segment * BF16_SEGMENT_ELEMS
+    line = STATE_BF16_ROWS_PER_VALUE * v_local + segment
+    return _s128_index(line, local, BF16_SEGMENT_ELEMS, BF16_GROUP_ELEMS)
+
+
+def vo_global_index(token, head, heads, dv_half, v_local):
+    """Flat element index of ``out[0, token, head, 64 * dv_half + v_local]``.
+
+    The partial-output tail stores through this map with 16-byte vectors (plan
+    Section 8.2); the full path never needs it, because TMA addresses the same
+    element through the descriptor instead.
+    """
+    return (token * heads + head) * DV + dv_half * DV_HALF + v_local
+
+
+WARP_VALUES = 8
+COMPUTE_WARPS = DV_HALF // WARP_VALUES
+
+
+def state_x2_ptr(lane, kb, v_base):
+    """SMEM index lane ``lane`` addresses for a state 16x8 ``ldmatrix.x2``.
+
+    The same 16 addresses serve both state reads .2: without
+    ``.trans`` they produce the MMA **B** operand of ``Kd @ H`` and ``Qd @ H``,
+    and with ``.trans`` they produce the **C** view the state update needs.  The
+    two passes therefore differ only in one instruction modifier, which is why
+    the second pass can reload from SMEM instead of keeping eight fragments
+    live.  Lanes 16-31 are ignored by an x2 copy.
+    """
+    matrix = (lane // 8) & 1
+    row = lane - (lane // 8) * 8
+    return state_bf16_idx(v_base + row, kb * BT + 8 * matrix)
+
+
+def vo_x2_ptr(lane, v_base):
+    """SMEM index lane ``lane`` addresses for a V/output 16x8 ``ldmatrix.x2``.
+
+    Non-transposed in both directions: the stage is token-major and the C tile's
+    rows are tokens, so the loaded V and the stored output share this map.
+    """
+    matrix = (lane // 8) & 1
+    row = (lane - (lane // 8) * 8) + 8 * matrix
+    return vo_idx(row, v_base)
+
+
+def factor_a_fragment_ptr(lane, kb):
+    """SMEM index lane ``lane`` addresses for a ``Kd``/``Qd`` A-operand x4 load.
+
+    Both stages are token-major, which is the A operand's orientation already,
+    so this is the plain (non-transposed) x4 map at key block ``kb``.
+    """
+    matrix_id = lane // 8
+    row = (lane - matrix_id * 8) + 8 * (matrix_id - (matrix_id // 2) * 2)
+    # The unscaled workspace layout publishes Kd/Qd at storage key
+    # ``logical_key ^ 8``. Applying that permutation to the ldmatrix base
+    # recovers the logical A fragment without moving the staged tile.
+    col = (kb * BT + 8 * (matrix_id // 2)) ^ FACTOR_KEY_XOR
+    return factor_idx(row, col)
+
+
+def pairwise_a_fragment_ptr(lane):
+    """SMEM index lane ``lane`` addresses for the ``Aq`` A-operand x4 load."""
+    matrix_id = lane // 8
+    row = (lane - matrix_id * 8) + 8 * (matrix_id - (matrix_id // 2) * 2)
+    col = 8 * (matrix_id // 2)
+    return pairwise_sw32(row, col)
+
+
+def ak_a_fragment_ptr(lane, kb):
+    """SMEM index lane ``lane`` addresses for the ``Ak`` A-operand x4 trans.
+
+    ``Ak`` is published by prepare as ``Ak.T`` with a ``token ^ 8`` row
+    permutation, so the stage holds ``[token][key]`` while the MMA wants
+    ``[key][token]``.  ``ldmatrix.x4.trans`` supplies the transpose, and the
+    four returned registers are ``(a0, a1, a2, a3)`` directly -- plan
+    Section 7.1 forbids permuting them afterwards.
+    """
+    matrix_id = lane // 8
+    row8 = lane - matrix_id * 8
+    logical_j = (matrix_id // 2) * 8 + row8
+    key = kb * BT + (matrix_id - (matrix_id // 2) * 2) * 8
+    return factor_idx(logical_j ^ KR_AK_TOKEN_XOR, key)
+
+
+_LLVM_STRUCT_TYPE = cast("Any", llvm).StructType
+
+
+@dsl_user_op
+def ldmatrix_x4(smem_ptr, *, loc=None, ip=None):
+    """``ldmatrix.sync.aligned.m8n8.x4.shared.b16`` -> four b32 registers."""
+    from cutlass._mlir.extras import types as _T
+
+    struct = llvm.inline_asm(
+        _LLVM_STRUCT_TYPE.get_literal([_T.IntegerType.get_signless(32)] * 4),
+        [smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)],
+        "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {$0, $1, $2, $3}, [$4];",
+        "=r,=r,=r,=r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        cutlass.Int32(
+            llvm.extractvalue(
+                _T.IntegerType.get_signless(32), struct, [i], loc=loc, ip=ip
+            )
+        )
+        for i in range(4)
+    )
+
+
+@dsl_user_op
+def sub_bf16x2(a, b, *, loc=None, ip=None):
+    """Packed BF16 subtract of two b32 registers, rounding each difference.
+
+    the design builds the residual with this rather than with
+    FP32 arithmetic: both operands are already BF16, so the exact difference is
+    representable and a single ``sub.rn`` reproduces the contract's
+    ``BF16(V - X)`` boundary for two values at once.
+    """
+    from cutlass._mlir.extras import types as _T
+
+    return cutlass.Int32(
+        llvm.inline_asm(
+            _T.IntegerType.get_signless(32),
+            [
+                cutlass.Int32(a).ir_value(loc=loc, ip=ip),
+                cutlass.Int32(b).ir_value(loc=loc, ip=ip),
+            ],
+            "sub.rn.bf16x2 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def unpack_bf16x2(value, *, loc=None, ip=None):
+    """Widen a packed BF16 pair to two FP32, low half first.
+
+    The state's decay term is ``FP32(GTotal) * FP32(H_bf16)``,
+    so the reloaded BF16 state has to reach the FP32 accumulator; this is the
+    widening, and it recovers nothing the entry rounding already discarded.
+    """
+    from cutlass._mlir.extras import types as _T
+
+    struct = llvm.inline_asm(
+        _LLVM_STRUCT_TYPE.get_literal([_T.F32Type.get()] * 2),
+        [cutlass.Int32(value).ir_value(loc=loc, ip=ip)],
+        "{ .reg .b16 lo, hi;"
+        "  mov.b32 {lo, hi}, $2;"
+        "  cvt.f32.bf16 $0, lo; cvt.f32.bf16 $1, hi; }",
+        "=f,=f,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        cutlass.Float32(
+            llvm.extractvalue(_T.F32Type.get(), struct, [i], loc=loc, ip=ip)
+        )
+        for i in range(2)
+    )
+
+
+@dsl_user_op
+def fence_tensormap_acquire(desc_addr, *, loc=None, ip=None):
+    """Publish a host-written tensor map to the tensormap proxy.
+
+    The descriptor is written by the host and read by the TMA unit through a
+    different proxy, so the kernel has to acquire it before first use.
+    """
+    llvm.inline_asm(
+        None,
+        [cutlass.Int64(desc_addr).ir_value(loc=loc, ip=ip)],
+        "fence.proxy.tensormap::generic.acquire.gpu [$0], 128;",
+        "l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+DESCRIPTOR_BYTES = 128
+SWIZZLES = ("128B", "64B", "NONE")
+
+
+def encode_tensor_map(
+    dtype: torch.dtype,
+    base_ptr: int,
+    global_dim,
+    strides_bytes,
+    box_dim,
+    *,
+    swizzle: str = "128B",
+) -> bytes:
+    """Encode one ``cuTensorMapEncodeTiled`` descriptor as 128 raw bytes.
+
+    Shared by prepare and the recurrence.  Every map fixes ``interleave=NONE``,
+    unit element strides, 128-byte L2 promotion and ``OOB_FILL_NONE``; only the
+    dtype, geometry and swizzle vary.
+    """
+    drv = importlib.import_module("cuda.bindings.driver")
+
+    if dtype is torch.bfloat16:
+        tma_dtype = drv.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_BFLOAT16
+    elif dtype is torch.float32:
+        tma_dtype = drv.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_FLOAT32
+    else:
+        raise ValueError(f"unsupported TMA element type {dtype}")
+    if swizzle not in SWIZZLES:
+        raise ValueError(f"swizzle must be one of {SWIZZLES}, got {swizzle!r}")
+
+    if swizzle == "128B":
+        swizzle_enum = drv.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B
+    elif swizzle == "64B":
+        swizzle_enum = drv.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_64B
+    else:
+        swizzle_enum = drv.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_NONE
+
+    rank = len(global_dim)
+    err, tmap = drv.cuTensorMapEncodeTiled(
+        tma_dtype,
+        rank,
+        base_ptr,
+        [drv.cuuint64_t(d) for d in global_dim],
+        [drv.cuuint64_t(s) for s in strides_bytes],
+        [drv.cuuint32_t(b) for b in box_dim],
+        [drv.cuuint32_t(1)] * rank,
+        drv.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE,
+        swizzle_enum,
+        drv.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
+        drv.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    )
+    if int(err) != 0:
+        raise RuntimeError(f"cuTensorMapEncodeTiled failed: {err}")
+    # cuda-python wraps the descriptor, so take its address via getPtr().
+    return bytes(ctypes.string_at(tmap.getPtr(), DESCRIPTOR_BYTES))
+
+
+@dataclass(frozen=True)
+class TensorMapSpec:
+    """Everything ``cuTensorMapEncodeTiled`` is given, and nothing else.
+
+    Two roles that produce equal specs are the same descriptor.  ``role`` is
+    deliberately absent from the comparison; it is carried alongside.
+    """
+
+    dtype: torch.dtype
+    base_ptr: int
+    global_dim: tuple[int, ...]
+    global_stride_bytes: tuple[int, ...]
+    box_dim: tuple[int, ...]
+    swizzle: str
+
+    def validate(self) -> None:
+        """Check the alignment rules a wrong descriptor would otherwise hide."""
+        element_bytes = 2 if self.dtype is torch.bfloat16 else 4
+        if self.base_ptr % 16:
+            raise ValueError(
+                f"TMA global base must be 16-byte aligned, got {self.base_ptr}"
+            )
+        inner_bytes = self.box_dim[0] * element_bytes
+        limit = {"128B": 128, "64B": 64, "NONE": 512}[self.swizzle]
+        if inner_bytes % 16 or inner_bytes > limit:
+            raise ValueError(
+                f"TMA inner box is {inner_bytes} B; must be a multiple of 16 "
+                f"and at most {limit} for swizzle {self.swizzle}"
+            )
+        for extent in self.box_dim:
+            if not 1 <= extent <= 256:
+                raise ValueError(f"TMA box extent {extent} outside [1, 256]")
+        for stride in self.global_stride_bytes:
+            if stride % 16:
+                raise ValueError(f"TMA global stride {stride} is not 16-byte aligned")
+        for dim, box in zip(self.global_dim, self.box_dim, strict=True):
+            if dim <= 0:
+                raise ValueError(f"TMA global dim {dim} must be positive")
+            if box > dim and box != self.box_dim[1]:
+                # A box may exceed a degenerate outer dim only through the row
+                # mode, which the tail path relies on; the inner and plane modes
+                # must fit.
+                raise ValueError(f"TMA box {box} exceeds global dim {dim}")
+
+    def encode(self) -> bytes:
+        return encode_tensor_map(
+            self.dtype,
+            self.base_ptr,
+            self.global_dim,
+            self.global_stride_bytes,
+            self.box_dim,
+            swizzle=self.swizzle,
+        )
+
+
+def _spec_fields(geometry: dict) -> dict:
+    """Rename :func:`factor_slab_geometry`'s keys for :class:`TensorMapSpec`.
+
+    The encoder takes ``strides_bytes``; the spec dataclass calls the same
+    field ``global_stride_bytes``.  One adapter beats two copies of the tuple.
+    """
+    return dict(
+        global_dim=geometry["global_dim"],
+        global_stride_bytes=geometry["strides_bytes"],
+        box_dim=geometry["box_dim"],
+    )
+
+
+def factor_slab_geometry(rows: int, heads: int, element_bytes: int = 2) -> dict:
+    """The one description of the fused Kd/Qd/Ak slab, as ``(DK, rows, 3H)``.
+
+    The three regions are the same geometry, the same dtype and exactly
+    adjacent -- ``prepare_region_offsets`` aligns each to 256 bytes and every
+    region size is a multiple of it, so no padding is inserted -- which makes
+    them 3H planes of one tensor rather than three tensors.  Plane ``r*H + h``
+    is region ``r`` (0=Kd, 1=Qd, 2=Ak) of head ``h``.
+
+    prepare writes through this and the recurrence reads through it, and the
+    fused entry passes prepare's encoded descriptor to both kernels, so the two
+    sides cannot be allowed to disagree about it.  Defining it once is what
+    makes that structural rather than a comment asking for care.
+    """
+    return dict(
+        global_dim=(DK, rows, 3 * heads),
+        strides_bytes=(DK * element_bytes, DK * rows * element_bytes),
+        box_dim=(BF16_SEGMENT_ELEMS, BT, 1),
+    )
+
+
+ROLES = ("factor", "aq", "gt", "v", "out", "state_in", "state_out")
+
+
+def recurrence_tensor_map_specs(
+    *,
+    kd_ptr: int,
+    aq_ptr: int,
+    gt_ptr: int,
+    v_ptr: int,
+    out_ptr: int,
+    heads: int,
+    total_tokens: int,
+    total_chunks: int,
+    sequences: int,
+    state_ptr: int,
+) -> dict[str, TensorMapSpec]:
+    """Build the exact v2-workspace TensorMap specifications as plain data."""
+    rows = BT * total_chunks
+    specs: dict[str, TensorMapSpec] = {
+        # Kd/Qd/Ak fused: 3H planes of R rows of 128 BF16 keys.  The geometry
+        # is prepare's -- literally the same function -- because the fused
+        # entry gives prepare's encoded descriptor to this kernel as well.
+        "factor": TensorMapSpec(
+            dtype=torch.bfloat16,
+            base_ptr=kd_ptr,
+            swizzle="128B",
+            **_spec_fields(factor_slab_geometry(rows, heads)),
+        ),
+        # The 16x16 pairwise record prepare already wrote in its SW32 image:
+        # moved verbatim, so no second swizzle is applied here.
+        "aq": TensorMapSpec(
+            dtype=torch.bfloat16,
+            base_ptr=aq_ptr,
+            global_dim=(BT * BT, total_chunks, heads),
+            global_stride_bytes=(BT * BT * 2, total_chunks * BT * BT * 2),
+            box_dim=(BT * BT, 1, 1),
+            swizzle="NONE",
+        ),
+        "gt": TensorMapSpec(
+            dtype=torch.float32,
+            base_ptr=gt_ptr,
+            global_dim=(DK, total_chunks, heads),
+            global_stride_bytes=(DK * 4, total_chunks * DK * 4),
+            box_dim=(DK, 1, 1),
+            swizzle="NONE",
+        ),
+    }
+    # V and out are the same geometry over [1, T, H, 128]; when they are also
+    # the same storage they collapse to one descriptor by equality.
+    activation = dict(
+        dtype=torch.bfloat16,
+        global_dim=(DV, total_tokens, heads),
+        global_stride_bytes=(heads * DV * 2, DV * 2),
+        box_dim=(DV_HALF, BT, 1),
+        swizzle=VO_SWIZZLE,
+    )
+    specs["v"] = TensorMapSpec(base_ptr=v_ptr, **activation)
+    specs["out"] = TensorMapSpec(base_ptr=out_ptr, **activation)
+
+    state = _state_spec_fields(sequences * heads)
+    specs["state_in"] = TensorMapSpec(base_ptr=state_ptr, **state)
+    specs["state_out"] = TensorMapSpec(base_ptr=state_ptr, **state)
+
+    for spec in specs.values():
+        spec.validate()
+    return specs
+
+
+def _state_spec_fields(planes: int) -> dict:
+    """Describe the exact in-place BF16 state consumed by this lowering."""
+
+    rows = STATE_BF16_ROWS_PER_VALUE * DV
+    return dict(
+        dtype=torch.bfloat16,
+        global_dim=(BF16_SEGMENT_ELEMS, rows, planes),
+        global_stride_bytes=(
+            BF16_SEGMENT_ELEMS * 2,
+            rows * BF16_SEGMENT_ELEMS * 2,
+        ),
+        box_dim=(
+            BF16_SEGMENT_ELEMS,
+            rows // RECURRENCE_DV_PARTITIONS,
+            1,
+        ),
+        swizzle="128B",
+    )
+
+
+def unique_descriptors(specs: dict[str, TensorMapSpec]) -> list[TensorMapSpec]:
+    """Distinct descriptors, in first-use order; equality *is* exact alias."""
+    seen: list[TensorMapSpec] = []
+    for role in ROLES:
+        spec = specs.get(role)
+        if spec is not None and spec not in seen:
+            seen.append(spec)
+    return seen
+
+
+@dataclass(frozen=True)
+class RecurrenceTensorMaps:
+    """Device addresses of each role's descriptor, plus the backing storage."""
+
+    storage: torch.Tensor
+    addresses: dict[str, int]
+
+    def address(self, role: str) -> int:
+        """Descriptor address, or 0 for a role this launch does not use."""
+        return self.addresses.get(role, 0)
+
+
+def build_recurrence_tensor_maps(
+    specs: dict[str, TensorMapSpec], device: torch.device
+) -> RecurrenceTensorMaps:
+    """Encode the distinct descriptors and upload them as one device buffer."""
+    distinct = unique_descriptors(specs)
+    packed = bytearray()
+    for spec in distinct:
+        packed += spec.encode()
+    storage = _upload_tensor_map_bytes(packed, device)
+    if storage.data_ptr() % 64:
+        raise RuntimeError("tensor map storage must be 64-byte aligned")
+
+    base = storage.data_ptr()
+    slot = {spec: base + i * DESCRIPTOR_BYTES for i, spec in enumerate(distinct)}
+    return RecurrenceTensorMaps(
+        storage=storage,
+        addresses={role: slot[spec] for role, spec in specs.items()},
+    )
+
+
+LOAD_WARP = COMPUTE_WARPS  # 4
+STORE_WARP = COMPUTE_WARPS + 1  # 5
+REC_WARPS = COMPUTE_WARPS + 2  # 6
+REC_THREADS = REC_WARPS * 32
+INPUT_STAGES = 8 if RECURRENCE_DV_PARTITIONS == 2 else 6
+OUTPUT_STAGES = 3
+STAGE_KD = 0
+STAGE_QD = 4096
+STAGE_AK = 8192
+STAGE_AQ = 12288
+STAGE_GT = 12800
+STAGE_V = 13312
+INPUT_STAGE_BYTES = STAGE_V + VO_STAGE_ELEMS * 2
+INPUT_STAGE_TX_BYTES = INPUT_STAGE_BYTES
+OUTPUT_STAGE_BYTES = BT * DV_HALF * 2  # 2048
+SMEM_STATE = 0
+STATE_BYTES = DV_HALF * DK * 2  # 16384
+SMEM_INPUT = SMEM_STATE + STATE_BYTES  # 16384
+SMEM_OUTPUT = SMEM_INPUT + INPUT_STAGES * INPUT_STAGE_BYTES  # 93184
+REC_SMEM_BARRIERS = SMEM_OUTPUT + OUTPUT_STAGES * OUTPUT_STAGE_BYTES  # 97280
+MBAR_INPUT_READY = 0
+MBAR_INPUT_CONSUMED = MBAR_INPUT_READY + INPUT_STAGES * 8  # 40
+MBAR_OUTPUT_READY = MBAR_INPUT_CONSUMED + INPUT_STAGES * 8  # 80
+MBAR_OUTPUT_CONSUMED = MBAR_OUTPUT_READY + OUTPUT_STAGES * 8  # 96
+MBAR_STATE_READY = MBAR_OUTPUT_CONSUMED + OUTPUT_STAGES * 8  # 112
+BARRIER_BYTES = MBAR_STATE_READY + 8  # 120
+SMEM_RAW_END = REC_SMEM_BARRIERS + BARRIER_BYTES  # 97400
+SMEM_ALIGNMENT = 256
+SMEM_DYNAMIC_BYTES = (
+    (SMEM_RAW_END + SMEM_ALIGNMENT - 1) // SMEM_ALIGNMENT * SMEM_ALIGNMENT
+)  # 97536
+MIN_BLOCKS_PER_MP = 1
+INPUT_READY_ARRIVALS = 1  # completed by transaction bytes
+INPUT_CONSUMED_ARRIVALS = COMPUTE_WARPS  # one per compute warp, not per thread
+OUTPUT_READY_ARRIVALS = COMPUTE_WARPS
+OUTPUT_CONSUMED_ARRIVALS = 1
+STATE_READY_ARRIVALS = 1
+
+
+def input_stage(chunk):
+    return chunk - (chunk // INPUT_STAGES) * INPUT_STAGES
+
+
+def input_generation(chunk):
+    return chunk // INPUT_STAGES
+
+
+def input_ready_parity(chunk):
+    """Compute warps: pass once the slot's TMA has landed ``ig + 1`` times."""
+    return input_generation(chunk) & 1
+
+
+def input_consumed_parity(chunk):
+    """Load warp: pass once all 4 compute warps have released the slot ``ig``
+    times.  Generation 0 passes against the initial phase with no seeding."""
+    return 1 ^ (input_generation(chunk) & 1)
+
+
+def output_stage(chunk):
+    return chunk - (chunk // OUTPUT_STAGES) * OUTPUT_STAGES
+
+
+def output_generation(chunk):
+    return chunk // OUTPUT_STAGES
+
+
+def output_ready_parity(chunk):
+    """Store warp: pass once all 4 compute warps have filled the slot."""
+    return output_generation(chunk) & 1
+
+
+def output_consumed_parity(chunk):
+    """Compute warps: pass once the store warp has finished reading the slot."""
+    return 1 ^ (output_generation(chunk) & 1)
+
+
+KEY_BLOCKS = DK // BT  # 8
+BAR_IN_READY = MBAR_INPUT_READY // 8  # 0
+BAR_IN_CONSUMED = MBAR_INPUT_CONSUMED // 8  # 5
+BAR_OUT_READY = MBAR_OUTPUT_READY // 8  # 10
+BAR_OUT_CONSUMED = MBAR_OUTPUT_CONSUMED // 8  # 12
+BAR_STATE = MBAR_STATE_READY // 8  # 14
+FACTOR_SEGMENT_ELEMS = BF16_SEGMENT_STRIDE  # 1024
+
+
+@cute.jit
+def zero_acc4():
+    z = cutlass.Float32(0.0)
+    return (z, z, z, z)
+
+
+@cute.jit
+def mma_n8(a, b, c):
+    """One native ``m16n8k16``: A is four registers, B two, C four."""
+    return mma_m16n8k16_bf16(a[0], a[1], a[2], a[3], b[0], b[1], c[0], c[1], c[2], c[3])
+
+
+@cute.kernel
+def emit_bt16_recurrence(
+    gout: cute.Tensor,
+    gcu_seqlens: cute.Tensor,
+    gcu_chunks: cute.Tensor,
+    desc_factor: cutlass.Int64,
+    desc_aq: cutlass.Int64,
+    desc_gt: cutlass.Int64,
+    desc_v: cutlass.Int64,
+    desc_out: cutlass.Int64,
+    desc_state_in: cutlass.Int64,
+    desc_state_out: cutlass.Int64,
+    heads: cutlass.Int32,
+    SCALE: cutlass.Float32,
+) -> None:
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, bidy, _ = cute.arch.block_idx()
+    warp_id = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    lane = tidx % 32
+
+    # x = P * seq + dv_half, y = head: the DV partition is the
+    # fastest-varying coordinate, so the partitions of a head are adjacent
+    # blocks and share a wave, which is what lets L2 serve the second one's
+    # factor loads.  Everything coarser keeps the order (N, 2H, 1) had.
+    seq = bidx // cutlass.Int32(RECURRENCE_DV_PARTITIONS)
+    dv_half = bidx - seq * cutlass.Int32(RECURRENCE_DV_PARTITIONS)
+    head = bidy
+
+    # --- fixed arena ------------------------------------
+    # One allocation of exactly SMEM_DYNAMIC_BYTES, so the launch parameter is
+    # the plan's number and every address is a compile-time constant offset.
+    alloc = cutlass.utils.SmemAllocator()
+    p_base = alloc.allocate(SMEM_DYNAMIC_BYTES, 1024)
+    p16 = cute.recast_ptr(p_base, dtype=cutlass.BFloat16)
+    p32 = cute.recast_ptr(p_base, dtype=cutlass.Float32)
+    p64 = cute.recast_ptr(p_base, dtype=cutlass.Int64)
+
+    p_state = p16 + (SMEM_STATE // 2)
+    p_bar = p64 + (REC_SMEM_BARRIERS // 8)
+
+    if warp_id == 0:
+        if lane == 0:
+            for s in cutlass.range_constexpr(INPUT_STAGES):
+                cute.arch.mbarrier_init(p_bar + BAR_IN_READY + s, INPUT_READY_ARRIVALS)
+                cute.arch.mbarrier_init(
+                    p_bar + BAR_IN_CONSUMED + s, INPUT_CONSUMED_ARRIVALS
+                )
+            for s in cutlass.range_constexpr(OUTPUT_STAGES):
+                cute.arch.mbarrier_init(
+                    p_bar + BAR_OUT_READY + s, OUTPUT_READY_ARRIVALS
+                )
+                cute.arch.mbarrier_init(
+                    p_bar + BAR_OUT_CONSUMED + s, OUTPUT_CONSUMED_ARRIVALS
+                )
+            cute.arch.mbarrier_init(p_bar + BAR_STATE, STATE_READY_ARRIVALS)
+            cute.arch.mbarrier_init_fence()
+            fence_tensormap_acquire(desc_factor)
+            fence_tensormap_acquire(desc_aq)
+            fence_tensormap_acquire(desc_gt)
+            fence_tensormap_acquire(desc_v)
+            fence_tensormap_acquire(desc_out)
+            fence_tensormap_acquire(desc_state_in)
+            fence_tensormap_acquire(desc_state_out)
+    cute.arch.barrier()
+
+    # --- sequence coordinates ---------------------------
+    token_start = cutlass.Int32(gcu_seqlens[seq])
+    token_end = cutlass.Int32(gcu_seqlens[seq + 1])
+    chunk_base = cutlass.Int32(gcu_chunks[seq])
+    num_chunks = cute.ceil_div(token_end - token_start, BT)
+    state_plane = seq * heads + head
+
+    # --- initial state ----------------------------------
+    if warp_id == 0:
+        if lane == 0:
+            cute.arch.mbarrier_arrive_and_expect_tx(p_bar + BAR_STATE, DV_HALF * DK * 2)
+            tma_load_3d(
+                p_state,
+                desc_state_in,
+                p_bar + BAR_STATE,
+                0,
+                dv_half * (STATE_BF16_ROWS_PER_VALUE * DV_HALF),
+                state_plane,
+            )
+    cute.arch.mbarrier_wait(p_bar + BAR_STATE, 0)
+    cute.arch.barrier()
+
+    # --- roles ---------------------------------
+    if warp_id < COMPUTE_WARPS:
+        v_base = warp_id * WARP_VALUES
+        # The state lives in registers for the whole kernel, read from shared
+        # memory once here and written back once after the chunk loop.  Sixteen
+        # packed BF16 registers per lane hold this warp's [128 key, 8 value]
+        # slice, which is warp-private -- ``v_base`` is ``warp_id *
+        # WARP_VALUES`` and no warp ever addresses another's columns -- so
+        # nothing here needs a cross-warp exchange.
+        #
+        # It replaces 24 shared-memory instructions per chunk per warp (eight
+        # ``ldmatrix_x2`` in pass 1, eight ``ldmatrix_x2_trans`` and eight
+        # ``stmatrix_x2_trans`` in pass 2) with 16 ``movmatrix``.  The
+        # ``.trans`` read is the C view, which is the layout pass 2 accumulates
+        # in; pass 1 wants the B operand and gets it with one ``movmatrix`` per
+        # register.  ``tests/test_recurrence_layouts.py`` enumerates that
+        # equality, 64 of 64.
+        h_state: tuple = ()
+        for kb in cutlass.range_constexpr(KEY_BLOCKS):
+            lo, hi = ldmatrix_x2_trans(p_state + state_x2_ptr(lane, kb, v_base))
+            h_state = h_state + (lo, hi)
+
+        for c in range(num_chunks):
+            in_stage = input_stage(c)
+            out_stage = output_stage(c)
+            stage16 = (SMEM_INPUT // 2) + in_stage * (INPUT_STAGE_BYTES // 2)
+            p_kd = p16 + (stage16 + STAGE_KD // 2)
+            p_qd = p16 + (stage16 + STAGE_QD // 2)
+            p_ak = p16 + (stage16 + STAGE_AK // 2)
+            p_aq = p16 + (stage16 + STAGE_AQ // 2)
+            p_v = p16 + (stage16 + STAGE_V // 2)
+            smem_gt = cute.make_tensor(
+                p32
+                + ((SMEM_INPUT + STAGE_GT) // 4 + in_stage * (INPUT_STAGE_BYTES // 4)),
+                cute.make_layout(DK),
+            )
+            p_out = p16 + ((SMEM_OUTPUT // 2) + out_stage * (OUTPUT_STAGE_BYTES // 2))
+
+            token_base = token_start + c * BT
+            valid_rows = token_end - token_base
+            if valid_rows > BT:
+                valid_rows = cutlass.Int32(BT)
+
+            # The nine IKET ranges below -- five here, two on the producer, two
+            # on the store warp -- are emitted only under the research build; see
+            # the research tracing hooks.  They split a chunk into stall and
+            # work for each role, which is what NCU cannot show.
+            cute.arch.mbarrier_wait(
+                p_bar + BAR_IN_READY + in_stage, input_ready_parity(c)
+            )
+
+            # ---- pass 1: X = Kd @ H and O = Qd @ H --------------------------
+            # One state B fragment per key block feeds both MMAs, and nothing
+            # writes the state until pass 2, so the fragment can be dropped
+            # immediately after use.
+            acc_x = zero_acc4()
+            acc_o = zero_acc4()
+            for kb in cutlass.range_constexpr(KEY_BLOCKS):
+                # C -> B is a within-tile 8x8 transpose, one instruction per
+                # packed register, and the fragment is fresh rather than
+                # aliased onto ``h_state``: aliasing an MMA operand onto
+                # persistent state registers is what made engine's equivalent
+                # probe spill.
+                b = (
+                    movmatrix_b16(h_state[2 * kb]),
+                    movmatrix_b16(h_state[2 * kb + 1]),
+                )
+                acc_x = mma_n8(
+                    ldmatrix_x4(p_kd + factor_a_fragment_ptr(lane, kb)),
+                    b,
+                    acc_x,
+                )
+                acc_o = mma_n8(
+                    ldmatrix_x4(p_qd + factor_a_fragment_ptr(lane, kb)),
+                    b,
+                    acc_o,
+                )
+
+            # ---- residual -------------------------
+            # Both halves of a packed C register are the same token row, so the
+            # tail mask is one predicate per register.  An invalid row selects an
+            # exact packed BF16 zero instead of subtracting a V that belongs to
+            # the next sequence.
+
+            v_lo, v_hi = ldmatrix_x2(p_v + vo_x2_ptr(lane, v_base))
+            row_lo = lane // 4
+            res_lo = cutlass.Int32(0)
+            res_hi = cutlass.Int32(0)
+            if row_lo < valid_rows:
+                res_lo = sub_bf16x2(v_lo, pack_bf16x2(acc_x[0], acc_x[1]))
+            if row_lo + 8 < valid_rows:
+                res_hi = sub_bf16x2(v_hi, pack_bf16x2(acc_x[2], acc_x[3]))
+            # C layout -> B layout: transpose each packed 8x8 quadrant in place.
+            res_b = (movmatrix_b16(res_lo), movmatrix_b16(res_hi))
+
+            # ---- O += Aq @ R, into the same FP32 accumulator ----------------
+            acc_o = mma_n8(
+                ldmatrix_x4(p_aq + pairwise_a_fragment_ptr(lane)), res_b, acc_o
+            )
+
+            # ---- publish the output before the state update -----------------
+            cute.arch.mbarrier_wait(
+                p_bar + BAR_OUT_CONSUMED + out_stage, output_consumed_parity(c)
+            )
+            stmatrix_x2(
+                p_out + vo_x2_ptr(lane, v_base),
+                pack_bf16x2(acc_o[0] * SCALE, acc_o[1] * SCALE),
+                pack_bf16x2(acc_o[2] * SCALE, acc_o[3] * SCALE),
+            )
+            warp_arrive(p_bar + BAR_OUT_READY + out_stage, lane)
+
+            # ---- pass 2: H_next = Diag(GTotal) H + Ak @ R -------------------
+            # The same addresses as pass 1, read with ``.trans`` so the state
+            # arrives already in the accumulator's layout.  Each warp writes
+            # only its own value columns, and pass 1 is complete, so the update
+            # is safe in place.
+            next_state: tuple = ()
+            for kb in cutlass.range_constexpr(KEY_BLOCKS):
+                h0, h1 = unpack_bf16x2(h_state[2 * kb])
+                h2, h3 = unpack_bf16x2(h_state[2 * kb + 1])
+                decay_lo = cutlass.Float32(smem_gt[kb * BT + row_lo])
+                decay_hi = cutlass.Float32(smem_gt[kb * BT + row_lo + 8])
+                acc_s = (
+                    decay_lo * h0,
+                    decay_lo * h1,
+                    decay_hi * h2,
+                    decay_hi * h3,
+                )
+                acc_s = mma_n8(
+                    ldmatrix_x4_trans(p_ak + ak_a_fragment_ptr(lane, kb)),
+                    res_b,
+                    acc_s,
+                )
+                next_state = next_state + (
+                    pack_bf16x2(acc_s[0], acc_s[1]),
+                    pack_bf16x2(acc_s[2], acc_s[3]),
+                )
+            h_state = next_state
+
+            warp_arrive(p_bar + BAR_IN_CONSUMED + in_stage, lane)
+
+        # The final-state path below reads the state from shared memory with all
+        # 192 threads, so the compute warps publish their registers first.  The
+        # converging barrier after this branch is what orders it.
+        for kb in cutlass.range_constexpr(KEY_BLOCKS):
+            stmatrix_x2_trans(
+                p_state + state_x2_ptr(lane, kb, v_base),
+                h_state[2 * kb],
+                h_state[2 * kb + 1],
+            )
+
+    elif warp_id == LOAD_WARP:
+        for c in range(num_chunks):
+            in_stage = input_stage(c)
+            cute.arch.mbarrier_wait(
+                p_bar + BAR_IN_CONSUMED + in_stage, input_consumed_parity(c)
+            )
+
+            if lane == 0:
+                gchunk = chunk_base + c
+                token_base = token_start + c * BT
+                factor_row = gchunk * BT
+                stage16 = SMEM_INPUT // 2 + in_stage * (INPUT_STAGE_BYTES // 2)
+                mbar = p_bar + BAR_IN_READY + in_stage
+                cute.arch.mbarrier_arrive_and_expect_tx(mbar, INPUT_STAGE_TX_BYTES)
+                # Nine instructions, one completion barrier, 15,360 bytes.
+                for factor in cutlass.range_constexpr(3):
+                    plane = factor * heads + head
+                    dst = stage16 + (STAGE_KD // 2) + factor * (4096 // 2)
+                    for segment in cutlass.range_constexpr(BF16_SEGMENTS):
+                        tma_load_3d(
+                            p16 + (dst + segment * FACTOR_SEGMENT_ELEMS),
+                            desc_factor,
+                            mbar,
+                            segment * BF16_SEGMENT_ELEMS,
+                            factor_row,
+                            plane,
+                        )
+                tma_load_3d(
+                    p16 + (stage16 + STAGE_AQ // 2),
+                    desc_aq,
+                    mbar,
+                    0,
+                    gchunk,
+                    head,
+                )
+                tma_load_3d(
+                    p32
+                    + (
+                        (SMEM_INPUT + STAGE_GT) // 4
+                        + in_stage * (INPUT_STAGE_BYTES // 4)
+                    ),
+                    desc_gt,
+                    mbar,
+                    0,
+                    gchunk,
+                    head,
+                )
+                tma_load_3d(
+                    p16 + (stage16 + STAGE_V // 2),
+                    desc_v,
+                    mbar,
+                    dv_half * DV_HALF,
+                    token_base,
+                    head,
+                )
+
+    else:
+        for c in range(num_chunks):
+            out_stage = output_stage(c)
+            p_out = p16 + ((SMEM_OUTPUT // 2) + out_stage * (OUTPUT_STAGE_BYTES // 2))
+            token_base = token_start + c * BT
+            valid_rows = token_end - token_base
+            if valid_rows > BT:
+                valid_rows = cutlass.Int32(BT)
+
+            cute.arch.mbarrier_wait(
+                p_bar + BAR_OUT_READY + out_stage, output_ready_parity(c)
+            )
+
+            if valid_rows == BT:
+                # The full path: the stage is released only after
+                # the store has read it, not when it is merely committed.
+                cute.arch.fence_view_async_shared()
+                cute.arch.sync_warp()
+                if lane == 0:
+                    tma_store_3d(desc_out, p_out, dv_half * DV_HALF, token_base, head)
+                    tma_store_commit_group()
+                    tma_store_wait_read(0)
+                    cute.arch.mbarrier_arrive(p_bar + BAR_OUT_CONSUMED + out_stage)
+            else:
+                # Tail path: the whole warp stores 16-byte vectors, and no TMA,
+                # fence, commit or wait-group is involved.
+                for rep in cutlass.range_constexpr(OUTPUT_TAIL_ROUNDS):
+                    task = lane + rep * 32
+                    if task < valid_rows * VO_VECTORS_PER_ROW:
+                        row = task // VO_VECTORS_PER_ROW
+                        vec = task - row * VO_VECTORS_PER_ROW
+                        frag = vec8_bf16(p_out, vo_idx(row, vec * 8))
+                        store_vec8_bf16(
+                            gout.iterator,
+                            vo_global_index(
+                                token_base + row, head, heads, dv_half, vec * 8
+                            ),
+                            frag,
+                        )
+                cute.arch.sync_warp()
+                if lane == 0:
+                    cute.arch.mbarrier_arrive(p_bar + BAR_OUT_CONSUMED + out_stage)
+
+    # --- final state handoff ----------------------------
+    # All three roles converge here: the loads are issued, the last state update
+    # is written, and every output store has completed its ``wait_group.read``.
+    cute.arch.barrier()
+    if warp_id == STORE_WARP:
+        cute.arch.fence_view_async_shared()
+        cute.arch.sync_warp()
+        if lane == 0:
+            tma_store_3d(
+                desc_state_out,
+                p_state,
+                0,
+                dv_half * (STATE_BF16_ROWS_PER_VALUE * DV_HALF),
+                state_plane,
+            )
+            tma_store_commit_group()
+            tma_store_wait_read(0)
+
+
+@cute.jit
+def _recurrence_entry(
+    gout: cute.Tensor,
+    gcu_seqlens: cute.Tensor,
+    gcu_chunks: cute.Tensor,
+    desc_factor: cutlass.Int64,
+    desc_aq: cutlass.Int64,
+    desc_gt: cutlass.Int64,
+    desc_v: cutlass.Int64,
+    desc_out: cutlass.Int64,
+    desc_state_in: cutlass.Int64,
+    desc_state_out: cutlass.Int64,
+    heads: cutlass.Int32,
+    scale: cutlass.Float32,
+    grid_x: cutlass.Int32,
+    grid_y: cutlass.Int32,
+    stream,
+):
+    emit_bt16_recurrence(
+        gout,
+        gcu_seqlens,
+        gcu_chunks,
+        desc_factor,
+        desc_aq,
+        desc_gt,
+        desc_v,
+        desc_out,
+        desc_state_in,
+        desc_state_out,
+        heads,
+        scale,
+    ).launch(
+        grid=(grid_x, grid_y, 1),
+        block=(REC_THREADS, 1, 1),
+        smem=SMEM_DYNAMIC_BYTES,
+        min_blocks_per_mp=MIN_BLOCKS_PER_MP,
+        stream=stream,
+    )
+
+
+__all__ = [
+    "COMPUTE_WARPS",
+    "DV_HALF",
+    "INPUT_STAGES",
+    "OUTPUT_TAIL_ROUNDS",
+    "OUTPUT_TAIL_TASKS",
+    "RECURRENCE_DV_PARTITIONS",
+    "REC_THREADS",
+    "ROLES",
+    "SMEM_DYNAMIC_BYTES",
+    "VO_VECTORS_PER_ROW",
+    "_recurrence_entry",
+    "build_recurrence_tensor_maps",
+    "factor_a_fragment_ptr",
+    "factor_idx",
+    "recurrence_tensor_map_specs",
+    "vo_idx",
+]

--- a/helion/_compiler/cute/chunk_recurrence_sm100.py
+++ b/helion/_compiler/cute/chunk_recurrence_sm100.py
@@ -1,0 +1,2100 @@
+# ruff: noqa: ANN001, ANN202
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""SM100 BT16 KDA recurrence schedule.
+
+Adapted from FlashInfer's ``kda_chunked_bt16.py`` at pinned commit
+``f67bc2ed555c1ad6a764ad68f7aa9622178e9eae``.  Helion owns the matcher,
+workspace layout, schedule selection, and launch integration around this device
+schedule.  The recurrence keeps FP32 state in TMEM and splits the 16 warps into
+output-drain, state-left, state-right, two tcgen05 issuers, TMA, and service
+roles.  The Helion schedule uses an eight-slot raw-input ring, a six-slot TMA
+completion ring, two TMEM output accumulators, rank-4 factor loads, and a
+seven-slot asynchronous output-SMEM ring.  These choices are explicit in the
+wrapper plan, with workspace-layout and device-ABI checks kept separate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+from typing import cast
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.experimental.cuda as cuda
+import cutlass.experimental.primitives as prims
+
+
+def packed_f32x2_binary(
+    op: Callable,
+    lhs: tuple[cutlass.Float32, cutlass.Float32],
+    rhs: tuple[cutlass.Float32, cutlass.Float32],
+) -> tuple[cutlass.Float32, cutlass.Float32]:
+    """Apply a CUTLASS packed-FP32 primitive to two scalar pairs."""
+
+    lhs_vec = cutlass.Vector.from_elements(lhs, cutlass.Float32)
+    rhs_vec = cutlass.Vector.from_elements(rhs, cutlass.Float32)
+    result = op(lhs_vec, rhs_vec, ftz=False, rnd="rn")
+    return cutlass.Float32(result[0]), cutlass.Float32(result[1])
+
+
+def fmul2(lhs, rhs):
+    return packed_f32x2_binary(prims.mul_packed_f32x2, lhs, rhs)
+
+
+@cute.jit
+def sub_b16x2_input_dtype(
+    lhs: cutlass.Int32,
+    rhs: cutlass.Int32,
+    input_dtype: cutlass.Constexpr,
+) -> cutlass.Int32:
+    """Subtract two packed pairs using the compile-time input dtype."""
+
+    if cutlass.const_expr(input_dtype is cutlass.BFloat16):
+        return cast(
+            "cutlass.Int32",
+            prims.inline_ptx_hl(
+                "sub.bf16x2 {$w0}, {$r0}, {$r1};",
+                write_only_types=[cutlass.Int32],
+                read_only_args=[lhs, rhs],
+            ),
+        )
+    return cast(
+        "cutlass.Int32",
+        prims.inline_ptx_hl(
+            "sub.f16x2 {$w0}, {$r0}, {$r1};",
+            write_only_types=[cutlass.Int32],
+            read_only_args=[lhs, rhs],
+        ),
+    )
+
+
+@cute.jit
+def pack_input_b16x2_to_i32(
+    value0: cutlass.Float32,
+    value1: cutlass.Float32,
+    input_dtype: cutlass.Constexpr,
+):
+    """Pack two FP32 values through the compile-time input 16-bit dtype."""
+
+    return (
+        cutlass.Vector.from_elements(
+            (value0, value1),
+            cutlass.Float32,
+        )
+        .to(input_dtype)
+        .bitcast(cutlass.Int32)[0]
+    )
+
+
+BT: int = 16
+
+DK: int = 128
+
+DV: int = 128
+
+THREADS_PER_WARP: int = 32
+
+THREADS_PER_CTA: int = 16 * THREADS_PER_WARP
+
+TMEM_USER_WARP_COUNT: int = 5
+
+TMEM_USER_THREADS: int = TMEM_USER_WARP_COUNT * THREADS_PER_WARP
+
+NBAR_TMEM_LIFECYCLE_ID: int = 2
+
+NBAR_OUTPUT_DRAIN_ID: int = 8
+
+OUTPUT_DRAIN_THREADS: int = 4 * THREADS_PER_WARP
+
+KDA_CG1_REGS: int = 136
+
+KDA_SERVICE_REGS: int = 56
+
+TCGEN05_F16_K_ATOM: int = 16
+
+TCGEN05_F16_ELEM_BYTES: int = 2
+
+TCGEN05_SW128_BYTES: int = 128
+
+TCGEN05_SW128_K_PHASES_PER_SLICE: int = 4
+
+TCGEN05_STATE_K_B_LEADING_BYTES: int = 16
+
+TCGEN05_STATE_K_B_STRIDE_BYTES: int = 1024
+
+TCGEN05_STATE_K_B_K_STEP_BYTES: int = TCGEN05_F16_K_ATOM * TCGEN05_F16_ELEM_BYTES
+
+TCGEN05_STATE_INPUT_LOAD_COLS: int = 16
+
+TCGEN05_STATE_INPUT_PACKED_COLS: int = TCGEN05_STATE_INPUT_LOAD_COLS // 2
+
+TCGEN05_STATE_K_TMEM_ROW_BLOCKS: int = DV // THREADS_PER_WARP
+
+
+def _tcgen05_accumulator_tmem_cols(n_dim: int) -> int:
+    """Return TMEM columns for an FP32 `[128, n_dim]` accumulator tile."""
+
+    if n_dim <= 0:
+        raise ValueError(f"n_dim must be positive, got {n_dim}")
+    if n_dim % 8 != 0:
+        raise ValueError(f"n_dim must be a multiple of 8, got {n_dim}")
+    return n_dim
+
+
+def _tcgen05_f16_input_tmem_cols(k_dim: int) -> int:
+    """Return TMEM columns for an F16 `[128, k_dim]` A-input staging tile."""
+
+    if k_dim <= 0:
+        raise ValueError(f"k_dim must be positive, got {k_dim}")
+    if k_dim % 2 != 0:
+        raise ValueError(f"k_dim must be even for packed F16 TMEM, got {k_dim}")
+    return k_dim // 2
+
+
+KDA_TMEM_N16_ACC_COLS: int = _tcgen05_accumulator_tmem_cols(BT)
+
+KDA_TMEM_N128_ACC_COLS: int = _tcgen05_accumulator_tmem_cols(DK)
+
+KDA_TMEM_STATE_COLS: int = KDA_TMEM_N128_ACC_COLS
+
+KDA_TMEM_STATE_AS_INPUT_COLS: int = _tcgen05_f16_input_tmem_cols(DK)
+
+KDA_TMEM_SHARED_INPUT_COLS: int = _tcgen05_f16_input_tmem_cols(BT)
+
+KDA_TMEM_SHARED_INPUT_STAGE_COUNT: int = 2
+
+KDA_TMEM_SHARED_ACC_STAGE_COUNT: int = 2
+
+KDA_TMEM_STATE_COL_OFFSET: int = 0
+
+KDA_TMEM_STATE_AS_INPUT_COL_OFFSET: int = (
+    KDA_TMEM_STATE_COL_OFFSET + KDA_TMEM_STATE_COLS
+)
+
+KDA_TMEM_SHARED_INPUT_COL_OFFSET: int = (
+    KDA_TMEM_STATE_AS_INPUT_COL_OFFSET + KDA_TMEM_STATE_AS_INPUT_COLS
+)
+
+KDA_TMEM_QSTATE_ACC_COL_OFFSET: int = (
+    KDA_TMEM_SHARED_INPUT_COL_OFFSET
+    + KDA_TMEM_SHARED_INPUT_STAGE_COUNT * KDA_TMEM_SHARED_INPUT_COLS
+)
+
+KDA_TMEM_SHARED_ACC_COL_OFFSET: int = (
+    KDA_TMEM_QSTATE_ACC_COL_OFFSET + KDA_TMEM_N16_ACC_COLS
+)
+
+KDA_TMEM_QSTATE_ACC_STAGE1_COL_OFFSET: int = (
+    KDA_TMEM_SHARED_ACC_COL_OFFSET
+    + KDA_TMEM_SHARED_ACC_STAGE_COUNT * KDA_TMEM_N16_ACC_COLS
+)
+
+KDA_TMEM_QSTATE_ACC_STAGE_STRIDE_COLS: int = (
+    KDA_TMEM_QSTATE_ACC_STAGE1_COL_OFFSET - KDA_TMEM_QSTATE_ACC_COL_OFFSET
+)
+
+
+@cute.jit
+def cta_sync() -> None:
+    """Synchronize all threads in the CTA."""
+
+    prims.barrier_cta_sync(0, thread_count=THREADS_PER_CTA)
+
+
+@cute.jit
+def tmem_user_sync() -> None:
+    """Named barrier for CG1 plus the tcgen05 warp during TMEM lifecycle setup."""
+
+    prims.barrier_cta_sync(NBAR_TMEM_LIFECYCLE_ID, thread_count=TMEM_USER_THREADS)
+
+
+@cute.jit
+def output_drain_sync() -> None:
+    """Synchronize the four warps that cooperatively drain output TMEM."""
+
+    prims.barrier_cta_sync(NBAR_OUTPUT_DRAIN_ID, thread_count=OUTPUT_DRAIN_THREADS)
+
+
+@cute.jit
+def is_compute_group0_warp(warp_idx) -> cutlass.Boolean:
+    """Return whether this warp belongs to CG0 preprocessing."""
+
+    return (warp_idx >= ROLES.compute_group0_first) & (
+        warp_idx <= ROLES.compute_group0_last
+    )
+
+
+@cute.jit
+def is_compute_group1_warp(warp_idx) -> cutlass.Boolean:
+    """Return whether this warp belongs to CG1 value/final-state work."""
+
+    return (warp_idx >= ROLES.compute_group1_first) & (
+        warp_idx <= ROLES.compute_group1_last
+    )
+
+
+@cute.jit
+def is_tmem_user_warp(warp_idx) -> cutlass.Boolean:
+    """Return whether this warp needs the allocated TMEM base pointer."""
+
+    return is_compute_group1_warp(warp_idx) | (warp_idx == ROLES.tcgen05_mma)
+
+
+@cute.jit
+def is_service_warpgroup(warp_idx) -> cutlass.Boolean:
+    """Return whether this warp belongs to the non-CG0/CG1 service warpgroup."""
+
+    return (warp_idx >= ROLES.super_mma) & (warp_idx <= ROLES.epilogue)
+
+
+O_OUT_OFFSET: int = 0
+
+O_ELEM_BYTES: int = TCGEN05_F16_ELEM_BYTES
+
+O_TMA_SWIZZLE_BYTES: int = 128
+
+O_TMA_SWIZZLE_ELEMS: int = O_TMA_SWIZZLE_BYTES // O_ELEM_BYTES
+
+O_TMA_SWIZZLE_GROUP_BYTES: int = 16
+
+O_TMA_SWIZZLE_GROUP_ELEMS: int = O_TMA_SWIZZLE_GROUP_BYTES // O_ELEM_BYTES
+
+O_TMA_SWIZZLE_ROW_MASK: int = (O_TMA_SWIZZLE_ELEMS // O_TMA_SWIZZLE_GROUP_ELEMS) - 1
+
+O_TMA_SWIZZLE_ALIGNMENT_BYTES: int = O_TMA_SWIZZLE_BYTES * (
+    O_TMA_SWIZZLE_ELEMS // O_TMA_SWIZZLE_GROUP_ELEMS
+)
+
+TCGEN05_VALUE_PAIRWISE_B_LEADING_BYTES: int = 16
+
+TCGEN05_VALUE_PAIRWISE_B_STRIDE_BYTES: int = 8 * BT * TCGEN05_F16_ELEM_BYTES
+
+TCGEN05_FINAL_STATE_B_N_GROUP_ELEMS: int = TCGEN05_SW128_BYTES // TCGEN05_F16_ELEM_BYTES
+
+TCGEN05_FINAL_STATE_B_LEADING_BYTES: int = (
+    BT * TCGEN05_FINAL_STATE_B_N_GROUP_ELEMS * TCGEN05_F16_ELEM_BYTES
+)
+
+TCGEN05_FINAL_STATE_B_STRIDE_BYTES: int = (
+    8 * TCGEN05_FINAL_STATE_B_N_GROUP_ELEMS * TCGEN05_F16_ELEM_BYTES
+)
+
+TCGEN05_FINAL_STATE_TMEM_LOAD_COLS: int = 32
+
+RAW_F16_TMA_SWIZZLE_BYTES: int = 128
+
+RAW_F16_TMA_SWIZZLE_ELEMS: int = RAW_F16_TMA_SWIZZLE_BYTES // TCGEN05_F16_ELEM_BYTES
+
+RAW_F16_TMA_SWIZZLE_GROUP_BYTES: int = 16
+
+RAW_F16_TMA_SWIZZLE_GROUP_ELEMS: int = (
+    RAW_F16_TMA_SWIZZLE_GROUP_BYTES // TCGEN05_F16_ELEM_BYTES
+)
+
+RAW_F16_TMA_SWIZZLE_ROW_MASK: int = (
+    RAW_F16_TMA_SWIZZLE_ELEMS // RAW_F16_TMA_SWIZZLE_GROUP_ELEMS
+) - 1
+
+RAW_F16_TMA_SEGMENTS: int = DK // RAW_F16_TMA_SWIZZLE_ELEMS
+
+RAW_F16_TMA_SEGMENT_ELEMS: int = BT * RAW_F16_TMA_SWIZZLE_ELEMS
+
+RAW_F16_TMA_SWIZZLE_ALIGNMENT_BYTES: int = RAW_F16_TMA_SWIZZLE_BYTES * (
+    RAW_F16_TMA_SWIZZLE_ELEMS // RAW_F16_TMA_SWIZZLE_GROUP_ELEMS
+)
+
+
+@dataclass(frozen=True)
+class WarpRoles:
+    """Warp assignment for the BT=16 fully fused KDA kernel."""
+
+    compute_group0_first: int = 0
+    compute_group0_last: int = 7
+    compute_group1_first: int = 8
+    compute_group1_last: int = 11
+    super_mma: int = 12
+    tcgen05_mma: int = 13
+    tma_load: int = 14
+    epilogue: int = 15
+
+
+ROLES = WarpRoles()
+
+
+@cute.jit
+def raw_f16_s128_smem_index(token_coord, dim):
+    """Return the physical s128 SMEM index for raw F16 q/k/v staging."""
+
+    segment = dim // RAW_F16_TMA_SWIZZLE_ELEMS
+    segment_dim = dim - segment * RAW_F16_TMA_SWIZZLE_ELEMS
+    col_group = segment_dim // RAW_F16_TMA_SWIZZLE_GROUP_ELEMS
+    col_in_group = segment_dim - col_group * RAW_F16_TMA_SWIZZLE_GROUP_ELEMS
+    row_swizzle = token_coord & RAW_F16_TMA_SWIZZLE_ROW_MASK
+    return (
+        segment * RAW_F16_TMA_SEGMENT_ELEMS
+        + token_coord * RAW_F16_TMA_SWIZZLE_ELEMS
+        + ((col_group ^ row_swizzle) * RAW_F16_TMA_SWIZZLE_GROUP_ELEMS)
+        + col_in_group
+    )
+
+
+@cute.jit
+def o_smem_swizzle_128b_elem_index(
+    o_stage_base,
+    value_dim,
+    token_coord,
+):
+    """Return the physical W128 SMEM index for one staged output element."""
+
+    segment = value_dim // O_TMA_SWIZZLE_ELEMS
+    segment_value_dim = value_dim - segment * O_TMA_SWIZZLE_ELEMS
+    col_group = segment_value_dim // O_TMA_SWIZZLE_GROUP_ELEMS
+    col_in_group = segment_value_dim - col_group * O_TMA_SWIZZLE_GROUP_ELEMS
+    row_swizzle = token_coord & O_TMA_SWIZZLE_ROW_MASK
+    return (
+        o_stage_base
+        + O_OUT_OFFSET
+        + segment * BT * O_TMA_SWIZZLE_ELEMS
+        + token_coord * O_TMA_SWIZZLE_ELEMS
+        + ((col_group ^ row_swizzle) * O_TMA_SWIZZLE_GROUP_ELEMS)
+        + col_in_group
+    )
+
+
+@cute.jit
+def o_smem_stmatrix_128b_ptr(
+    o_smem,
+    o_stage_base,
+    value_dim_base,
+    lane,
+):
+    """Return the per-lane W128 row-start pointer for one 16x16 STSM.T tile."""
+
+    matrix_id = lane // 8
+    row_in_matrix = lane & 7
+    token_block = matrix_id // 2
+    value_block = matrix_id & 1
+    token_coord = token_block * 8 + row_in_matrix
+    value_dim = value_dim_base + value_block * 8
+    smem_idx = o_smem_swizzle_128b_elem_index(
+        o_stage_base,
+        value_dim,
+        token_coord,
+    )
+    return o_smem.subview(smem_idx).data_ptr()
+
+
+@cute.jit
+def raw_v_ldmatrix_trans_ptr(raw_v_smem, value_dim_base, lane):
+    """Return the per-lane row-start pointer for raw V `ldmatrix.x4.trans`."""
+
+    matrix_id = lane // 8
+    row_in_matrix = lane & 7
+    token_block = matrix_id // 2
+    value_block = matrix_id & 1
+    token_coord = token_block * 8 + row_in_matrix
+    value_dim = value_dim_base + value_block * 8
+    smem_idx = raw_f16_s128_smem_index(token_coord, value_dim)
+    return raw_v_smem.subview(smem_idx).data_ptr()
+
+
+@cute.jit
+def tma_transfer_wait(tma_mbar, tma_phase) -> None:
+    """Spin until one tma_mbar ring slot's expect_tx transaction completes."""
+
+    while not prims.mbarrier_wait_parity(
+        tma_mbar,
+        tma_phase,
+        prims.MBarrierWait.TRY,
+    ):
+        pass
+
+
+@cute.jit
+def output_ready_arrive(output_ready_mbar) -> None:
+    """Signal that this CG1 warp has finished staging output SMEM."""
+
+    if prims.elect_sync():
+        prims.mbarrier_arrive(output_ready_mbar)
+
+
+@cute.jit
+def output_ready_wait(output_ready_mbar, output_ready_phase):
+    """Wait until all CG1 warps have staged the output tile."""
+
+    while not prims.mbarrier_wait_parity(
+        output_ready_mbar,
+        output_ready_phase,
+        prims.MBarrierWait.TRY,
+    ):
+        pass
+    return output_ready_phase ^ cutlass.Int32(1)
+
+
+@cute.jit
+def raw_ready_arrive(raw_ready_mbar) -> None:
+    """Signal that raw SMEM inputs are ready (k2-chain relay only)."""
+
+    if prims.elect_sync():
+        prims.mbarrier_arrive(raw_ready_mbar)
+
+
+@cute.jit
+def raw_ready_wait(raw_ready_mbar, raw_ready_phase):
+    """Generic mbarrier parity spin-wait.
+
+    The engine-class kernels observe raw readiness directly on the
+    chunk's tma_mbar ring slot (consumer-direct wait); the k2 chain
+    kernels still wait their raw_ready relay ring, and the ws_stored /
+    The deltas_issued relay ring uses this helper too.
+    """
+
+    while not prims.mbarrier_wait_parity(
+        raw_ready_mbar,
+        raw_ready_phase,
+        prims.MBarrierWait.TRY,
+    ):
+        pass
+    return raw_ready_phase ^ cutlass.Int32(1)
+
+
+@cute.jit
+def raw_consumed_arrive(raw_consumed_mbar) -> None:
+    """Signal that one participating warp has finished raw-slot reads."""
+
+    if prims.elect_sync():
+        prims.mbarrier_arrive(raw_consumed_mbar)
+
+
+@cute.jit
+def raw_consumed_wait(raw_consumed_mbar, raw_consumed_phase):
+    """Wait until the previous chunk no longer reads raw input SMEM."""
+
+    while not prims.mbarrier_wait_parity(
+        raw_consumed_mbar,
+        raw_consumed_phase,
+        prims.MBarrierWait.TRY,
+    ):
+        pass
+    return raw_consumed_phase ^ cutlass.Int32(1)
+
+
+@cute.jit
+def state_input_ready_arrive(state_input_ready_mbar) -> None:
+    """Signal that this CG1 warp has packed state_as_input TMEM."""
+
+    if prims.elect_sync():
+        prims.mbarrier_arrive(state_input_ready_mbar)
+
+
+@cute.jit
+def state_input_ready_wait(state_input_ready_mbar, state_input_ready_phase):
+    """Wait until all CG1 warps have packed state_as_input TMEM."""
+
+    while not prims.mbarrier_wait_parity(
+        state_input_ready_mbar,
+        state_input_ready_phase,
+        prims.MBarrierWait.TRY,
+    ):
+        pass
+    return state_input_ready_phase ^ cutlass.Int32(1)
+
+
+@cute.jit
+def update_ready_arrive(update_ready_mbar) -> None:
+    """Signal that this CG1 warp has staged update for qkv MMA."""
+
+    if prims.elect_sync():
+        prims.mbarrier_arrive(update_ready_mbar)
+
+
+@cute.jit
+def update_ready_wait(update_ready_mbar, update_ready_phase):
+    """Wait until all CG1 warps have staged update for qkv MMA."""
+
+    while not prims.mbarrier_wait_parity(
+        update_ready_mbar,
+        update_ready_phase,
+        prims.MBarrierWait.TRY,
+    ):
+        pass
+    return update_ready_phase ^ cutlass.Int32(1)
+
+
+@cute.jit
+def final_state_stored_arrive(final_state_stored_mbar) -> None:
+    """Signal that this CG1 warp has finished draining final_state TMEM."""
+
+    if prims.elect_sync():
+        prims.mbarrier_arrive(final_state_stored_mbar)
+
+
+@cute.jit
+def final_state_stored_wait(final_state_stored_mbar, final_state_stored_phase):
+    """Wait until CG1 has drained final_state before TMEM deallocation."""
+
+    while not prims.mbarrier_wait_parity(
+        final_state_stored_mbar,
+        final_state_stored_phase,
+        prims.MBarrierWait.TRY,
+    ):
+        pass
+    return final_state_stored_phase ^ cutlass.Int32(1)
+
+
+@cute.jit
+def pack_output_b16x2_to_i32(
+    value0: cutlass.Float32,
+    value1: cutlass.Float32,
+    output_dtype: cutlass.Constexpr,
+):
+    """Pack two FP32 output values through the compile-time 16-bit output dtype."""
+
+    return (
+        cutlass.Vector.from_elements(
+            (value0, value1),
+            cutlass.Float32,
+        )
+        .to(output_dtype)
+        .bitcast(cutlass.Int32)[0]
+    )
+
+
+@cute.jit
+def tcgen05_qstate_acc_tmem_col_offset(qstate_acc_stage):
+    """Return the runtime TMEM column offset for one qstate acc stage."""
+
+    return (
+        KDA_TMEM_QSTATE_ACC_COL_OFFSET
+        + qstate_acc_stage * KDA_TMEM_QSTATE_ACC_STAGE_STRIDE_COLS
+    )
+
+
+@cute.jit
+def tcgen05_shared_acc_tmem_col_offset(shared_acc_stage):
+    """Return the runtime TMEM column offset for one shared acc stage."""
+
+    return KDA_TMEM_SHARED_ACC_COL_OFFSET + shared_acc_stage * KDA_TMEM_N16_ACC_COLS
+
+
+@cute.jit
+def tcgen05_shared_input_tmem_col_offset(shared_input_stage):
+    """Return the runtime TMEM column offset for one shared input stage."""
+
+    return (
+        KDA_TMEM_SHARED_INPUT_COL_OFFSET
+        + shared_input_stage * KDA_TMEM_SHARED_INPUT_COLS
+    )
+
+
+@cute.jit
+def advance_ring_stage(
+    stage,
+    step: cutlass.Constexpr,
+    stage_count: cutlass.Constexpr,
+):
+    """Advance a runtime ring index without division or a wrap branch."""
+
+    next_stage = stage + cutlass.Int32(step)
+    wrapped = cutlass.Int32(next_stage >= cutlass.Int32(stage_count))
+    return next_stage - wrapped * cutlass.Int32(stage_count), wrapped
+
+
+@cute.jit
+def tcgen05_store_initial_state_tmem(
+    tmem_raw_addr,
+    state: cute.Tensor,
+    sequence,
+    bidy,
+    dv_half,
+    warp_idx,
+    lane,
+) -> None:
+    """Initialize recurrent TMEM from the exact DV2 BF16 state."""
+
+    base_col_id = tmem_raw_addr & 0xFFFF
+    base_row_id = tmem_raw_addr >> 16
+    tmem_sp = warp_idx % TCGEN05_STATE_K_TMEM_ROW_BLOCKS
+
+    row_id = base_row_id + tmem_sp * THREADS_PER_WARP
+    value_dim = (
+        dv_half * cutlass.Int32(DV_HALF)
+        + tmem_sp * ROWS_PER_WARP
+        + (lane % ROWS_PER_WARP)
+    )
+    valid_lane = lane < ROWS_PER_WARP
+    for key_block_start in cutlass.range_constexpr(
+        0,
+        DK,
+        TCGEN05_FINAL_STATE_TMEM_LOAD_COLS,
+    ):
+        state_block = cutlass.Array(
+            cutlass.Float32,
+            TCGEN05_FINAL_STATE_TMEM_LOAD_COLS,
+            alignment=16,
+        )
+        for col in cutlass.range_constexpr(TCGEN05_FINAL_STATE_TMEM_LOAD_COLS):
+            key_dim = key_block_start + col
+            state_value = cutlass.Float32(0.0)
+            if valid_lane:
+                state_value = cast(
+                    "cutlass.Numeric",
+                    state[sequence, bidy, value_dim, key_dim],
+                ).to(cutlass.Float32)
+            state_block[col] = state_value
+
+        projection_col_id = base_col_id + KDA_TMEM_STATE_COL_OFFSET + key_block_start
+        block_addr = (row_id << 16) | projection_col_id
+        block_ptr = cutlass.inttoptr(block_addr, 6, cutlass.Float32)
+        prims.tcgen05_st(
+            "32x32b",
+            block_ptr,
+            state_block[0:TCGEN05_FINAL_STATE_TMEM_LOAD_COLS],
+        )
+
+    prims.tcgen05_wait(kind=prims.Tcgen05Wait.STORE)
+
+
+@cute.jit
+def tcgen05_stage_state_input_dv2_half_tmem(
+    tmem_raw_addr,
+    warp_idx,
+    input_dtype: cutlass.Constexpr,
+    HALF: cutlass.Constexpr,
+) -> cutlass.Array:
+    """Load one FP32 state half and asynchronously pack its MMA-A image."""
+
+    base_col_id = tmem_raw_addr & 0xFFFF
+    base_row_id = tmem_raw_addr >> 16
+    tmem_sp = warp_idx % TCGEN05_STATE_K_TMEM_ROW_BLOCKS
+    row_addr = (base_row_id + tmem_sp * THREADS_PER_WARP) << 16
+    state_half_col = (
+        base_col_id
+        + KDA_TMEM_STATE_COL_OFFSET
+        + HALF * 4 * TCGEN05_STATE_INPUT_LOAD_COLS
+    )
+    state_ptr = cutlass.inttoptr(
+        row_addr | state_half_col,
+        6,
+        cutlass.Float32,
+    )
+    state = prims.tcgen05_ld("16x256b", state_ptr, num=8)
+    prims.tcgen05_wait(kind=prims.Tcgen05Wait.LOAD)
+
+    packed_state = cutlass.Array(cutlass.Int32, 16, alignment=16)
+    for dst_repeat in cutlass.range_constexpr(8):
+        src_base = (dst_repeat ^ 1) * 4
+        dst_base = dst_repeat * 2
+        packed_state[dst_base] = pack_input_b16x2_to_i32(
+            state[src_base],
+            state[src_base + 1],
+            input_dtype,
+        )
+        packed_state[dst_base + 1] = pack_input_b16x2_to_i32(
+            state[src_base + 2],
+            state[src_base + 3],
+            input_dtype,
+        )
+
+    packed_col = (
+        base_col_id
+        + KDA_TMEM_STATE_AS_INPUT_COL_OFFSET
+        + HALF * 4 * TCGEN05_STATE_INPUT_PACKED_COLS
+    )
+    packed_ptr = prims.make_tmem_ptr(
+        (base_row_id << 16) | packed_col,
+        cutlass.Int8,
+    )
+    prims.tcgen05_st("16x128b", packed_ptr, packed_state[0:16])
+    return state
+
+
+@cute.jit
+def tcgen05_rescale_state_dv2_half_regs(
+    tmem_raw_addr,
+    state_scale_f32_smem,
+    warp_idx,
+    state,
+    state_input_ready_mbar,
+    HALF: cutlass.Constexpr,
+) -> None:
+    """Overlap true-FP32 decay with the outstanding packed-state store."""
+
+    base_col_id = tmem_raw_addr & 0xFFFF
+    base_row_id = tmem_raw_addr >> 16
+    tmem_sp = warp_idx % TCGEN05_STATE_K_TMEM_ROW_BLOCKS
+    row_addr = (base_row_id + tmem_sp * THREADS_PER_WARP) << 16
+    state_half_col = (
+        base_col_id
+        + KDA_TMEM_STATE_COL_OFFSET
+        + HALF * 4 * TCGEN05_STATE_INPUT_LOAD_COLS
+    )
+    state_ptr = cutlass.inttoptr(
+        row_addr | state_half_col,
+        6,
+        cutlass.Float32,
+    )
+    state_scale_f32_ptr = state_scale_f32_smem.data_ptr()
+    key_half_start: cutlass.Constexpr = HALF * 4 * TCGEN05_STATE_INPUT_LOAD_COLS
+    scaled_state = cutlass.Array(cutlass.Float32, 32, alignment=16)
+    lane_col_pair = (cute.arch.lane_idx() % 4) * 2
+    for repeat in cutlass.range_constexpr(8):
+        reg_base = repeat * 4
+        scale_dim = key_half_start + repeat * 8 + lane_col_pair
+        scale = (state_scale_f32_ptr + scale_dim).load(count=2, alignment=8)
+        scaled_state[reg_base], scaled_state[reg_base + 1] = fmul2(
+            (state[reg_base], state[reg_base + 1]),
+            (scale[0], scale[1]),
+        )
+        scaled_state[reg_base + 2], scaled_state[reg_base + 3] = fmul2(
+            (state[reg_base + 2], state[reg_base + 3]),
+            (scale[0], scale[1]),
+        )
+
+    prims.tcgen05_wait(kind=prims.Tcgen05Wait.STORE)
+    prims.tcgen05_fence(prims.Tcgen05Fence.BEFORE_THREAD_SYNC)
+    state_input_ready_arrive(state_input_ready_mbar)
+    prims.tcgen05_st("16x256b", state_ptr, scaled_state[0:32])
+    prims.tcgen05_wait(kind=prims.Tcgen05Wait.STORE)
+    prims.tcgen05_fence(prims.Tcgen05Fence.BEFORE_THREAD_SYNC)
+
+
+@cute.jit
+def tcgen05_issue_state_projection_mma(
+    tcgen05_decay_smem,
+    tmem_raw_addr,
+    acc_ready_mbar,
+    tmem_col_offset,
+    input_dtype: cutlass.Constexpr,
+    K_BLOCK_BEGIN: cutlass.Constexpr,
+    K_BLOCK_END: cutlass.Constexpr,
+    INITIAL_SCALE_D: cutlass.Constexpr,
+    COMMIT: cutlass.Constexpr,
+    M_DIM: cutlass.Constexpr,
+) -> None:
+    """Issue state*decay K-slices through tcgen05, optionally committing."""
+
+    tmem_ptr = cutlass.inttoptr(
+        tmem_raw_addr + tmem_col_offset,
+        6,
+        cutlass.Float32,
+    )
+    idesc = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=input_dtype,
+        b_dtype=input_dtype,
+        n_dim=BT,
+        m_dim=M_DIM,
+        b_major=0,
+    )
+    desc_k_decay = prims.Tcgen05SmemDesc.build(
+        tcgen05_decay_smem.subview(0),
+        leading_byte_offset=TCGEN05_STATE_K_B_LEADING_BYTES,
+        stride_byte_offset=TCGEN05_STATE_K_B_STRIDE_BYTES,
+        layout=prims.Tcgen05SmemSwizzle.SWIZZLE_128B,
+    )
+
+    for k_block in cutlass.range_constexpr(K_BLOCK_BEGIN, K_BLOCK_END):
+        scale_d = INITIAL_SCALE_D or k_block != K_BLOCK_BEGIN
+        k_decay_offset = (
+            k_block % TCGEN05_SW128_K_PHASES_PER_SLICE
+        ) * TCGEN05_STATE_K_B_K_STEP_BYTES + (
+            k_block // TCGEN05_SW128_K_PHASES_PER_SLICE
+        ) * BT * TCGEN05_SW128_BYTES
+        state_a_tmem = prims.make_tmem_ptr(tmem_raw_addr, cutlass.Int8).subview(
+            KDA_TMEM_STATE_AS_INPUT_COL_OFFSET + k_block * (TCGEN05_F16_K_ATOM // 2)
+        )
+        if prims.elect_sync():
+            prims.tcgen05_mma(
+                prims.Tcgen05MMAKind.F16,
+                prims.CTAGroup.CTA_1,
+                tmem_ptr,
+                state_a_tmem,
+                desc_k_decay.advance_start_address(k_decay_offset),
+                idesc,
+                scale_d,
+            )
+
+    if cutlass.const_expr(COMMIT):
+        if prims.elect_sync():
+            prims.tcgen05_commit(acc_ready_mbar, group=prims.CTAGroup.CTA_1)
+
+
+@cute.jit
+def tcgen05_issue_state_k_mma(
+    tcgen05_k_decay_smem,
+    tmem_raw_addr,
+    acc_ready_mbar,
+    shared_acc_stage,
+    input_dtype: cutlass.Constexpr,
+    K_BLOCK_BEGIN: cutlass.Constexpr,
+    K_BLOCK_END: cutlass.Constexpr,
+    INITIAL_SCALE_D: cutlass.Constexpr,
+    COMMIT: cutlass.Constexpr,
+    M_DIM: cutlass.Constexpr,
+) -> None:
+    """Issue a K-slice range of state*k into a scheduled shared_acc stage."""
+
+    tcgen05_issue_state_projection_mma(
+        tcgen05_k_decay_smem,
+        tmem_raw_addr,
+        acc_ready_mbar,
+        tcgen05_shared_acc_tmem_col_offset(shared_acc_stage),
+        input_dtype,
+        K_BLOCK_BEGIN,
+        K_BLOCK_END,
+        INITIAL_SCALE_D,
+        COMMIT,
+        M_DIM,
+    )
+
+
+@cute.jit
+def tcgen05_wait_acc_buffer_ready(
+    acc_ready_mbar,
+    acc_ready_phase,
+):
+    """Wait until a producer commit has filled the corresponding TMEM acc tile."""
+
+    while not prims.mbarrier_wait_parity(
+        acc_ready_mbar,
+        acc_ready_phase,
+        prims.MBarrierWait.TRY,
+    ):
+        pass
+    return acc_ready_phase ^ cutlass.Int32(1)
+
+
+@cute.jit
+def tcgen05_rhs_token_pair_from_16x256b_fragment(
+    fragment,
+    reg_idx: cutlass.Constexpr,
+):
+    """Select the lane-local state*k pair needed by the RHS TMEM store."""
+
+    if cutlass.const_expr(reg_idx == 0):
+        return fragment[4], fragment[5]
+    if cutlass.const_expr(reg_idx == 1):
+        return fragment[6], fragment[7]
+    if cutlass.const_expr(reg_idx == 2):
+        return fragment[0], fragment[1]
+    return fragment[2], fragment[3]
+
+
+@cute.jit
+def tcgen05_store_final_state_tmem(
+    tmem_raw_addr,
+    state_col_offset,
+    state: cute.Tensor,
+    sequence,
+    bidy,
+    dv_half,
+    warp_idx,
+    lane,
+) -> None:
+    """Store the live recurrent TMEM state to the exact DV2 BF16 state."""
+
+    base_col_id = tmem_raw_addr & 0xFFFF
+    base_row_id = tmem_raw_addr >> 16
+    tmem_sp = warp_idx % TCGEN05_STATE_K_TMEM_ROW_BLOCKS
+
+    row_id = base_row_id + tmem_sp * THREADS_PER_WARP
+    value_dim = (
+        dv_half * cutlass.Int32(DV_HALF)
+        + tmem_sp * ROWS_PER_WARP
+        + (lane % ROWS_PER_WARP)
+    )
+    valid_lane = lane < ROWS_PER_WARP
+    for key_block_start in cutlass.range_constexpr(
+        0,
+        DK,
+        TCGEN05_FINAL_STATE_TMEM_LOAD_COLS,
+    ):
+        projection_col_id = base_col_id + state_col_offset + key_block_start
+        block_addr = (row_id << 16) | projection_col_id
+        block_ptr = cutlass.inttoptr(block_addr, 6, cutlass.Float32)
+        loaded = prims.tcgen05_ld(
+            "32x32b",
+            block_ptr,
+            num=TCGEN05_FINAL_STATE_TMEM_LOAD_COLS,
+        )
+        prims.tcgen05_wait(kind=prims.Tcgen05Wait.LOAD)
+
+        for col in cutlass.range_constexpr(TCGEN05_FINAL_STATE_TMEM_LOAD_COLS):
+            key_dim = key_block_start + col
+            if valid_lane:
+                state[sequence, bidy, value_dim, key_dim] = loaded[col].to(
+                    state.element_type
+                )
+
+
+K2_RAW_STAGE_COUNT: int = 8
+
+K2_TMA_MBAR_STAGE_COUNT: int = 6
+
+TILE_ELEMS: int = BT * DK
+
+DIAG_REC_ELEMS: int = DK  # per-chunk fp32 diag record
+
+QK_REC_ELEMS: int = BT * BT  # per-chunk SW32-permuted QK' record
+
+TMEM_ALLOC_COLS: int = 512
+
+K2_QSTATE_STAGE_COUNT: int = 2
+
+K2_OUTPUT_SMEM_STAGE_COUNT: int = 7
+
+DV_HALF: int = DV // 2
+
+ROWS_PER_WARP: int = DV_HALF // 4  # Layout F: 16 rows per quadrant
+
+V_TILE_ELEMS: int = BT * DV_HALF  # one 64-elem s128 TMA segment
+
+K2_O_SMEM_STAGE_SIZE: int = BT * DV_HALF
+
+K2_O_SMEM_TILE_SIZE: int = K2_OUTPUT_SMEM_STAGE_COUNT * K2_O_SMEM_STAGE_SIZE
+
+K2_TX_BYTES: int = (
+    3 * TILE_ELEMS * 2  # kd + w + qd (bf16, full DK)
+    + V_TILE_ELEMS * 2  # v (bf16, DV half)
+    + DIAG_REC_ELEMS * 4  # diag (fp32)
+    + QK_REC_ELEMS * 2  # qk' (bf16)
+)
+
+
+@cute.jit
+def tma_chain_load_tile(
+    tma_desc: cutlass.GridConstant[cuda.TensorMap],
+    tile_smem,
+    row_start,
+    head_idx,
+    tma_mbar,
+) -> None:
+    """Issue one rank-4 TMA for a complete [16, DK] workspace tile."""
+
+    tma_coord = (
+        cutlass.Int32(0),
+        row_start,
+        head_idx,
+        cutlass.Int32(0),
+    )
+    prims.cp_async_bulk_tensor_shared_cta_global(
+        tile_smem.subview(0),
+        tma_desc.get_ptr(),
+        tma_coord,
+        tma_mbar,
+    )
+
+
+@cute.jit
+def tcgen05_commit(mbar) -> None:
+    """Commit the tensor pipe's progress to an mbarrier (single elected lane)."""
+
+    if prims.elect_sync():
+        prims.tcgen05_commit(mbar, group=prims.CTAGroup.CTA_1)
+
+
+@cute.jit
+def tcgen05_chain_issue_delta_half_mma(
+    b_smem,
+    tmem_raw_addr,
+    a_input_col,
+    input_dtype: cutlass.Constexpr,
+    HALF: cutlass.Constexpr,
+) -> None:
+    """M=64 delta-half MMA issue."""
+
+    half_n = DK // 2
+    tmem_ptr = cutlass.inttoptr(
+        tmem_raw_addr + KDA_TMEM_STATE_COL_OFFSET + HALF * half_n,
+        6,
+        cutlass.Float32,
+    )
+    desc_b = prims.Tcgen05SmemDesc.build(
+        b_smem.subview(0),
+        leading_byte_offset=TCGEN05_FINAL_STATE_B_LEADING_BYTES,
+        stride_byte_offset=TCGEN05_FINAL_STATE_B_STRIDE_BYTES,
+        layout=prims.Tcgen05SmemSwizzle.SWIZZLE_128B,
+    )
+    idesc = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=input_dtype,
+        b_dtype=input_dtype,
+        n_dim=half_n,
+        m_dim=DV_HALF,
+        b_major=1,
+    )
+    half_byte_offset = HALF * TCGEN05_FINAL_STATE_B_LEADING_BYTES
+    a_tmem = prims.make_tmem_ptr(tmem_raw_addr, cutlass.Int8).subview(a_input_col)
+    if prims.elect_sync():
+        prims.tcgen05_mma(
+            prims.Tcgen05MMAKind.F16,
+            prims.CTAGroup.CTA_1,
+            tmem_ptr,
+            a_tmem,
+            desc_b.advance_start_address(half_byte_offset),
+            idesc,
+            True,
+        )
+
+
+@cute.jit
+def tcgen05_chain_issue_qkv_mma(
+    qk_stage_smem,
+    tmem_raw_addr,
+    a_input_col,
+    qstate_acc_stage,
+    acc_ready_mbar,
+    input_dtype: cutlass.Constexpr,
+    COMMIT: cutlass.Constexpr,
+) -> None:
+    """M=64 qkv MMA issue."""
+
+    tmem_ptr = cutlass.inttoptr(
+        tmem_raw_addr + tcgen05_qstate_acc_tmem_col_offset(qstate_acc_stage),
+        6,
+        cutlass.Float32,
+    )
+    idesc = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=input_dtype,
+        b_dtype=input_dtype,
+        n_dim=BT,
+        m_dim=DV_HALF,
+        b_major=0,
+    )
+    lhs_tmem = prims.make_tmem_ptr(tmem_raw_addr, cutlass.Int8).subview(a_input_col)
+    desc_pairwise = prims.Tcgen05SmemDesc.build(
+        qk_stage_smem.subview(0),
+        leading_byte_offset=TCGEN05_VALUE_PAIRWISE_B_LEADING_BYTES,
+        stride_byte_offset=TCGEN05_VALUE_PAIRWISE_B_STRIDE_BYTES,
+        layout=prims.Tcgen05SmemSwizzle.SWIZZLE_32B,
+    )
+    if prims.elect_sync():
+        prims.tcgen05_mma(
+            prims.Tcgen05MMAKind.F16,
+            prims.CTAGroup.CTA_1,
+            tmem_ptr,
+            lhs_tmem,
+            desc_pairwise,
+            idesc,
+            True,
+        )
+        if cutlass.const_expr(COMMIT):
+            prims.tcgen05_commit(acc_ready_mbar, group=prims.CTAGroup.CTA_1)
+
+
+@cute.jit
+def tcgen05_chain_stage_vmx_input_tmem(
+    tmem_raw_addr,
+    raw_v_smem,
+    warp_idx,
+    lane,
+    shared_acc_stage,
+    shared_input_stage,
+    input_dtype: cutlass.Constexpr,
+) -> None:
+    """M=64 (v - X) fused repack staging.
+
+    ONE v ldmatrix ([16,64] half tile) + ONE 16x256b X
+    fragment read + sub.b16x2 + ONE 16x128b store.
+    """
+
+    base_col_id = tmem_raw_addr & 0xFFFF
+    base_row_id = tmem_raw_addr >> 16
+    tmem_sp = warp_idx % TCGEN05_STATE_K_TMEM_ROW_BLOCKS
+
+    projection_col_id = base_col_id + tcgen05_shared_acc_tmem_col_offset(
+        shared_acc_stage
+    )
+    input_col_id = base_col_id + tcgen05_shared_input_tmem_col_offset(
+        shared_input_stage
+    )
+    value_dim_base = tmem_sp * ROWS_PER_WARP
+
+    row_id0 = base_row_id + tmem_sp * THREADS_PER_WARP
+    block_ptr0 = cutlass.inttoptr(
+        (row_id0 << 16) | projection_col_id, 6, cutlass.Float32
+    )
+    state_k0 = prims.tcgen05_ld("16x256b", block_ptr0, num=2)
+
+    raw_v_regs0 = prims.ldmatrix(
+        raw_v_ldmatrix_trans_ptr(raw_v_smem, value_dim_base, lane),
+        4,
+        prims.MMALayout.COL,
+    )
+    prims.tcgen05_wait(kind=prims.Tcgen05Wait.LOAD)
+
+    packed0 = cutlass.Array(cutlass.Int32, 4, space=cutlass.AddressSpace.rmem)
+    for reg_idx in cutlass.range_constexpr(4):
+        raw_matrix: cutlass.Constexpr[int] = (1 - (reg_idx // 2)) * 2 + (reg_idx & 1)
+        val0, val1 = tcgen05_rhs_token_pair_from_16x256b_fragment(
+            state_k0,
+            reg_idx,
+        )
+        packed0[reg_idx] = sub_b16x2_input_dtype(
+            raw_v_regs0[raw_matrix],
+            pack_input_b16x2_to_i32(val0, val1, input_dtype),
+            input_dtype,
+        )
+
+    input_block_addr0 = (base_row_id << 16) | input_col_id
+    input_block_ptr0 = prims.make_tmem_ptr(input_block_addr0, cutlass.Int8)
+    prims.tcgen05_st("16x128b", input_block_ptr0, packed0[0:4])
+    prims.tcgen05_wait(kind=prims.Tcgen05Wait.STORE)
+    prims.tcgen05_fence(prims.Tcgen05Fence.BEFORE_THREAD_SYNC)
+
+
+@cute.jit
+def tcgen05_chain_load_qstate_output_regs(
+    tmem_raw_addr,
+    warp_idx,
+    qstate_acc_stage,
+    scale: cutlass.Float32,
+    output_dtype: cutlass.Constexpr,
+):
+    """Load, scale, and pack one warp's output quadrant from TMEM."""
+
+    base_col_id = tmem_raw_addr & 0xFFFF
+    base_row_id = tmem_raw_addr >> 16
+    tmem_sp = warp_idx % TCGEN05_STATE_K_TMEM_ROW_BLOCKS
+
+    projection_col_id = base_col_id + tcgen05_qstate_acc_tmem_col_offset(
+        qstate_acc_stage
+    )
+    row_id0 = base_row_id + tmem_sp * THREADS_PER_WARP
+    block_addr0 = (row_id0 << 16) | projection_col_id
+    block_ptr0 = cutlass.inttoptr(block_addr0, 6, cutlass.Float32)
+    loaded0 = prims.tcgen05_ld(
+        "16x256b",
+        block_ptr0,
+        num=2,
+    )
+    prims.tcgen05_wait(kind=prims.Tcgen05Wait.LOAD)
+
+    stsm_regs0 = cutlass.Array(
+        cutlass.Int32,
+        4,
+        space=cutlass.AddressSpace.rmem,
+    )
+    for reg_idx in cutlass.range_constexpr(4):
+        scaled0_0, scaled0_1 = fmul2(
+            (loaded0[2 * reg_idx], loaded0[2 * reg_idx + 1]),
+            (scale, scale),
+        )
+        stsm_regs0[reg_idx] = pack_output_b16x2_to_i32(
+            scaled0_0,
+            scaled0_1,
+            output_dtype,
+        )
+    return stsm_regs0
+
+
+@cute.jit
+def tcgen05_chain_store_output_smem(
+    o_smem,
+    warp_idx,
+    lane,
+    o_stage_base,
+    stsm_regs0,
+) -> None:
+    """Store one warp's packed output quadrant into the output-SMEM ring."""
+
+    tmem_sp = warp_idx % TCGEN05_STATE_K_TMEM_ROW_BLOCKS
+    value_dim_base = tmem_sp * ROWS_PER_WARP
+    smem_dst0 = o_smem_stmatrix_128b_ptr(
+        o_smem,
+        o_stage_base,
+        value_dim_base,
+        lane,
+    )
+    prims.stmatrix(
+        smem_dst0,
+        stsm_regs0.data_ptr().load(count=4, alignment=4),
+        prims.MMALayout.COL,
+        shape=prims.StoreShape.M8N8,
+    )
+    cute.arch.fence_view_async_shared()
+
+
+@cute.jit
+def tma_chain_stage_load_inputs(
+    tma_desc_kd: cutlass.GridConstant[cuda.TensorMap],
+    tma_desc_w: cutlass.GridConstant[cuda.TensorMap],
+    tma_desc_qd: cutlass.GridConstant[cuda.TensorMap],
+    tma_desc_v: cutlass.GridConstant[cuda.TensorMap],
+    tma_desc_diag: cutlass.GridConstant[cuda.TensorMap],
+    tma_desc_qk: cutlass.GridConstant[cuda.TensorMap],
+    kd_stage,
+    w_stage,
+    qd_stage,
+    v_stage,
+    diag_stage,
+    qk_stage,
+    head_idx,
+    dv_half,
+    ws_row_start,
+    ws_chunk,
+    v_row_start,
+    tma_mbar,
+    tma_tx_bytes: cutlass.Constexpr,
+) -> None:
+    """DV2 chunk operand transaction: full kd/w/qd, HALF v (one segment)."""
+
+    if prims.elect_sync():
+        prims.mbarrier_arrive_expect_tx(tma_mbar, tma_tx_bytes)
+    if prims.elect_sync():
+        tma_chain_load_tile(tma_desc_kd, kd_stage, ws_row_start, head_idx, tma_mbar)
+        tma_chain_load_tile(tma_desc_w, w_stage, ws_row_start, head_idx, tma_mbar)
+        tma_chain_load_tile(tma_desc_qd, qd_stage, ws_row_start, head_idx, tma_mbar)
+        v_coord = (
+            dv_half * cutlass.Int32(DV_HALF),
+            v_row_start,
+            head_idx,
+            cutlass.Int32(0),
+        )
+        prims.cp_async_bulk_tensor_shared_cta_global(
+            v_stage.subview(0),
+            tma_desc_v.get_ptr(),
+            v_coord,
+            tma_mbar,
+        )
+        diag_coord = (
+            cutlass.Int32(0),
+            ws_chunk,
+            head_idx,
+            cutlass.Int32(0),
+        )
+        prims.cp_async_bulk_tensor_shared_cta_global(
+            diag_stage.subview(0),
+            tma_desc_diag.get_ptr(),
+            diag_coord,
+            tma_mbar,
+        )
+        prims.cp_async_bulk_tensor_shared_cta_global(
+            qk_stage.subview(0),
+            tma_desc_qk.get_ptr(),
+            diag_coord,
+            tma_mbar,
+        )
+
+
+@cute.jit
+def epilogue_chain_stage_store(
+    tma_desc_o: cutlass.GridConstant[cuda.TensorMap],
+    o_smem,
+    sequence_start,
+    head_idx,
+    dv_half,
+    chunk_start,
+    o_stage_base,
+) -> None:
+    """Store the staged `[BT, 64]` half-output tile (one s128 segment)."""
+
+    global_chunk_start = sequence_start + chunk_start
+    if prims.elect_sync():
+        o_coord = (
+            dv_half * cutlass.Int32(DV_HALF),
+            global_chunk_start,
+            head_idx,
+            cutlass.Int32(0),
+        )
+        prims.cp_async_bulk_tensor_global_shared_cta(
+            tma_desc_o.get_ptr(),
+            o_smem.subview(o_stage_base + O_OUT_OFFSET),
+            o_coord,
+        )
+        prims.cp_async_bulk_commit_group()
+    prims.bar_warp_sync(cute.arch.FULL_MASK)
+
+
+@cute.jit
+def epilogue_chain_tail_store(
+    out,
+    o_smem,
+    sequence_start,
+    head_idx,
+    dv_half,
+    chunk_start,
+    seqlen,
+    o_stage_base,
+    lane,
+) -> None:
+    """Store a partial packed-sequence half-tail without crossing its boundary."""
+
+    valid_tokens = seqlen - chunk_start
+    value_base = dv_half * cutlass.Int32(DV_HALF)
+    for elem_iter in cutlass.range_constexpr((BT * DV_HALF) // THREADS_PER_WARP):
+        linear_idx = elem_iter * THREADS_PER_WARP + lane
+        token_coord = linear_idx // DV_HALF
+        value_dim = linear_idx - token_coord * DV_HALF
+        if token_coord < valid_tokens:
+            smem_idx = o_smem_swizzle_128b_elem_index(
+                o_stage_base,
+                value_dim,
+                token_coord,
+            )
+            out[
+                0,
+                sequence_start + chunk_start + token_coord,
+                head_idx,
+                value_base + value_dim,
+            ] = o_smem[smem_idx]
+    prims.bar_warp_sync(cute.arch.FULL_MASK)
+
+
+@cute.kernel
+def kernel_chain_dv2(
+    tma_desc_kd: cutlass.GridConstant[cuda.TensorMap],
+    tma_desc_w: cutlass.GridConstant[cuda.TensorMap],
+    tma_desc_qd: cutlass.GridConstant[cuda.TensorMap],
+    tma_desc_v: cutlass.GridConstant[cuda.TensorMap],
+    tma_desc_diag: cutlass.GridConstant[cuda.TensorMap],
+    tma_desc_qk: cutlass.GridConstant[cuda.TensorMap],
+    tma_desc_o: cutlass.GridConstant[cuda.TensorMap],
+    v: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    cu_chunks: cute.Tensor,
+    state: cute.Tensor,
+    out: cute.Tensor,
+    head_base: cutlass.Int32,
+    SCALE: cutlass.Float32,
+) -> None:
+    """kernel 2, DV-split: each CTA owns half the hidden dimension.
+
+    Grid `(num_sequences, launch_heads * 2, 1)`; bidy = head * 2 + half.
+    Identical schedule and mbar topology to the base chain with M=64
+    MMAs (PTX Layout F: 16 rows per warp quadrant, lane alignment 0);
+    kd/W/QK'/diag are read identically by both halves, v/o/state are
+    DV-split (one 64-elem s128 TMA segment at value offset half*64).
+    """
+
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, bidy, _ = cute.arch.block_idx()
+    dv_half = bidy % 2
+    bidy = head_base + bidy // 2
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    lane = tidx % THREADS_PER_WARP
+
+    sequence_start = cutlass.Int32(cu_seqlens[bidx])
+    sequence_end = cutlass.Int32(cu_seqlens[bidx + 1])
+    seqlen = sequence_end - sequence_start
+    num_chunks = cute.ceil_div(seqlen, BT)
+    chunk_base = cutlass.Int32(cu_chunks[bidx])
+    input_dtype = v.element_type
+
+    # --- mbarriers (identical topology to the base chain) ----------------
+    tma_mbar = cutlass.Array(
+        cutlass.Int64,
+        K2_TMA_MBAR_STAGE_COUNT,
+        space=cutlass.AddressSpace.smem,
+        alignment=8,
+    )
+    raw_ready_mbar = cutlass.Array(
+        cutlass.Int64,
+        K2_RAW_STAGE_COUNT,
+        space=cutlass.AddressSpace.smem,
+        alignment=8,
+    )
+    raw_consumed_mbar = cutlass.Array(
+        cutlass.Int64,
+        K2_RAW_STAGE_COUNT,
+        space=cutlass.AddressSpace.smem,
+        alignment=8,
+    )
+    state_input_ready_l_mbar = cutlass.Array(
+        cutlass.Int64, 1, space=cutlass.AddressSpace.smem, alignment=8
+    )
+    state_input_ready_mbar = cutlass.Array(
+        cutlass.Int64, 1, space=cutlass.AddressSpace.smem, alignment=8
+    )
+    u_input_ready_mbar = cutlass.Array(
+        cutlass.Int64, 2, space=cutlass.AddressSpace.smem, alignment=8
+    )
+    update_ready_mbar = cutlass.Array(
+        cutlass.Int64, 1, space=cutlass.AddressSpace.smem, alignment=8
+    )
+    shared_acc_ready_mbar = cutlass.Array(
+        cutlass.Int64, 2, space=cutlass.AddressSpace.smem, alignment=8
+    )
+    k_restore_consumed_l_mbar = cutlass.Array(
+        cutlass.Int64, 2, space=cutlass.AddressSpace.smem, alignment=8
+    )
+    k_restore_consumed_mbar = cutlass.Array(
+        cutlass.Int64, 2, space=cutlass.AddressSpace.smem, alignment=8
+    )
+    qstate_acc_ready_mbar = cutlass.Array(
+        cutlass.Int64,
+        K2_QSTATE_STAGE_COUNT,
+        space=cutlass.AddressSpace.smem,
+        alignment=8,
+    )
+    stateq_done_mbar = cutlass.Array(
+        cutlass.Int64, 2, space=cutlass.AddressSpace.smem, alignment=8
+    )
+    output_ready_mbar = cutlass.Array(
+        cutlass.Int64,
+        K2_QSTATE_STAGE_COUNT,
+        space=cutlass.AddressSpace.smem,
+        alignment=8,
+    )
+    final_state_stored_mbar = cutlass.Array(
+        cutlass.Int64, 1, space=cutlass.AddressSpace.smem, alignment=8
+    )
+    tmem_ptr_i32 = cutlass.Array(
+        cutlass.Int32, 1, space=cutlass.AddressSpace.smem, alignment=4
+    )
+
+    # --- SMEM rings (v halved to one segment; o halved) --------------------
+    kd_smem = cutlass.Array(
+        input_dtype,
+        K2_RAW_STAGE_COUNT * TILE_ELEMS,
+        space=cutlass.AddressSpace.smem,
+        alignment=RAW_F16_TMA_SWIZZLE_ALIGNMENT_BYTES,
+    )
+    w_smem = cutlass.Array(
+        input_dtype,
+        K2_RAW_STAGE_COUNT * TILE_ELEMS,
+        space=cutlass.AddressSpace.smem,
+        alignment=RAW_F16_TMA_SWIZZLE_ALIGNMENT_BYTES,
+    )
+    qd_smem = cutlass.Array(
+        input_dtype,
+        K2_RAW_STAGE_COUNT * TILE_ELEMS,
+        space=cutlass.AddressSpace.smem,
+        alignment=RAW_F16_TMA_SWIZZLE_ALIGNMENT_BYTES,
+    )
+    v_raw_smem = cutlass.Array(
+        input_dtype,
+        K2_RAW_STAGE_COUNT * V_TILE_ELEMS,
+        space=cutlass.AddressSpace.smem,
+        alignment=RAW_F16_TMA_SWIZZLE_ALIGNMENT_BYTES,
+    )
+    diag_raw_smem = cutlass.Array(
+        cutlass.Float32,
+        K2_RAW_STAGE_COUNT * DIAG_REC_ELEMS,
+        space=cutlass.AddressSpace.smem,
+        alignment=1024,
+    )
+    qk_smem = cutlass.Array(
+        input_dtype,
+        K2_RAW_STAGE_COUNT * QK_REC_ELEMS,
+        space=cutlass.AddressSpace.smem,
+        alignment=1024,
+    )
+    o_smem = cutlass.Array(
+        out.element_type,
+        K2_O_SMEM_TILE_SIZE,
+        space=cutlass.AddressSpace.smem,
+        alignment=O_TMA_SWIZZLE_ALIGNMENT_BYTES,
+    )
+
+    # --- init (identical to the base chain) ------------------------------
+    if warp_idx == ROLES.tma_load:
+        if prims.elect_sync():
+            for stage in cutlass.range_constexpr(K2_TMA_MBAR_STAGE_COUNT):
+                prims.mbarrier_init(tma_mbar.subview(stage), 1)
+            for stage in cutlass.range_constexpr(K2_RAW_STAGE_COUNT):
+                prims.mbarrier_init(raw_ready_mbar.subview(stage), 1)
+                prims.mbarrier_init(
+                    raw_consumed_mbar.subview(stage),
+                    5,
+                )
+    elif warp_idx == ROLES.tcgen05_mma:
+        if prims.elect_sync():
+            prims.mbarrier_init(state_input_ready_l_mbar, 4)
+            prims.mbarrier_init(state_input_ready_mbar, 4)
+            for stage in cutlass.range_constexpr(2):
+                prims.mbarrier_init(u_input_ready_mbar.subview(stage), 4)
+                prims.mbarrier_init(shared_acc_ready_mbar.subview(stage), 1)
+                prims.mbarrier_init(k_restore_consumed_l_mbar.subview(stage), 1)
+                prims.mbarrier_init(k_restore_consumed_mbar.subview(stage), 1)
+                prims.mbarrier_init(stateq_done_mbar.subview(stage), 1)
+            # CG1 fuses the right-half pack/scale while idle CG0 warps 4-7
+            # fuse the left half. Both groups must finish before delta.
+            prims.mbarrier_init(update_ready_mbar, 8)
+            for stage in cutlass.range_constexpr(K2_QSTATE_STAGE_COUNT):
+                prims.mbarrier_init(qstate_acc_ready_mbar.subview(stage), 1)
+            prims.mbarrier_init(final_state_stored_mbar, 8)
+    elif warp_idx == ROLES.epilogue:
+        if prims.elect_sync():
+            for stage in cutlass.range_constexpr(K2_QSTATE_STAGE_COUNT):
+                prims.mbarrier_init(output_ready_mbar.subview(stage), 4)
+    prims.fence_mbarrier_init()
+    cta_sync()
+
+    if is_tmem_user_warp(warp_idx):
+        if warp_idx == ROLES.tcgen05_mma:
+            prims.tcgen05_alloc(tmem_ptr_i32, TMEM_ALLOC_COLS, group="cta_1")
+        tmem_user_sync()
+        if warp_idx == ROLES.tcgen05_mma:
+            prims.tcgen05_relinquish_alloc_permit(group="cta_1")
+        tmem_user_sync()
+    cta_sync()
+
+    if is_service_warpgroup(warp_idx):
+        prims.setmaxregister(KDA_SERVICE_REGS, prims.SetMaxRegisterAction.DECREASE)
+
+    # ======================= warp 14: TMA ring =========================
+    if warp_idx == ROLES.tma_load:
+        raw_stage = cutlass.Int32(0)
+        raw_consumed_phase = cutlass.Int32(1)
+        issue_mbar_slot = cutlass.Int32(0)
+        wait_mbar_slot = cutlass.Int32(0)
+        ready_stage = cutlass.Int32(0)
+        tma_phase = cutlass.Int32(0)
+        for chunk in cutlass.range(num_chunks, unroll=1):
+            ws_chunk = chunk_base + chunk
+            ws_row_start = ws_chunk * cutlass.Int32(BT)
+            v_row_start = sequence_start + chunk * cutlass.Int32(BT)
+            raw_consumed_wait(
+                raw_consumed_mbar.subview(raw_stage),
+                raw_consumed_phase,
+            )
+            tma_chain_stage_load_inputs(
+                tma_desc_kd,
+                tma_desc_w,
+                tma_desc_qd,
+                tma_desc_v,
+                tma_desc_diag,
+                tma_desc_qk,
+                kd_smem.subview(raw_stage * TILE_ELEMS),
+                w_smem.subview(raw_stage * TILE_ELEMS),
+                qd_smem.subview(raw_stage * TILE_ELEMS),
+                v_raw_smem.subview(raw_stage * V_TILE_ELEMS),
+                diag_raw_smem.subview(raw_stage * DIAG_REC_ELEMS),
+                qk_smem.subview(raw_stage * QK_REC_ELEMS),
+                bidy,
+                dv_half,
+                ws_row_start,
+                ws_chunk,
+                v_row_start,
+                tma_mbar.subview(issue_mbar_slot),
+                K2_TX_BYTES,
+            )
+            issue_mbar_slot, _ = advance_ring_stage(
+                issue_mbar_slot, 1, K2_TMA_MBAR_STAGE_COUNT
+            )
+            if chunk >= cutlass.Int32(K2_TMA_MBAR_STAGE_COUNT - 1):
+                tma_transfer_wait(tma_mbar.subview(wait_mbar_slot), tma_phase)
+                wait_mbar_slot, wait_wrapped = advance_ring_stage(
+                    wait_mbar_slot, 1, K2_TMA_MBAR_STAGE_COUNT
+                )
+                tma_phase = tma_phase ^ wait_wrapped
+                raw_ready_arrive(raw_ready_mbar.subview(ready_stage))
+                ready_stage, _ = advance_ring_stage(ready_stage, 1, K2_RAW_STAGE_COUNT)
+            raw_stage, raw_wrapped = advance_ring_stage(
+                raw_stage, 1, K2_RAW_STAGE_COUNT
+            )
+            raw_consumed_phase = raw_consumed_phase ^ raw_wrapped
+        tma_full = cutlass.Int32(
+            num_chunks >= cutlass.Int32(K2_TMA_MBAR_STAGE_COUNT - 1)
+        )
+        tma_tail = (
+            tma_full * cutlass.Int32(K2_TMA_MBAR_STAGE_COUNT - 1)
+            + (cutlass.Int32(1) - tma_full) * num_chunks
+        )
+        for _tail in cutlass.range(tma_tail, unroll=1):
+            tma_transfer_wait(tma_mbar.subview(wait_mbar_slot), tma_phase)
+            wait_mbar_slot, wait_wrapped = advance_ring_stage(
+                wait_mbar_slot, 1, K2_TMA_MBAR_STAGE_COUNT
+            )
+            tma_phase = tma_phase ^ wait_wrapped
+            raw_ready_arrive(raw_ready_mbar.subview(ready_stage))
+            ready_stage, _ = advance_ring_stage(ready_stage, 1, K2_RAW_STAGE_COUNT)
+
+    # ====== warp 12: output-group issuer (OUT_ISSUER12) / flag relay ======
+    elif warp_idx == ROLES.super_mma:
+        tmem_raw_addr = tmem_ptr_i32.load()
+        si_phase12 = cutlass.Int32(0)
+        upd_phase12 = cutlass.Int32(0)
+        for chunk in cutlass.range(num_chunks, unroll=1):
+            raw_stage = chunk % K2_RAW_STAGE_COUNT
+            qstate_stage = chunk % K2_QSTATE_STAGE_COUNT
+            kr_stage = chunk % 2
+            acc_stage = chunk % 2
+            if chunk > 0:
+                prev12 = chunk - cutlass.Int32(1)
+                tcgen05_wait_acc_buffer_ready(
+                    qstate_acc_ready_mbar.subview(prev12 % K2_QSTATE_STAGE_COUNT),
+                    (prev12 // K2_QSTATE_STAGE_COUNT) % 2,
+                )
+                raw_consumed_arrive(
+                    raw_consumed_mbar.subview(prev12 % K2_RAW_STAGE_COUNT)
+                )
+            raw_ready_wait(
+                raw_ready_mbar.subview(raw_stage),
+                (chunk // K2_RAW_STAGE_COUNT) % 2,
+            )
+            si_phase12 = state_input_ready_wait(state_input_ready_mbar, si_phase12)
+            prims.tcgen05_fence(prims.Tcgen05Fence.AFTER_THREAD_SYNC)
+            output_ready_wait(
+                output_ready_mbar.subview(qstate_stage),
+                (chunk // K2_QSTATE_STAGE_COUNT + cutlass.Int32(1)) % 2,
+            )
+            tcgen05_issue_state_projection_mma(
+                qd_smem.subview(raw_stage * TILE_ELEMS),
+                tmem_raw_addr,
+                stateq_done_mbar.subview(kr_stage),
+                tcgen05_qstate_acc_tmem_col_offset(qstate_stage),
+                input_dtype,
+                0,
+                DK // TCGEN05_F16_K_ATOM,
+                False,
+                True,
+                DV_HALF,
+            )
+            upd_phase12 = update_ready_wait(update_ready_mbar, upd_phase12)
+            prims.tcgen05_fence(prims.Tcgen05Fence.AFTER_THREAD_SYNC)
+            xpack_col12 = tcgen05_shared_input_tmem_col_offset(acc_stage)
+            tcgen05_chain_issue_qkv_mma(
+                qk_smem.subview(raw_stage * QK_REC_ELEMS),
+                tmem_raw_addr,
+                xpack_col12,
+                qstate_stage,
+                qstate_acc_ready_mbar.subview(qstate_stage),
+                input_dtype,
+                True,
+            )
+
+    # =============== warp 13: tcgen05 issuer (the chain owner) =============
+    elif warp_idx == ROLES.tcgen05_mma:
+        tmem_raw_addr = tmem_ptr_i32.load()
+        si_l_phase = cutlass.Int32(0)
+        si_phase = cutlass.Int32(0)
+        upd_phase = cutlass.Int32(0)
+        for chunk in cutlass.range(num_chunks, unroll=1):
+            raw_stage = chunk % K2_RAW_STAGE_COUNT
+            raw_phase = (chunk // K2_RAW_STAGE_COUNT) % 2
+            acc_stage = chunk % 2
+            qstate_stage = chunk % K2_QSTATE_STAGE_COUNT
+            kr_stage = chunk % 2
+            kd_stage_smem = kd_smem.subview(raw_stage * TILE_ELEMS)
+            w_stage_smem = w_smem.subview(raw_stage * TILE_ELEMS)
+
+            raw_ready_wait(raw_ready_mbar.subview(raw_stage), raw_phase)
+
+            si_l_phase = state_input_ready_wait(state_input_ready_l_mbar, si_l_phase)
+            prims.tcgen05_fence(prims.Tcgen05Fence.AFTER_THREAD_SYNC)
+            tcgen05_issue_state_k_mma(
+                kd_stage_smem,
+                tmem_raw_addr,
+                shared_acc_ready_mbar.subview(acc_stage),
+                acc_stage,
+                input_dtype,
+                0,
+                (DK // TCGEN05_F16_K_ATOM) // 2,
+                False,
+                False,
+                DV_HALF,
+            )
+            si_phase = state_input_ready_wait(state_input_ready_mbar, si_phase)
+            prims.tcgen05_fence(prims.Tcgen05Fence.AFTER_THREAD_SYNC)
+            tcgen05_issue_state_k_mma(
+                kd_stage_smem,
+                tmem_raw_addr,
+                shared_acc_ready_mbar.subview(acc_stage),
+                acc_stage,
+                input_dtype,
+                (DK // TCGEN05_F16_K_ATOM) // 2,
+                DK // TCGEN05_F16_K_ATOM,
+                True,
+                True,
+                DV_HALF,
+            )
+
+            xpack_col = tcgen05_shared_input_tmem_col_offset(acc_stage)
+            upd_phase = update_ready_wait(update_ready_mbar, upd_phase)
+            prims.tcgen05_fence(prims.Tcgen05Fence.AFTER_THREAD_SYNC)
+            tcgen05_chain_issue_delta_half_mma(
+                w_stage_smem,
+                tmem_raw_addr,
+                xpack_col,
+                input_dtype,
+                0,
+            )
+            tcgen05_commit(k_restore_consumed_l_mbar.subview(kr_stage))
+            tcgen05_chain_issue_delta_half_mma(
+                w_stage_smem,
+                tmem_raw_addr,
+                xpack_col,
+                input_dtype,
+                1,
+            )
+            tcgen05_commit(k_restore_consumed_mbar.subview(kr_stage))
+
+        final_state_stored_wait(final_state_stored_mbar, cutlass.Int32(0))
+        tmem_ptr = cutlass.inttoptr(tmem_raw_addr, 6, cutlass.Float32)
+        prims.tcgen05_dealloc(tmem_ptr, TMEM_ALLOC_COLS, group="cta_1")
+
+    # ================= CG1 (warps 8-11): TMEM epilogues ====================
+    elif is_compute_group1_warp(warp_idx):
+        prims.setmaxregister(KDA_CG1_REGS, prims.SetMaxRegisterAction.INCREASE)
+        tmem_raw_addr = tmem_ptr_i32.load()
+        tcgen05_store_initial_state_tmem(
+            tmem_raw_addr,
+            state,
+            bidx,
+            bidy,
+            dv_half,
+            warp_idx,
+            lane,
+        )
+        if num_chunks > 0:
+            diag_raw_stage = diag_raw_smem.subview(0)
+            state_left = tcgen05_stage_state_input_dv2_half_tmem(
+                tmem_raw_addr,
+                warp_idx,
+                input_dtype,
+                0,
+            )
+            raw_ready_wait(raw_ready_mbar.subview(0), 0)
+            tcgen05_rescale_state_dv2_half_regs(
+                tmem_raw_addr,
+                diag_raw_stage,
+                warp_idx,
+                state_left,
+                state_input_ready_l_mbar,
+                0,
+            )
+            state_right = tcgen05_stage_state_input_dv2_half_tmem(
+                tmem_raw_addr,
+                warp_idx,
+                input_dtype,
+                1,
+            )
+            tcgen05_rescale_state_dv2_half_regs(
+                tmem_raw_addr,
+                diag_raw_stage,
+                warp_idx,
+                state_right,
+                state_input_ready_mbar,
+                1,
+            )
+            tcgen05_wait_acc_buffer_ready(shared_acc_ready_mbar.subview(0), 0)
+            vmx_lane = cute.arch.lane_idx()
+            tcgen05_chain_stage_vmx_input_tmem(
+                tmem_raw_addr,
+                v_raw_smem.subview(0),
+                warp_idx,
+                vmx_lane,
+                0,
+                0,
+                input_dtype,
+            )
+            update_ready_arrive(update_ready_mbar)
+        for chunk in cutlass.range(1, num_chunks, 1, unroll=1):
+            prev = chunk - cutlass.Int32(1)
+            raw_stage = chunk % K2_RAW_STAGE_COUNT
+            diag_raw_stage = diag_raw_smem.subview(raw_stage * DIAG_REC_ELEMS)
+            acc_stage = chunk % 2
+            prev_kr_phase = (prev // 2) % 2
+            tcgen05_wait_acc_buffer_ready(
+                stateq_done_mbar.subview(prev % 2), prev_kr_phase
+            )
+            tcgen05_wait_acc_buffer_ready(
+                k_restore_consumed_mbar.subview(prev % 2), prev_kr_phase
+            )
+            state_right = tcgen05_stage_state_input_dv2_half_tmem(
+                tmem_raw_addr,
+                warp_idx,
+                input_dtype,
+                1,
+            )
+            raw_consumed_arrive(raw_consumed_mbar.subview(prev % K2_RAW_STAGE_COUNT))
+            raw_ready_wait(
+                raw_ready_mbar.subview(raw_stage),
+                (chunk // K2_RAW_STAGE_COUNT) % 2,
+            )
+            tcgen05_rescale_state_dv2_half_regs(
+                tmem_raw_addr,
+                diag_raw_stage,
+                warp_idx,
+                state_right,
+                state_input_ready_mbar,
+                1,
+            )
+            tcgen05_wait_acc_buffer_ready(
+                shared_acc_ready_mbar.subview(acc_stage), (chunk // 2) % 2
+            )
+            vmx_lane = cute.arch.lane_idx()
+            tcgen05_chain_stage_vmx_input_tmem(
+                tmem_raw_addr,
+                v_raw_smem.subview(raw_stage * V_TILE_ELEMS),
+                warp_idx,
+                vmx_lane,
+                acc_stage,
+                acc_stage,
+                input_dtype,
+            )
+            update_ready_arrive(update_ready_mbar)
+        if num_chunks > 0:
+            last = num_chunks - cutlass.Int32(1)
+            last_kr_phase = (last // 2) % 2
+            tcgen05_wait_acc_buffer_ready(
+                k_restore_consumed_l_mbar.subview(last % 2), last_kr_phase
+            )
+            tcgen05_wait_acc_buffer_ready(
+                k_restore_consumed_mbar.subview(last % 2), last_kr_phase
+            )
+        final_lane = cute.arch.lane_idx()
+        tcgen05_store_final_state_tmem(
+            tmem_raw_addr,
+            KDA_TMEM_STATE_COL_OFFSET,
+            state,
+            bidx,
+            bidy,
+            dv_half,
+            warp_idx,
+            final_lane,
+        )
+        final_state_stored_arrive(final_state_stored_mbar)
+    elif is_compute_group0_warp(warp_idx):
+        if warp_idx < 4:
+            prims.setmaxregister(KDA_CG1_REGS, prims.SetMaxRegisterAction.INCREASE)
+            tmem_raw_addr = tmem_ptr_i32.load()
+            for chunk in cutlass.range(num_chunks, unroll=1):
+                qstate_stage = chunk % K2_QSTATE_STAGE_COUNT
+                qstate_phase = (chunk // K2_QSTATE_STAGE_COUNT) % 2
+                output_stage = chunk % K2_OUTPUT_SMEM_STAGE_COUNT
+                tcgen05_wait_acc_buffer_ready(
+                    qstate_acc_ready_mbar.subview(qstate_stage), qstate_phase
+                )
+                output_regs = tcgen05_chain_load_qstate_output_regs(
+                    tmem_raw_addr,
+                    warp_idx,
+                    qstate_stage,
+                    SCALE,
+                    out.element_type,
+                )
+                # Release the two-stage TMEM accumulator as soon as its values
+                # are in registers.  Output-SMEM reuse is independently
+                # protected by the seven-deep async TMA store group.
+                output_ready_arrive(output_ready_mbar.subview(qstate_stage))
+                if warp_idx == 0:
+                    prims.cp_async_bulk_wait_group(6, read=True)
+                output_drain_sync()
+                output_stage_base = output_stage * K2_O_SMEM_STAGE_SIZE
+                tcgen05_chain_store_output_smem(
+                    o_smem,
+                    warp_idx,
+                    lane,
+                    output_stage_base,
+                    output_regs,
+                )
+                output_drain_sync()
+                output_chunk_start = chunk * BT
+                if seqlen >= output_chunk_start + BT:
+                    if warp_idx == 0:
+                        epilogue_chain_stage_store(
+                            tma_desc_o,
+                            o_smem,
+                            sequence_start,
+                            bidy,
+                            dv_half,
+                            output_chunk_start,
+                            output_stage_base,
+                        )
+                else:
+                    if warp_idx == 0:
+                        epilogue_chain_tail_store(
+                            out,
+                            o_smem,
+                            sequence_start,
+                            bidy,
+                            dv_half,
+                            output_chunk_start,
+                            seqlen,
+                            output_stage_base,
+                            lane,
+                        )
+            if warp_idx == 0:
+                prims.cp_async_bulk_wait_group(0, read=True)
+            output_drain_sync()
+            final_state_stored_arrive(final_state_stored_mbar)
+        else:
+            # Chunk 0 is initialized by CG1. Afterwards, warps 4-7 own the
+            # fused left-half state pack and FP32 decay while CG1 owns right.
+            prims.setmaxregister(KDA_CG1_REGS, prims.SetMaxRegisterAction.INCREASE)
+            tmem_raw_addr = tmem_ptr_i32.load()
+            if num_chunks > 0:
+                state_input_ready_wait(
+                    state_input_ready_l_mbar,
+                    cutlass.Int32(0),
+                )
+                prims.tcgen05_fence(prims.Tcgen05Fence.AFTER_THREAD_SYNC)
+                update_ready_arrive(update_ready_mbar)
+            for chunk in cutlass.range(1, num_chunks, 1, unroll=1):
+                prev = chunk - cutlass.Int32(1)
+                raw_stage = chunk % K2_RAW_STAGE_COUNT
+                prev_kr_phase = (prev // 2) % 2
+                tcgen05_wait_acc_buffer_ready(
+                    stateq_done_mbar.subview(prev % 2),
+                    prev_kr_phase,
+                )
+                tcgen05_wait_acc_buffer_ready(
+                    k_restore_consumed_l_mbar.subview(prev % 2),
+                    prev_kr_phase,
+                )
+                state_left = tcgen05_stage_state_input_dv2_half_tmem(
+                    tmem_raw_addr,
+                    warp_idx,
+                    input_dtype,
+                    0,
+                )
+                raw_ready_wait(
+                    raw_ready_mbar.subview(raw_stage),
+                    (chunk // K2_RAW_STAGE_COUNT) % 2,
+                )
+                diag_raw_stage = diag_raw_smem.subview(raw_stage * DIAG_REC_ELEMS)
+                tcgen05_rescale_state_dv2_half_regs(
+                    tmem_raw_addr,
+                    diag_raw_stage,
+                    warp_idx,
+                    state_left,
+                    state_input_ready_l_mbar,
+                    0,
+                )
+                update_ready_arrive(update_ready_mbar)
+
+
+@cute.jit
+def host_chain_dv2(
+    v: cute.Tensor,
+    cu_seqlens: cute.Tensor,
+    cu_chunks: cute.Tensor,
+    ws_kd: cute.Tensor,
+    ws_qd: cute.Tensor,
+    ws_w: cute.Tensor,
+    ws_qk: cute.Tensor,
+    ws_diag: cute.Tensor,
+    state: cute.Tensor,
+    out: cute.Tensor,
+    stream,
+    head_base: cutlass.Int32,
+    launch_heads: cutlass.Int32,
+    SCALE: cutlass.Float32,
+    THREADS: cutlass.Constexpr,
+) -> None:
+    """DV2 host: identical tensor maps to the base chain host, doubled grid-y."""
+
+    cu_seqlens_shape = cast("tuple[int | cutlass.Integer, ...]", cu_seqlens.shape)
+    v_shape = cast("tuple[int | cutlass.Integer, ...]", v.shape)
+    ws_kd_shape = cast("tuple[int | cutlass.Integer, ...]", ws_kd.shape)
+    ws_qk_shape = cast("tuple[int | cutlass.Integer, ...]", ws_qk.shape)
+    num_sequences = cu_seqlens_shape[0] - 1
+    seqlen = v_shape[1]
+    heads = v_shape[2]
+    ws_rows = ws_kd_shape[2]
+    num_chunks_total = ws_qk_shape[2]
+    # Keep singleton TensorMap modes canonical for the same reason as K1.
+    tile_head_stride = DK
+    diag_head_stride = DIAG_REC_ELEMS
+    qk_head_stride = QK_REC_ELEMS
+    if heads != cutlass.Int32(1):
+        tile_head_stride = DK * ws_rows
+        diag_head_stride = DIAG_REC_ELEMS * num_chunks_total
+        qk_head_stride = QK_REC_ELEMS * num_chunks_total
+    factor_layout = cute.make_layout(
+        (RAW_F16_TMA_SWIZZLE_ELEMS, ws_rows, heads, RAW_F16_TMA_SEGMENTS),
+        stride=(1, DK, tile_head_stride, RAW_F16_TMA_SWIZZLE_ELEMS),
+    )
+    v_layout = cute.make_layout(
+        (DV, seqlen, heads, 1),
+        stride=(1, DV * heads, DV, DV * seqlen * heads),
+    )
+    diag_layout = cute.make_layout(
+        (DIAG_REC_ELEMS, num_chunks_total, heads, 1),
+        stride=(
+            1,
+            DIAG_REC_ELEMS,
+            diag_head_stride,
+            DIAG_REC_ELEMS,
+        ),
+    )
+    qk_layout = cute.make_layout(
+        (QK_REC_ELEMS, num_chunks_total, heads, 1),
+        stride=(
+            1,
+            QK_REC_ELEMS,
+            qk_head_stride,
+            QK_REC_ELEMS,
+        ),
+    )
+    factor_box = (
+        RAW_F16_TMA_SWIZZLE_ELEMS,
+        BT,
+        1,
+        RAW_F16_TMA_SEGMENTS,
+    )
+    value_box = (RAW_F16_TMA_SWIZZLE_ELEMS, BT, 1, 1)
+    tma_desc_kd = cuda.create_tensor_map_tiled_from_view(
+        cute.make_tensor(ws_kd.iterator, factor_layout),
+        box_dims=factor_box,
+        stride_order=(0, 1, 2, 3),
+        swizzle=cuda.TensorMapSwizzle.s128b,
+    )
+    tma_desc_w = cuda.create_tensor_map_tiled_from_view(
+        cute.make_tensor(ws_w.iterator, factor_layout),
+        box_dims=factor_box,
+        stride_order=(0, 1, 2, 3),
+        swizzle=cuda.TensorMapSwizzle.s128b,
+    )
+    tma_desc_qd = cuda.create_tensor_map_tiled_from_view(
+        cute.make_tensor(ws_qd.iterator, factor_layout),
+        box_dims=factor_box,
+        stride_order=(0, 1, 2, 3),
+        swizzle=cuda.TensorMapSwizzle.s128b,
+    )
+    tma_desc_v = cuda.create_tensor_map_tiled_from_view(
+        cute.make_tensor(v.iterator, v_layout),
+        box_dims=value_box,
+        stride_order=(0, 1, 2, 3),
+        swizzle=cuda.TensorMapSwizzle.s128b,
+    )
+    tma_desc_diag = cuda.create_tensor_map_tiled_from_view(
+        cute.make_tensor(ws_diag.iterator, diag_layout),
+        box_dims=(DIAG_REC_ELEMS, 1, 1, 1),
+        stride_order=(0, 1, 2, 3),
+        swizzle=cuda.TensorMapSwizzle.none,
+    )
+    tma_desc_qk = cuda.create_tensor_map_tiled_from_view(
+        cute.make_tensor(ws_qk.iterator, qk_layout),
+        box_dims=(QK_REC_ELEMS, 1, 1, 1),
+        stride_order=(0, 1, 2, 3),
+        swizzle=cuda.TensorMapSwizzle.none,
+    )
+    tma_desc_o = cuda.create_tensor_map_tiled_from_view(
+        cute.make_tensor(out.iterator, v_layout),
+        box_dims=(O_TMA_SWIZZLE_ELEMS, BT, 1, 1),
+        stride_order=(0, 1, 2, 3),
+        swizzle=cuda.TensorMapSwizzle.s128b,
+    )
+    kernel_chain_dv2(
+        tma_desc_kd,
+        tma_desc_w,
+        tma_desc_qd,
+        tma_desc_v,
+        tma_desc_diag,
+        tma_desc_qk,
+        tma_desc_o,
+        v,
+        cu_seqlens,
+        cu_chunks,
+        state,
+        out,
+        head_base,
+        SCALE,
+    ).launch(
+        grid=(num_sequences, launch_heads * 2, 1),
+        block=(THREADS, 1, 1),
+        stream=stream,
+        min_blocks_per_mp=1,
+        preferred_smem_carveout=100,
+    )
+
+
+__all__ = ["host_chain_dv2", "kernel_chain_dv2"]

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
     from ..tile_strategy import DeviceLoopState
     from .attention_plan import AttentionScorePlan
     from .aux_tensor import Tcgen05AuxTensorDescriptor
+    from .chunk_prepare import CuteChunkPreparePlan
+    from .chunk_recurrence import CuteChunkRecurrencePlan
     from .cute_epilogue import Tcgen05GroupedTailEpilogueMatch
     from .cute_mma import _Tcgen05AuxPipelinePlan
     from .cute_mma import _Tcgen05SchedPipelinePlan
@@ -600,6 +602,13 @@ class CuteDeviceFunctionState:
         # BF16 rank-1 state recurrence. The plan is absent by default and is
         # additionally gated by the user-facing fast_math setting.
         self.single_token_rank1_plan: CuteSingleTokenRank1Plan | None = None
+        # Whole-root BT16 five-factor prepare schedule.  This is installed only
+        # after the complete semantic graph and packed workspace ABI match.
+        self.chunk_prepare_plan: CuteChunkPreparePlan | None = None
+        # Whole-root BT16 KDA recurrence/output schedule. Like the
+        # prepare plan, this exists only after the complete semantic graph and
+        # packed workspace ABI have matched.
+        self.chunk_recurrence_plan: CuteChunkRecurrencePlan | None = None
         # Set by the backend's flash-attention detector when the fused
         # tcgen05 QK->softmax->PV path is active (HELION_CUTE_FLASH). Holds the
         # tile_n device-loop block ids. The dedicated flash codegen emits the

--- a/helion/_compiler/cute/kda_device_primitives.py
+++ b/helion/_compiler/cute/kda_device_primitives.py
@@ -1,0 +1,317 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# The CuTe DSL intentionally leaves its compile-time value types implicit.
+# ruff: noqa: ANN001, ANN202
+
+"""Shared low-level primitives for exact KDA CuTe schedules."""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import cast
+
+import cutlass
+from cutlass._mlir.dialects import llvm
+import cutlass.cute as cute
+from cutlass.cutlass_dsl import dsl_user_op
+
+make_rmem_tensor = cute.make_rmem_tensor
+_LLVM_STRUCT_TYPE = cast("Any", llvm).StructType
+
+
+def _ldmatrix(count: str, trans: str, smem_ptr, num: int, *, loc=None, ip=None):
+    from cutlass._mlir.extras import types as _T
+
+    outs = ", ".join(f"${i}" for i in range(num))
+    struct = llvm.inline_asm(
+        _LLVM_STRUCT_TYPE.get_literal([_T.IntegerType.get_signless(32)] * num),
+        [smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip)],
+        f"ldmatrix.sync.aligned.m8n8{count}{trans}.shared.b16 {{{outs}}}, [${num}];",
+        ",".join(["=r"] * num) + ",r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        cutlass.Int32(
+            llvm.extractvalue(
+                _T.IntegerType.get_signless(32), struct, [i], loc=loc, ip=ip
+            )
+        )
+        for i in range(num)
+    )
+
+
+@dsl_user_op
+def ldmatrix_x2(smem_ptr, *, loc=None, ip=None):
+    """Load two 8x8 b16 matrices into registers."""
+    return _ldmatrix(".x2", "", smem_ptr, 2, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def ldmatrix_x2_trans(smem_ptr, *, loc=None, ip=None):
+    """Load and transpose two 8x8 b16 matrices into registers."""
+    return _ldmatrix(".x2", ".trans", smem_ptr, 2, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def ldmatrix_x4_trans(smem_ptr, *, loc=None, ip=None):
+    """Load and transpose four 8x8 b16 matrices into registers."""
+    return _ldmatrix(".x4", ".trans", smem_ptr, 4, loc=loc, ip=ip)
+
+
+def _stmatrix(count: str, trans: str, smem_ptr, regs, *, loc=None, ip=None):
+    ins = ", ".join(f"${i + 1}" for i in range(len(regs)))
+    llvm.inline_asm(
+        None,
+        [
+            smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            *[cutlass.Int32(r).ir_value(loc=loc, ip=ip) for r in regs],
+        ],
+        f"stmatrix.sync.aligned.m8n8{count}{trans}.shared.b16 [$0], {{{ins}}};",
+        ",".join(["r"] * (len(regs) + 1)),
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def stmatrix_x2(smem_ptr, r0, r1, *, loc=None, ip=None):
+    """Store two 8x8 b16 register matrices to shared memory."""
+    _stmatrix(".x2", "", smem_ptr, (r0, r1), loc=loc, ip=ip)
+
+
+@dsl_user_op
+def stmatrix_x2_trans(smem_ptr, r0, r1, *, loc=None, ip=None):
+    """Transpose and store two 8x8 b16 register matrices."""
+    _stmatrix(".x2", ".trans", smem_ptr, (r0, r1), loc=loc, ip=ip)
+
+
+@dsl_user_op
+def movmatrix_b16(value, *, loc=None, ip=None):
+    """Transpose one 8x8 b16 register matrix."""
+    from cutlass._mlir.extras import types as _T
+
+    return cutlass.Int32(
+        llvm.inline_asm(
+            _T.IntegerType.get_signless(32),
+            [cutlass.Int32(value).ir_value(loc=loc, ip=ip)],
+            "movmatrix.sync.aligned.m8n8.trans.b16 $0, $1;",
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+def _mma_m16n8k16(
+    kind: str, a0, a1, a2, a3, b0, b1, c0, c1, c2, c3, *, loc=None, ip=None
+):
+    from cutlass._mlir.extras import types as _T
+
+    struct = llvm.inline_asm(
+        _LLVM_STRUCT_TYPE.get_literal([_T.F32Type.get()] * 4),
+        [
+            cutlass.Int32(a0).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(a1).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(a2).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(a3).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(b0).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(b1).ir_value(loc=loc, ip=ip),
+            cutlass.Float32(c0).ir_value(loc=loc, ip=ip),
+            cutlass.Float32(c1).ir_value(loc=loc, ip=ip),
+            cutlass.Float32(c2).ir_value(loc=loc, ip=ip),
+            cutlass.Float32(c3).ir_value(loc=loc, ip=ip),
+        ],
+        f"mma.sync.aligned.m16n8k16.row.col.f32.{kind}.{kind}.f32 "
+        "{$0, $1, $2, $3}, {$4, $5, $6, $7}, {$8, $9}, {$10, $11, $12, $13};",
+        "=f,=f,=f,=f,r,r,r,r,r,r,f,f,f,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        cutlass.Float32(
+            llvm.extractvalue(_T.F32Type.get(), struct, [i], loc=loc, ip=ip)
+        )
+        for i in range(4)
+    )
+
+
+@dsl_user_op
+def mma_m16n8k16_bf16(a0, a1, a2, a3, b0, b1, c0, c1, c2, c3, *, loc=None, ip=None):
+    """Accumulate one m16n8k16 BF16 MMA into four FP32 registers."""
+    return _mma_m16n8k16("bf16", a0, a1, a2, a3, b0, b1, c0, c1, c2, c3, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def pack_bf16x2(lo: cutlass.Float32, hi: cutlass.Float32, *, loc=None, ip=None):
+    """Round two FP32 values to BF16 and pack them into one b32 register."""
+    from cutlass._mlir.extras import types as _T
+
+    return cutlass.Int32(
+        llvm.inline_asm(
+            _T.IntegerType.get_signless(32),
+            [
+                cutlass.Float32(hi).ir_value(loc=loc, ip=ip),
+                cutlass.Float32(lo).ir_value(loc=loc, ip=ip),
+            ],
+            "cvt.rn.bf16x2.f32 $0, $1, $2;",
+            "=r,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def tma_load_3d(smem_ptr, desc_addr, mbar_ptr, c0, c1, c2, *, loc=None, ip=None):
+    """Issue one global-to-shared 3D TMA load."""
+    llvm.inline_asm(
+        None,
+        [
+            smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            cutlass.Int64(desc_addr).ir_value(loc=loc, ip=ip),
+            mbar_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c0).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c1).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c2).ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes"
+        " [$0], [$1, {$3, $4, $5}], [$2];",
+        "r,l,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def tma_store_3d(desc_addr, smem_ptr, c0, c1, c2, *, loc=None, ip=None):
+    """Issue one shared-to-global 3D TMA store."""
+    llvm.inline_asm(
+        None,
+        [
+            cutlass.Int64(desc_addr).ir_value(loc=loc, ip=ip),
+            smem_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c0).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c1).ir_value(loc=loc, ip=ip),
+            cutlass.Int32(c2).ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
+        " [$0, {$2, $3, $4}], [$1];",
+        "l,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def tma_store_commit_group(*, loc=None, ip=None):
+    """Close the current bulk-store group."""
+    llvm.inline_asm(
+        None,
+        [],
+        "cp.async.bulk.commit_group;",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def tma_store_wait_read(keep: int, *, loc=None, ip=None):
+    """Wait until at most ``keep`` stores still hold their source memory."""
+    llvm.inline_asm(
+        None,
+        [],
+        f"cp.async.bulk.wait_group.read {keep};",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@cute.jit
+def warp_arrive(mbar, lane):
+    """Synchronize a warp, then elect one lane to arrive on an mbarrier."""
+    cute.arch.sync_warp()
+    if lane == 0:
+        cute.arch.mbarrier_arrive(mbar)
+
+
+@cute.jit
+def vec_at(ptr, idx, elems):
+    """Build an aligned ``elems``-long tensor at a dynamic pointer offset."""
+    return cute.make_tensor(
+        ptr + cute.assume(cutlass.Int32(idx), divby=elems), cute.make_layout(elems)
+    )
+
+
+@cute.jit
+def vec8_bf16(ptr, idx):
+    """Load eight contiguous BF16 values into a register fragment."""
+    frag = make_rmem_tensor(8, cutlass.BFloat16)
+    cute.autovec_copy(vec_at(ptr, idx, 8), frag)
+    return frag
+
+
+@cute.jit
+def vec4_f32(ptr, idx):
+    """Load four contiguous FP32 values into a register fragment."""
+    frag = make_rmem_tensor(4, cutlass.Float32)
+    cute.autovec_copy(vec_at(ptr, idx, 4), frag)
+    return frag
+
+
+@cute.jit
+def store_vec8_bf16(ptr, idx, frag):
+    """Store an eight-element BF16 fragment as one 16-byte access."""
+    cute.autovec_copy(frag, vec_at(ptr, idx, 8))
+
+
+__all__ = [
+    "_mma_m16n8k16",
+    "ldmatrix_x2",
+    "ldmatrix_x2_trans",
+    "ldmatrix_x4_trans",
+    "mma_m16n8k16_bf16",
+    "movmatrix_b16",
+    "pack_bf16x2",
+    "stmatrix_x2",
+    "stmatrix_x2_trans",
+    "store_vec8_bf16",
+    "tma_load_3d",
+    "tma_store_3d",
+    "tma_store_commit_group",
+    "tma_store_wait_read",
+    "vec4_f32",
+    "vec8_bf16",
+    "vec_at",
+    "warp_arrive",
+]

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -424,6 +424,28 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             "cute", "fixed-token rank-1 recurrence failed late validation"
         )
 
+    def _try_codegen_chunk_prepare_root(self) -> bool:
+        plan = self.device_function.cute_state.chunk_prepare_plan
+        if plan is None:
+            return False
+        from .cute.chunk_prepare import codegen_chunk_prepare
+
+        if codegen_chunk_prepare(self):
+            return True
+        self.device_function.cute_state.chunk_prepare_plan = None
+        raise exc.BackendUnsupported("cute", "chunk prepare failed late validation")
+
+    def _try_codegen_chunk_recurrence_root(self) -> bool:
+        plan = self.device_function.cute_state.chunk_recurrence_plan
+        if plan is None:
+            return False
+        from .cute.chunk_recurrence import codegen_chunk_recurrence
+
+        if codegen_chunk_recurrence(self):
+            return True
+        self.device_function.cute_state.chunk_recurrence_plan = None
+        raise exc.BackendUnsupported("cute", "chunk recurrence failed late validation")
+
     def add_statement(self, stmt: ast.AST | str | None) -> None:
         if stmt is None:
             return
@@ -1185,7 +1207,9 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                         )
                     root = root_graph_info.graph
                     if (
-                        not self._try_codegen_single_token_rank1_root()
+                        not self._try_codegen_chunk_prepare_root()
+                        and not self._try_codegen_chunk_recurrence_root()
+                        and not self._try_codegen_single_token_rank1_root()
                         and not self._try_codegen_split_single_token_rank1_root()
                         and not self._try_codegen_fixed_token_rank1_root()
                         and not self._try_codegen_attention_flash_root()
@@ -1601,7 +1625,14 @@ def generate_ast(
             )
             final_host_statements = rng_statements + codegen.host_statements
             shape_bake_safe_wrapper_only = codegen.cute_wrapper_plans and all(
-                plan.get("kind") in {"helion_small_biased_attention", "helion_flash"}
+                plan.get("kind")
+                in {
+                    "helion_small_biased_attention",
+                    "helion_flash",
+                    "chunk_prepare_tma",
+                    "chunk_recurrence_sm100",
+                    "chunk_recurrence_warp_dv4",
+                }
                 for plan in codegen.cute_wrapper_plans
             )
             if codegen.cute_uses_matmul and not shape_bake_safe_wrapper_only:
@@ -1647,8 +1678,22 @@ def generate_ast(
                         "d_name",
                         "q_name",
                         "k_name",
+                        "g_name",
+                        "beta_name",
+                        "a_log_name",
+                        "dt_name",
+                        "cu_seqlens_name",
+                        "cu_chunks_name",
+                        "chunk_to_seq_name",
+                        "kd_name",
+                        "qd_name",
+                        "ak_name",
+                        "aq_name",
+                        "gt_name",
                         "v_name",
                         "o_name",
+                        "out_name",
+                        "state_name",
                         "lse_name",
                         "bias_name",
                         "alibi_name",
@@ -1658,6 +1703,7 @@ def generate_ast(
                         "k_sizes_name",
                         "direct_pointers_name",
                         "direct_strides_name",
+                        "scale_name",
                     ):
                         if key in resolved:
                             arg_name = str(resolved.pop(key))

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -766,6 +766,26 @@ def shrink_block_sizes_for_numel_constraints(
 DEFAULT_NUM_WARPS = 4
 DEFAULT_NUM_STAGES = 1
 VALID_CROSS_LOOP_SCHEDULES = ("barrier", "static_pipeline")
+CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY = "cute_chunk_recurrence_dv_partitions"
+CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY = "cute_chunk_recurrence_register_cap"
+VALID_CUTE_CHUNK_RECURRENCE_REGISTER_CAPS = (None, 72, 76, 80)
+CUTE_CHUNK_PREPARE_SCHEDULE_KEY = "cute_chunk_prepare_schedule"
+VALID_CUTE_CHUNK_PREPARE_SCHEDULES = (
+    "split_alias_cpc1",
+    "split_alias_cpc2",
+    "split_alias_cpc3",
+    "split_alias_cpc4",
+    "split_alias_cpc5",
+)
+
+
+def _cute_chunk_recurrence_config_is_safe(
+    dv_partitions: object, register_cap: object
+) -> bool:
+    """Reject register caps on the TMEM schedule's dynamic register protocol."""
+
+    return dv_partitions != 2 or register_cap is None
+
 
 # Upper bound (power of two) that a matmul tile dimension's block size may reach
 # even when the dimension itself is smaller. Applied only to dimensions that
@@ -814,6 +834,9 @@ BACKEND_SPECIFIC_KEYS: frozenset[str] = (
     | frozenset(FLASH_CONFIG_KEYS)
     | {
         "cross_loop_schedule",
+        CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY,
+        CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY,
+        CUTE_CHUNK_PREPARE_SCHEDULE_KEY,
         "num_threads",
         "cute_vector_widths",
         "cute_lane_layouts",
@@ -851,6 +874,9 @@ VALID_KEYS: frozenset[str] = frozenset(
         "range_flattens",
         "static_ranges",
         "cross_loop_schedule",
+        CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY,
+        CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY,
+        CUTE_CHUNK_PREPARE_SCHEDULE_KEY,
         "num_warps",
         "num_stages",
         "pid_type",
@@ -1125,6 +1151,17 @@ class ConfigSpec:
         # Populated only after DeviceIR proves that this kernel contains an
         # implicit cross-root dependency supported by the CUDA Triton backend.
         self.cross_loop_schedule: EnumFragment | None = None
+        # Enabled only when the exact five-factor BT16 recurrence carrier is
+        # detected. Choice ordering makes the geometry seed the no-autotune
+        # default while leaving both legal schedules in cold/full search.
+        self.cute_chunk_recurrence_dv_partitions: EnumFragment | None = None
+        # Enabled by the same exact recurrence matcher. The backend turns the
+        # selected value into a ptxas max-register constraint; unrelated CuTe
+        # kernels never see this search dimension.
+        self.cute_chunk_recurrence_register_cap: EnumFragment | None = None
+        # Enabled only when the exact five-factor BT16 chunk-prepare carrier is
+        # detected. Choice order defines the default and ranked seed order.
+        self.cute_chunk_prepare_schedule: EnumFragment | None = None
         self._cute_tcgen05_config = CuteTcgen05Config(self)
         # CuTe flash-attention autotune surface gating.
         # Default False so the flash knobs never appear in the search surface
@@ -1864,6 +1901,22 @@ class ConfigSpec:
             spec.autotuner_min = target
             spec.max_size = target
 
+    def enable_cute_chunk_recurrence_search(self, *, preferred_partitions: int) -> None:
+        """Expose the exact BT16 recurrence schedule as CuTe search knobs."""
+
+        if preferred_partitions not in (2, 4):
+            raise ValueError(
+                "unsupported chunk-recurrence DV partition count: "
+                f"{preferred_partitions}"
+            )
+        alternate = 4 if preferred_partitions == 2 else 2
+        self.cute_chunk_recurrence_dv_partitions = EnumFragment(
+            choices=(preferred_partitions, alternate)
+        )
+        self.cute_chunk_recurrence_register_cap = EnumFragment(
+            choices=VALID_CUTE_CHUNK_RECURRENCE_REGISTER_CAPS
+        )
+
     def enable_cute_attention_generic_fallback(
         self, *, block_size_targets: Mapping[int, int] | None = None
     ) -> None:
@@ -1881,6 +1934,31 @@ class ConfigSpec:
         ) in self._cute_attention_generic_fallback_block_size_targets.items():
             spec = self.block_sizes.block_id_lookup(block_id)
             spec.autotuner_min = max(spec.autotuner_min, target)
+
+    def enable_cute_chunk_prepare_schedule_search(
+        self, *, preferred_schedule: str
+    ) -> None:
+        """Expose the exact BT16 prepare shared-memory schedule knob."""
+
+        if not self.supports_config_key(CUTE_CHUNK_PREPARE_SCHEDULE_KEY):
+            raise InvalidConfig(
+                f"{CUTE_CHUNK_PREPARE_SCHEDULE_KEY} is not supported by backend "
+                f"{self.backend_name!r}"
+            )
+        if preferred_schedule not in VALID_CUTE_CHUNK_PREPARE_SCHEDULES:
+            raise ValueError(
+                f"unsupported chunk-prepare schedule: {preferred_schedule!r}"
+            )
+        self.cute_chunk_prepare_schedule = EnumFragment(
+            choices=(
+                preferred_schedule,
+                *(
+                    schedule
+                    for schedule in VALID_CUTE_CHUNK_PREPARE_SCHEDULES
+                    if schedule != preferred_schedule
+                ),
+            )
+        )
 
     def _pre_normalize_cute_flash_block_sizes(self, config: dict[str, object]) -> None:
         if not self.cute_flash_search_enabled or "block_sizes" not in config:
@@ -2530,6 +2608,45 @@ class ConfigSpec:
                     "with compiler-inferred cross-loop dependencies"
                 )
 
+        if (
+            CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY in config
+            and self.cute_chunk_recurrence_dv_partitions is None
+            and self.supports_config_key(CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY)
+        ):
+            if _fix_invalid:
+                config.pop(CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY)
+            else:
+                raise InvalidConfig(
+                    f"{CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY} is available only "
+                    "for matched BT16 chunk-recurrence kernels"
+                )
+
+        if (
+            CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY in config
+            and self.cute_chunk_recurrence_register_cap is None
+            and self.supports_config_key(CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY)
+        ):
+            if _fix_invalid:
+                config.pop(CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY)
+            else:
+                raise InvalidConfig(
+                    f"{CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY} is available only "
+                    "for matched BT16 chunk-recurrence kernels"
+                )
+
+        if (
+            CUTE_CHUNK_PREPARE_SCHEDULE_KEY in config
+            and self.cute_chunk_prepare_schedule is None
+            and self.supports_config_key(CUTE_CHUNK_PREPARE_SCHEDULE_KEY)
+        ):
+            if _fix_invalid:
+                config.pop(CUTE_CHUNK_PREPARE_SCHEDULE_KEY)
+            else:
+                raise InvalidConfig(
+                    f"{CUTE_CHUNK_PREPARE_SCHEDULE_KEY} is available only for "
+                    "matched BT16 chunk-prepare kernels"
+                )
+
         if unsupported := self.unsupported_config_keys(config):
             # Separate backend-specific keys (e.g. AMD tunables, TileIR tunables)
             # from common keys (e.g. num_warps, num_stages, indexing).
@@ -2888,6 +3005,81 @@ class ConfigSpec:
                         "cross_loop_schedule must be one of "
                         f"{cross_loop_schedule_fragment.choices!r}, got "
                         f"{cross_loop_schedule!r}"
+                    )
+        recurrence_dv_fragment = self.cute_chunk_recurrence_dv_partitions
+        if recurrence_dv_fragment is not None:
+            recurrence_dv_partitions = config.setdefault(
+                CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY,
+                recurrence_dv_fragment.default(),
+            )
+            if (
+                type(recurrence_dv_partitions) is not int
+                or recurrence_dv_partitions not in recurrence_dv_fragment.choices
+            ):
+                if _fix_invalid:
+                    config[CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY] = (
+                        recurrence_dv_fragment.default()
+                    )
+                else:
+                    raise InvalidConfig(
+                        f"{CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY} must be one of "
+                        f"{recurrence_dv_fragment.choices!r}, got "
+                        f"{recurrence_dv_partitions!r}"
+                    )
+        recurrence_register_cap_fragment = self.cute_chunk_recurrence_register_cap
+        if recurrence_register_cap_fragment is not None:
+            recurrence_register_cap = config.setdefault(
+                CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY,
+                recurrence_register_cap_fragment.default(),
+            )
+            if (
+                (
+                    recurrence_register_cap is not None
+                    and type(recurrence_register_cap) is not int
+                )
+                or recurrence_register_cap
+                not in recurrence_register_cap_fragment.choices
+            ):
+                if _fix_invalid:
+                    config[CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY] = (
+                        recurrence_register_cap_fragment.default()
+                    )
+                else:
+                    raise InvalidConfig(
+                        f"{CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY} must be one of "
+                        f"{recurrence_register_cap_fragment.choices!r}, got "
+                        f"{recurrence_register_cap!r}"
+                    )
+            if recurrence_dv_fragment is not None and not (
+                _cute_chunk_recurrence_config_is_safe(
+                    config[CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY],
+                    config[CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY],
+                )
+            ):
+                if _fix_invalid:
+                    config[CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY] = None
+                else:
+                    raise InvalidConfig(
+                        f"{CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY} must be None for "
+                        f"{CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY}=2 because the "
+                        "TMEM schedule dynamically reallocates registers"
+                    )
+        prepare_schedule_fragment = self.cute_chunk_prepare_schedule
+        if prepare_schedule_fragment is not None:
+            prepare_schedule = config.setdefault(
+                CUTE_CHUNK_PREPARE_SCHEDULE_KEY,
+                prepare_schedule_fragment.default(),
+            )
+            if prepare_schedule not in prepare_schedule_fragment.choices:
+                if _fix_invalid:
+                    config[CUTE_CHUNK_PREPARE_SCHEDULE_KEY] = (
+                        prepare_schedule_fragment.default()
+                    )
+                else:
+                    raise InvalidConfig(
+                        f"{CUTE_CHUNK_PREPARE_SCHEDULE_KEY} must be one of "
+                        f"{prepare_schedule_fragment.choices!r}, got "
+                        f"{prepare_schedule!r}"
                     )
         if self.backend_name == "cute":
             self._cute_tcgen05_config.normalize_pre_pid_type(
@@ -3659,6 +3851,18 @@ class ConfigSpec:
             ):
                 fields["epilogue_subtile"] = EnumFragment(
                     choices=self.epilogue_subtile_autotune_choices
+                )
+            if self.cute_chunk_recurrence_dv_partitions is not None:
+                fields[CUTE_CHUNK_RECURRENCE_DV_PARTITIONS_KEY] = (
+                    self.cute_chunk_recurrence_dv_partitions
+                )
+            if self.cute_chunk_recurrence_register_cap is not None:
+                fields[CUTE_CHUNK_RECURRENCE_REGISTER_CAP_KEY] = (
+                    self.cute_chunk_recurrence_register_cap
+                )
+            if self.cute_chunk_prepare_schedule is not None:
+                fields[CUTE_CHUNK_PREPARE_SCHEDULE_KEY] = (
+                    self.cute_chunk_prepare_schedule
                 )
             fields.update(self.user_defined_tunables)
             return fields

--- a/helion/runtime/cute/launcher.py
+++ b/helion/runtime/cute/launcher.py
@@ -446,6 +446,117 @@ def _append_cute_wrapper_plan(
         call_args.extend(kernel_args)
 
     kind = plan["kind"]
+    if kind == "chunk_recurrence_sm100":
+        outputs_scaled = plan.get("outputs_scaled")
+        factor_key_xor = plan.get("factor_key_xor")
+        if (
+            plan_int("chunk_size") != 16
+            or plan_int("key_size") != 128
+            or plan_int("value_size") != 128
+            or plan_int("threads") != 512
+            or plan_int("workspace_layout_version") != 2
+            or outputs_scaled is not False
+            or factor_key_xor != 8
+            or plan_int("device_abi") != 2
+            or plan_int("input_stages") != 8
+            or plan_int("tma_stages") != 6
+            or plan_int("factor_tma_value_splits") != 2
+            or plan_int("output_acc_stages") != 2
+            or plan_int("output_smem_stages") != 7
+            or plan_int("output_store_wait_groups") != 6
+            or plan_int("tmem_cols") != 512
+        ):
+            raise exc.BackendUnsupported(
+                "cute", "invalid SM100 chunk-recurrence schedule ABI"
+            )
+        return
+    if kind == "chunk_recurrence_warp_dv4":
+        outputs_scaled = plan.get("outputs_scaled")
+        factor_key_xor = plan.get("factor_key_xor")
+        if (
+            plan_int("chunk_size") != 16
+            or plan_int("key_size") != 128
+            or plan_int("value_size") != 128
+            or plan_int("threads") != 192
+            or plan_int("smem_bytes") != 97_536
+            or plan_int("workspace_layout_version") != 2
+            or outputs_scaled is not False
+            or factor_key_xor != 8
+            or plan_int("device_abi") != 3
+            or plan_int("input_stages") != 6
+            or plan_int("tma_stages") != 6
+            or plan_int("factor_tma_value_splits") != 1
+            or plan_int("output_acc_stages") != 2
+            or plan_int("output_smem_stages") != 3
+            or plan_int("output_store_wait_groups") != 0
+            or plan_int("tmem_cols") != 0
+            or plan_int("dv_partitions") != 4
+        ):
+            raise exc.BackendUnsupported(
+                "cute", "invalid SM100 warp-DV4 chunk-recurrence schedule ABI"
+            )
+        desc_args = plan.get("desc_args")
+        if (
+            not isinstance(desc_args, (list, tuple))
+            or len(desc_args) != 7
+            or not all(isinstance(name, str) for name in desc_args)
+        ):
+            raise exc.BackendUnsupported(
+                "cute", "invalid SM100 warp-DV4 descriptor ABI"
+            )
+        body.extend(
+            (
+                f"    grid_x = cutlass.Int32({4 * plan_int('sequences')})",
+                f"    grid_y = cutlass.Int32({plan_int('heads')})",
+                "    grid_z = cutlass.Int32(1)",
+            )
+        )
+        call_args.extend(cast("Sequence[str]", desc_args))
+        return
+    if kind == "chunk_prepare_tma":
+        outputs_scaled = plan.get("outputs_scaled")
+        factor_key_xor = plan.get("factor_key_xor")
+        device_abi = plan_int("device_abi")
+        schedule = plan.get("schedule")
+        split_alias_schedules = tuple(
+            f"split_alias_cpc{chunks_per_cta}" for chunks_per_cta in range(1, 6)
+        )
+        expected_smem = 21_968 if schedule in split_alias_schedules else None
+        if (
+            plan_int("chunk_size") != 16
+            or plan_int("key_size") != 128
+            or plan_int("chunks_per_cta") not in (1, 2, 3, 4, 5)
+            or (
+                schedule in split_alias_schedules
+                and schedule != f"split_alias_cpc{plan_int('chunks_per_cta')}"
+            )
+            or expected_smem is None
+            or plan_int("smem_bytes") != expected_smem
+            or plan_int("bf16_mma_count") != 168
+            or plan_int("fp16_mma_count") != 24
+            or type(outputs_scaled) is not bool
+            or device_abi != (3 if outputs_scaled else 4)
+            or factor_key_xor != (0 if outputs_scaled else 8)
+        ):
+            raise exc.BackendUnsupported("cute", "invalid chunk-prepare schedule ABI")
+        desc_args = plan.get("desc_args")
+        if (
+            not isinstance(desc_args, (list, tuple))
+            or len(desc_args) != 4
+            or not all(isinstance(name, str) for name in desc_args)
+        ):
+            raise exc.BackendUnsupported("cute", "invalid chunk-prepare descriptor ABI")
+        chunks_per_cta = plan_int("chunks_per_cta")
+        grid_x = (plan_int("total_chunks") + chunks_per_cta - 1) // chunks_per_cta
+        body.extend(
+            (
+                f"    grid_x = cutlass.Int32({grid_x})",
+                f"    grid_y = cutlass.Int32({plan_int('heads')})",
+                "    grid_z = cutlass.Int32(1)",
+            )
+        )
+        call_args.extend(cast("Sequence[str]", desc_args))
+        return
     if kind == "helion_small_biased_attention":
         batch = plan_int("batch")
         seq = plan_int("seq")
@@ -1180,6 +1291,144 @@ def _cute_cluster_shape(
     return _cute_cluster_shape_from_wrapper_plans(wrapper_plans)
 
 
+def _append_sm100_chunk_recurrence_host_call(
+    body: list[str], plan: dict[str, object]
+) -> None:
+    """Build the tensor views consumed by the SM100 recurrence host schedule."""
+
+    def plan_int(key: str) -> int:
+        value = plan.get(key)
+        if type(value) is not int:
+            raise exc.BackendUnsupported(
+                "cute", f"invalid SM100 chunk-recurrence {key}"
+            )
+        return value
+
+    def tensor_arg(key: str) -> str:
+        return f"arg{plan_int(key)}"
+
+    output_scale = f"arg{plan_int('scale_idx')}"
+
+    heads = plan_int("heads")
+    sequences = plan_int("sequences")
+    total_tokens = plan_int("total_tokens")
+    total_chunks = plan_int("total_chunks")
+    rows = total_chunks * 16
+    kd = tensor_arg("kd_idx")
+    qd = tensor_arg("qd_idx")
+    ak = tensor_arg("ak_idx")
+    aq = tensor_arg("aq_idx")
+    gt = tensor_arg("gt_idx")
+    values = tensor_arg("v_idx")
+    output = tensor_arg("out_idx")
+    state = tensor_arg("state_idx")
+    cu_seqlens = tensor_arg("cu_seqlens_idx")
+    cu_chunks = tensor_arg("cu_chunks_idx")
+
+    factor_shape = (1, heads, rows, 128)
+    factor_stride = (heads * rows * 128, rows * 128, 128, 1)
+    aq_shape = (1, heads, total_chunks, 256)
+    aq_stride = (heads * total_chunks * 256, total_chunks * 256, 256, 1)
+    gt_shape = (1, heads, total_chunks, 128)
+    gt_stride = (heads * total_chunks * 128, total_chunks * 128, 128, 1)
+    activation_shape = (1, total_tokens, heads, 128)
+    activation_stride = (total_tokens * heads * 128, heads * 128, 128, 1)
+
+    def append_view(
+        name: str, source: str, shape: tuple[int, ...], stride: tuple[int, ...]
+    ) -> None:
+        body.append(
+            f"    {name} = cute.make_tensor({source}.iterator, "
+            f"layout=cute.make_layout({shape!r}, stride={stride!r}))"
+        )
+
+    append_view("_chunk_kd", kd, factor_shape, factor_stride)
+    append_view("_chunk_qd", qd, factor_shape, factor_stride)
+    append_view("_chunk_ak", ak, factor_shape, factor_stride)
+    append_view("_chunk_aq", aq, aq_shape, aq_stride)
+    append_view("_chunk_gt", gt, gt_shape, gt_stride)
+    append_view("_chunk_v", values, activation_shape, activation_stride)
+    append_view("_chunk_out", output, activation_shape, activation_stride)
+    host_call = (
+        "    _helion_sm100_chain_host("
+        "_chunk_v, "
+        f"{cu_seqlens}, {cu_chunks}, "
+        "_chunk_kd, _chunk_qd, _chunk_ak, _chunk_aq, _chunk_gt, "
+        f"{state}, _chunk_out, stream, "
+        f"cutlass.Int32(0), cutlass.Int32({heads}), "
+        f"cutlass.Float32({output_scale}), "
+        "512)"
+    )
+    body.extend(("    _helion_cute_kernel_tag = 'chunk_recurrence_sm100'", host_call))
+
+    if sequences <= 0:
+        raise exc.BackendUnsupported("cute", "empty SM100 recurrence launch")
+
+
+def _append_sm100_warp_dv4_host_call(body: list[str], plan: dict[str, object]) -> None:
+    """Launch the selected warp-HMMA DV4 schedule through its pinned host entry."""
+
+    def plan_int(key: str) -> int:
+        value = plan.get(key)
+        if type(value) is not int:
+            raise exc.BackendUnsupported(
+                "cute", f"invalid SM100 warp-DV4 recurrence {key}"
+            )
+        return value
+
+    def tensor_arg(key: str) -> str:
+        return f"arg{plan_int(key)}"
+
+    desc_args = plan.get("desc_args")
+    if not isinstance(desc_args, (tuple, list)) or not all(
+        isinstance(name, str) for name in desc_args
+    ):
+        raise exc.BackendUnsupported("cute", "invalid warp-DV4 descriptor arguments")
+
+    heads = plan_int("heads")
+    sequences = plan_int("sequences")
+    total_tokens = plan_int("total_tokens")
+    output = tensor_arg("out_idx")
+    cu_seqlens = tensor_arg("cu_seqlens_idx")
+    cu_chunks = tensor_arg("cu_chunks_idx")
+    output_scale = f"arg{plan_int('scale_idx')}"
+    body.extend(
+        (
+            (
+                "    _chunk_output = cute.make_tensor("
+                f"{output}.iterator, cute.make_layout("
+                f"({total_tokens * heads * 128},), stride=(1,)))"
+            ),
+            (
+                "    _chunk_cu_seqlens = cute.make_tensor("
+                f"{cu_seqlens}.iterator, cute.make_layout("
+                f"({sequences + 1},), stride=(1,)))"
+            ),
+            (
+                "    _chunk_cu_chunks = cute.make_tensor("
+                f"{cu_chunks}.iterator, cute.make_layout("
+                f"({sequences + 1},), stride=(1,)))"
+            ),
+            "    _helion_cute_kernel_tag = 'chunk_recurrence_warp_dv4'",
+            "    _helion_sm100_warp_dv4_host("
+            + ", ".join(
+                (
+                    "_chunk_output",
+                    "_chunk_cu_seqlens",
+                    "_chunk_cu_chunks",
+                    *cast("Sequence[str]", desc_args),
+                    f"cutlass.Int32({heads})",
+                    f"cutlass.Float32({output_scale})",
+                    "grid_x",
+                    "grid_y",
+                    "stream",
+                )
+            )
+            + ")",
+        )
+    )
+
+
 def _create_cute_wrapper(
     cute_kernel: object,
     schema_key: tuple[tuple[object, ...], ...],
@@ -1347,6 +1596,24 @@ def _create_cute_wrapper(
     ]
     for plan in wrapper_plans:
         _append_cute_wrapper_plan(body, call_args, plan, num_sm=num_sm)
+    sm100_recurrence_plans = [
+        plan for plan in wrapper_plans if plan.get("kind") == "chunk_recurrence_sm100"
+    ]
+    warp_dv4_recurrence_plans = [
+        plan
+        for plan in wrapper_plans
+        if plan.get("kind") == "chunk_recurrence_warp_dv4"
+    ]
+    if len(sm100_recurrence_plans) > 1:
+        raise exc.BackendUnsupported("cute", "multiple SM100 recurrence plans")
+    if len(warp_dv4_recurrence_plans) > 1:
+        raise exc.BackendUnsupported("cute", "multiple SM100 warp-DV4 plans")
+    if (sm100_recurrence_plans or warp_dv4_recurrence_plans) and len(
+        wrapper_plans
+    ) != 1:
+        raise exc.BackendUnsupported(
+            "cute", "SM100 recurrence must own the complete device root"
+        )
     launch_suffix = f", block={block!r}"
     cluster_shape = _cute_cluster_shape(cute_kernel, wrapper_plans)
     if cluster_shape is not None:
@@ -1391,14 +1658,19 @@ def _create_cute_wrapper(
         launch_suffix += f", min_blocks_per_mp={explicit_min_blocks}"
     elif any(plan.get("topology") == "fa4" for plan in wrapper_plans):
         launch_suffix += ", min_blocks_per_mp=1"
-    body.extend(
-        (
-            f"    _helion_cute_kernel_tag = {kernel_tag!r}",
-            "    _kernel("
-            + ", ".join(call_args)
-            + f").launch(grid=(grid_x, grid_y, grid_z){launch_suffix}, stream=stream)",
+    if sm100_recurrence_plans:
+        _append_sm100_chunk_recurrence_host_call(body, sm100_recurrence_plans[0])
+    elif warp_dv4_recurrence_plans:
+        _append_sm100_warp_dv4_host_call(body, warp_dv4_recurrence_plans[0])
+    else:
+        body.extend(
+            (
+                f"    _helion_cute_kernel_tag = {kernel_tag!r}",
+                "    _kernel("
+                + ", ".join(call_args)
+                + f").launch(grid=(grid_x, grid_y, grid_z){launch_suffix}, stream=stream)",
+            )
         )
-    )
 
     source = "\n".join(
         [
@@ -1414,6 +1686,14 @@ def _create_cute_wrapper(
         "CUstream": cuda_driver.CUstream,
         "_kernel": cute_kernel,
     }
+    if sm100_recurrence_plans:
+        from ..._compiler.cute.chunk_recurrence_sm100 import host_chain_dv2
+
+        namespace["_helion_sm100_chain_host"] = host_chain_dv2
+    elif warp_dv4_recurrence_plans:
+        from ..._compiler.cute.chunk_recurrence_dv4_sm100 import _recurrence_entry
+
+        namespace["_helion_sm100_warp_dv4_host"] = _recurrence_entry
     filename = f"<helion_cute_launcher:{kernel_tag}:{schema_key!r}:{block!r}>"
     linecache.cache[filename] = (
         len(source),
@@ -4075,7 +4355,12 @@ def _build_cached_cute_schema_and_args(
 
 def _cute_wrapper_plan_bakes_tensor_shapes(plan: dict[str, object]) -> bool:
     kind = str(plan.get("kind", ""))
-    if kind == "helion_small_biased_attention":
+    if kind in {
+        "helion_small_biased_attention",
+        "chunk_prepare_tma",
+        "chunk_recurrence_sm100",
+        "chunk_recurrence_warp_dv4",
+    }:
         return True
     if not kind.startswith("tcgen05"):
         return False
@@ -4092,6 +4377,530 @@ def _cute_wrapper_plan_bakes_tensor_shapes(plan: dict[str, object]) -> bool:
         if type(extent) is not int or type(block) is not int or extent % block:
             return False
     return True
+
+
+@dataclass(frozen=True)
+class _ChunkPrepareTensorMapSpec:
+    dtype: torch.dtype
+    base_ptr: int
+    global_dim: tuple[int, ...]
+    global_stride_bytes: tuple[int, ...]
+    box_dim: tuple[int, ...]
+
+
+def _chunk_prepare_expected_tensor_map_specs(
+    *,
+    total_tokens: int,
+    total_chunks: int,
+    heads: int,
+    q_ptr: int,
+    k_ptr: int,
+    gate_ptr: int,
+    factor_ptr: int,
+    gate_dtype: torch.dtype,
+) -> tuple[_ChunkPrepareTensorMapSpec, ...]:
+    """Build descriptor geometry from already-validated ABI metadata."""
+
+    def activation_spec(dtype: torch.dtype, pointer: int) -> _ChunkPrepareTensorMapSpec:
+        element_bytes = dtype.itemsize
+        segment = 32 if dtype is torch.float32 else 64
+        segments = 128 // segment
+        return _ChunkPrepareTensorMapSpec(
+            dtype=dtype,
+            base_ptr=pointer,
+            global_dim=(segment, total_tokens, heads, segments),
+            global_stride_bytes=(
+                heads * 128 * element_bytes,
+                128 * element_bytes,
+                segment * element_bytes,
+            ),
+            box_dim=(segment, 16, 1, segments),
+        )
+
+    return (
+        activation_spec(torch.bfloat16, q_ptr),
+        activation_spec(torch.bfloat16, k_ptr),
+        activation_spec(gate_dtype, gate_ptr),
+        _ChunkPrepareTensorMapSpec(
+            dtype=torch.bfloat16,
+            base_ptr=factor_ptr,
+            global_dim=(128, total_chunks * 16, 3 * heads),
+            global_stride_bytes=(128 * 2, 128 * total_chunks * 16 * 2),
+            box_dim=(64, 16, 1),
+        ),
+    )
+
+
+def _chunk_prepare_plan_tensor(
+    plan: dict[str, object],
+    args: tuple[object, ...],
+    key: str,
+) -> torch.Tensor:
+    index = plan.get(key)
+    if type(index) is not int or not 0 <= index < len(args):
+        raise exc.BackendUnsupported("cute", f"invalid chunk-prepare {key}")
+    tensor = args[index]
+    if not isinstance(tensor, torch.Tensor):
+        raise exc.BackendUnsupported("cute", f"chunk-prepare {key} is not a tensor")
+    return tensor
+
+
+def _chunk_prepare_tensor_map_specs(
+    plan: dict[str, object],
+    args: tuple[object, ...],
+) -> tuple[_ChunkPrepareTensorMapSpec, ...]:
+    """Validate the five-factor ABI and return the four exact TMA maps."""
+
+    def plan_int(key: str) -> int:
+        value = plan.get(key)
+        if type(value) is not int:
+            raise exc.BackendUnsupported("cute", f"invalid chunk-prepare {key}")
+        return value
+
+    schedule = plan.get("schedule")
+    split_alias_schedules = tuple(
+        f"split_alias_cpc{chunks_per_cta}" for chunks_per_cta in range(1, 6)
+    )
+    if (
+        plan_int("device_abi") not in (3, 4)
+        or plan_int("chunk_size") != 16
+        or plan_int("key_size") != 128
+        or plan_int("chunks_per_cta") not in (1, 2, 3, 4, 5)
+        or (
+            schedule in split_alias_schedules
+            and schedule != f"split_alias_cpc{plan_int('chunks_per_cta')}"
+        )
+        or type(plan.get("outputs_scaled")) is not bool
+        or plan_int("device_abi") != (3 if plan["outputs_scaled"] else 4)
+        or plan.get("factor_key_xor") != (0 if plan["outputs_scaled"] else 8)
+        or schedule not in split_alias_schedules
+    ):
+        raise exc.BackendUnsupported("cute", "unsupported chunk-prepare ABI")
+    total_tokens = plan_int("total_tokens")
+    total_chunks = plan_int("total_chunks")
+    heads = plan_int("heads")
+    if total_tokens <= 0 or total_chunks <= 0 or heads <= 0:
+        raise exc.BackendUnsupported("cute", "empty chunk-prepare launch")
+
+    names = (
+        "q_idx",
+        "k_idx",
+        "g_idx",
+        "beta_idx",
+        "a_log_idx",
+        "dt_idx",
+        "cu_seqlens_idx",
+        "cu_chunks_idx",
+        "chunk_to_seq_idx",
+        "kd_idx",
+        "qd_idx",
+        "ak_idx",
+        "aq_idx",
+        "gt_idx",
+    )
+    (
+        q,
+        k,
+        gate,
+        beta,
+        a_log,
+        dt_bias,
+        cu_seqlens,
+        cu_chunks,
+        chunk_to_seq,
+        kd,
+        qd,
+        ak,
+        aq,
+        g_total,
+    ) = tuple(_chunk_prepare_plan_tensor(plan, args, name) for name in names)
+    tensors = (
+        q,
+        k,
+        gate,
+        beta,
+        a_log,
+        dt_bias,
+        cu_seqlens,
+        cu_chunks,
+        chunk_to_seq,
+        kd,
+        qd,
+        ak,
+        aq,
+        g_total,
+    )
+    if any(tensor.device != q.device for tensor in tensors):
+        raise exc.BackendUnsupported("cute", "chunk-prepare tensors span devices")
+    if q.device.type != "cuda" or any(not tensor.is_contiguous() for tensor in tensors):
+        raise exc.BackendUnsupported(
+            "cute", "chunk-prepare tensors must be contiguous CUDA tensors"
+        )
+
+    token_rows = total_tokens * heads
+    rows = total_chunks * 16
+    expected = (
+        (q, torch.bfloat16, (token_rows, 128)),
+        (k, torch.bfloat16, (token_rows, 128)),
+        (
+            gate,
+            torch.float32 if bool(plan.get("gate_is_fp32")) else torch.bfloat16,
+            (token_rows, 128),
+        ),
+        (beta, torch.bfloat16, (token_rows,)),
+        (a_log, torch.float32, (heads,)),
+        (dt_bias, torch.float32, (heads, 128)),
+        (chunk_to_seq, torch.int32, (total_chunks,)),
+        (kd, torch.bfloat16, (heads * rows, 128)),
+        (qd, torch.bfloat16, (heads * rows, 128)),
+        (ak, torch.bfloat16, (heads * rows, 128)),
+        (aq, torch.bfloat16, (heads * total_chunks, 256)),
+        (g_total, torch.float32, (heads * total_chunks, 128)),
+    )
+    for tensor, dtype, shape in expected:
+        if tensor.dtype is not dtype or tuple(tensor.shape) != shape:
+            raise exc.BackendUnsupported(
+                "cute", "chunk-prepare tensor dtype/shape ABI mismatch"
+            )
+    if (
+        cu_seqlens.dtype is not torch.int32
+        or cu_chunks.dtype is not torch.int32
+        or cu_seqlens.ndim != 1
+        or tuple(cu_chunks.shape) != tuple(cu_seqlens.shape)
+    ):
+        raise exc.BackendUnsupported("cute", "chunk-prepare metadata ABI mismatch")
+
+    vector_bytes = heads * rows * 128 * 2
+    aq_bytes = heads * total_chunks * 256 * 2
+    kd_ptr = kd.data_ptr()
+    expected_ptrs = (
+        kd_ptr,
+        kd_ptr + vector_bytes,
+        kd_ptr + 2 * vector_bytes,
+        kd_ptr + 3 * vector_bytes,
+        kd_ptr + 3 * vector_bytes + aq_bytes,
+    )
+    actual_ptrs = tuple(tensor.data_ptr() for tensor in (kd, qd, ak, aq, g_total))
+    output_storages = tuple(
+        tensor.untyped_storage() for tensor in (kd, qd, ak, aq, g_total)
+    )
+    storage_bases = tuple(storage.data_ptr() for storage in output_storages)
+    workspace_bytes = (
+        3 * vector_bytes + aq_bytes + g_total.numel() * g_total.element_size()
+    )
+    if (
+        kd_ptr % 256
+        or actual_ptrs != expected_ptrs
+        or len(set(storage_bases)) != 1
+        or storage_bases[0] != kd_ptr
+        or any(storage.nbytes() < workspace_bytes for storage in output_storages)
+    ):
+        raise exc.BackendUnsupported(
+            "cute", "chunk-prepare factors must use the exact packed workspace ABI"
+        )
+
+    output_begin = kd_ptr
+    output_end = g_total.data_ptr() + g_total.numel() * g_total.element_size()
+    for tensor in (
+        q,
+        k,
+        gate,
+        beta,
+        a_log,
+        dt_bias,
+        cu_seqlens,
+        cu_chunks,
+        chunk_to_seq,
+    ):
+        begin = tensor.data_ptr()
+        end = begin + tensor.numel() * tensor.element_size()
+        if begin < output_end and output_begin < end:
+            raise exc.BackendUnsupported("cute", "chunk-prepare input aliases output")
+    if any(tensor.data_ptr() % 16 for tensor in (q, k, gate, kd)):
+        raise exc.BackendUnsupported("cute", "chunk-prepare TMA base is misaligned")
+
+    return _chunk_prepare_expected_tensor_map_specs(
+        total_tokens=total_tokens,
+        total_chunks=total_chunks,
+        heads=heads,
+        q_ptr=q.data_ptr(),
+        k_ptr=k.data_ptr(),
+        gate_ptr=gate.data_ptr(),
+        factor_ptr=kd_ptr,
+        gate_dtype=gate.dtype,
+    )
+
+
+def _encode_chunk_prepare_tensor_map(spec: _ChunkPrepareTensorMapSpec) -> bytes:
+    cuda_driver = importlib.import_module("cuda.bindings.driver")
+    dtype = (
+        cuda_driver.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_BFLOAT16
+        if spec.dtype is torch.bfloat16
+        else cuda_driver.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_FLOAT32
+    )
+    rank = len(spec.global_dim)
+    if (
+        rank not in (3, 4)
+        or len(spec.global_stride_bytes) != rank - 1
+        or len(spec.box_dim) != rank
+    ):
+        raise exc.BackendUnsupported("cute", "invalid chunk-prepare tensor-map rank")
+    error, tensor_map = cuda_driver.cuTensorMapEncodeTiled(
+        dtype,
+        rank,
+        spec.base_ptr,
+        [cuda_driver.cuuint64_t(value) for value in spec.global_dim],
+        [cuda_driver.cuuint64_t(value) for value in spec.global_stride_bytes],
+        [cuda_driver.cuuint32_t(value) for value in spec.box_dim],
+        [cuda_driver.cuuint32_t(1)] * rank,
+        cuda_driver.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE,
+        cuda_driver.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B,
+        cuda_driver.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
+        cuda_driver.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    )
+    if int(error) != 0:
+        raise exc.BackendUnsupported(
+            "cute", f"chunk-prepare tensor-map encoding failed: {error}"
+        )
+    return bytes(ctypes.string_at(tensor_map.getPtr(), 128))
+
+
+def _build_chunk_prepare_tensor_maps(
+    plan: dict[str, object],
+    args: tuple[object, ...],
+) -> tuple[torch.Tensor, tuple[int, int, int, int]]:
+    specs = _chunk_prepare_tensor_map_specs(plan, args)
+    payload = bytearray().join(_encode_chunk_prepare_tensor_map(spec) for spec in specs)
+    q = _chunk_prepare_plan_tensor(plan, args, "q_idx")
+    storage = torch.frombuffer(payload, dtype=torch.uint8).clone().to(q.device)
+    if storage.data_ptr() % 64:
+        raise exc.BackendUnsupported(
+            "cute", "chunk-prepare tensor-map storage is misaligned"
+        )
+    base = storage.data_ptr()
+    return storage, cast(
+        "tuple[int, int, int, int]",
+        tuple(base + 128 * index for index in range(4)),
+    )
+
+
+def _chunk_recurrence_plan_tensor(
+    plan: dict[str, object],
+    args: tuple[object, ...],
+    key: str,
+) -> torch.Tensor:
+    index = plan.get(key)
+    if type(index) is not int or not 0 <= index < len(args):
+        raise exc.BackendUnsupported("cute", f"invalid chunk-recurrence {key}")
+    tensor = args[index]
+    if not isinstance(tensor, torch.Tensor):
+        raise exc.BackendUnsupported("cute", f"chunk-recurrence {key} is not a tensor")
+    return tensor
+
+
+def _chunk_recurrence_tensor_map_specs(
+    plan: dict[str, object],
+    args: tuple[object, ...],
+    *,
+    validate_only: bool = False,
+) -> dict[str, Any]:
+    """Validate v2-workspace recurrence arguments and describe DV4 TensorMaps."""
+
+    def plan_int(key: str) -> int:
+        value = plan.get(key)
+        if type(value) is not int:
+            raise exc.BackendUnsupported("cute", f"invalid chunk-recurrence {key}")
+        return value
+
+    kind = plan.get("kind")
+    if (
+        kind not in ("chunk_recurrence_sm100", "chunk_recurrence_warp_dv4")
+        or plan_int("workspace_layout_version") != 2
+        or plan.get("outputs_scaled") is not False
+        or plan.get("factor_key_xor") != 8
+        or plan_int("chunk_size") != 16
+        or plan_int("key_size") != 128
+        or plan_int("value_size") != 128
+    ):
+        raise exc.BackendUnsupported("cute", "unsupported chunk-recurrence ABI")
+    total_tokens = plan_int("total_tokens")
+    total_chunks = plan_int("total_chunks")
+    heads = plan_int("heads")
+    sequences = plan_int("sequences")
+    if min(total_tokens, total_chunks, heads, sequences) <= 0:
+        raise exc.BackendUnsupported("cute", "empty chunk-recurrence launch")
+
+    names = (
+        "kd_idx",
+        "qd_idx",
+        "ak_idx",
+        "aq_idx",
+        "gt_idx",
+        "v_idx",
+        "out_idx",
+        "state_idx",
+        "cu_seqlens_idx",
+        "cu_chunks_idx",
+    )
+    (
+        kd,
+        qd,
+        ak,
+        aq,
+        g_total,
+        values,
+        output,
+        state,
+        cu_seqlens,
+        cu_chunks,
+    ) = tuple(_chunk_recurrence_plan_tensor(plan, args, name) for name in names)
+    tensors = (kd, qd, ak, aq, g_total, values, output, state, cu_seqlens, cu_chunks)
+    if kd.device.type != "cuda" or any(
+        tensor.device != kd.device for tensor in tensors
+    ):
+        raise exc.BackendUnsupported(
+            "cute", "chunk-recurrence tensors must share one CUDA device"
+        )
+    if any(not tensor.is_contiguous() for tensor in tensors):
+        raise exc.BackendUnsupported(
+            "cute", "chunk-recurrence tensors must be contiguous"
+        )
+
+    rows = total_chunks * 16
+    expected = (
+        (kd, torch.bfloat16, (heads * rows, 128)),
+        (qd, torch.bfloat16, (heads * rows, 128)),
+        (ak, torch.bfloat16, (heads * rows, 128)),
+        (aq, torch.bfloat16, (heads * total_chunks, 256)),
+        (g_total, torch.float32, (heads * total_chunks, 128)),
+        (values, torch.bfloat16, (total_tokens * heads, 128)),
+        (output, torch.bfloat16, (total_tokens * heads, 128)),
+        (state, torch.bfloat16, (sequences, heads, 128, 128)),
+        (cu_seqlens, torch.int32, (sequences + 1,)),
+        (cu_chunks, torch.int32, (sequences + 1,)),
+    )
+    for tensor, dtype, shape in expected:
+        if tensor.dtype is not dtype or tuple(tensor.shape) != shape:
+            raise exc.BackendUnsupported(
+                "cute", "chunk-recurrence tensor dtype/shape ABI mismatch"
+            )
+
+    vector_bytes = heads * rows * 128 * 2
+    aq_bytes = heads * total_chunks * 256 * 2
+    kd_ptr = kd.data_ptr()
+    expected_ptrs = (
+        kd_ptr,
+        kd_ptr + vector_bytes,
+        kd_ptr + 2 * vector_bytes,
+        kd_ptr + 3 * vector_bytes,
+        kd_ptr + 3 * vector_bytes + aq_bytes,
+    )
+    factor_tensors = (kd, qd, ak, aq, g_total)
+    actual_ptrs = tuple(tensor.data_ptr() for tensor in factor_tensors)
+    storages = tuple(tensor.untyped_storage() for tensor in factor_tensors)
+    storage_bases = tuple(storage.data_ptr() for storage in storages)
+    workspace_bytes = (
+        3 * vector_bytes + aq_bytes + g_total.numel() * g_total.element_size()
+    )
+    if (
+        kd_ptr % 256
+        or actual_ptrs != expected_ptrs
+        or len(set(storage_bases)) != 1
+        or storage_bases[0] != kd_ptr
+        or any(storage.nbytes() < workspace_bytes for storage in storages)
+    ):
+        raise exc.BackendUnsupported(
+            "cute", "chunk-recurrence factors must use the exact packed workspace ABI"
+        )
+
+    def byte_range(tensor: torch.Tensor) -> tuple[int, int]:
+        begin = tensor.data_ptr()
+        return begin, begin + tensor.numel() * tensor.element_size()
+
+    def overlaps(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
+        lhs_begin, lhs_end = byte_range(lhs)
+        rhs_begin, rhs_end = byte_range(rhs)
+        return lhs_begin < rhs_end and rhs_begin < lhs_end
+
+    value_range = byte_range(values)
+    output_range = byte_range(output)
+    if value_range != output_range and overlaps(values, output):
+        raise exc.BackendUnsupported(
+            "cute", "chunk-recurrence value/output must alias exactly or be disjoint"
+        )
+    for name, tensor in (("cu_seqlens", cu_seqlens), ("cu_chunks", cu_chunks)):
+        if overlaps(output, tensor):
+            raise exc.BackendUnsupported(
+                "cute", f"chunk-recurrence output aliases {name}"
+            )
+    for tensor in (*factor_tensors, values, output, cu_seqlens, cu_chunks):
+        if overlaps(state, tensor):
+            raise exc.BackendUnsupported("cute", "chunk-recurrence state aliases input")
+    factor_begin = kd_ptr
+    factor_end = kd_ptr + workspace_bytes
+    for tensor in (values, output, state, cu_seqlens, cu_chunks):
+        begin, end = byte_range(tensor)
+        if begin < factor_end and factor_begin < end:
+            raise exc.BackendUnsupported(
+                "cute", "chunk-recurrence factor workspace aliases another argument"
+            )
+    if any(
+        tensor.data_ptr() % 16 for tensor in (kd, aq, g_total, values, output, state)
+    ):
+        raise exc.BackendUnsupported("cute", "chunk-recurrence TMA base is misaligned")
+
+    if validate_only:
+        return {}
+
+    # The DV2 host schedule builds CuTe TensorMaps from the validated tensor
+    # views itself.  Only the external warp-DV4 schedule consumes raw encoded
+    # descriptors owned by this launcher.
+    if kind != "chunk_recurrence_warp_dv4":
+        raise exc.BackendUnsupported(
+            "cute", "raw chunk-recurrence TensorMaps require the warp-DV4 schedule"
+        )
+
+    from helion._compiler.cute.chunk_recurrence_dv4_sm100 import (
+        recurrence_tensor_map_specs,
+    )
+
+    return recurrence_tensor_map_specs(
+        kd_ptr=kd_ptr,
+        aq_ptr=aq.data_ptr(),
+        gt_ptr=g_total.data_ptr(),
+        v_ptr=values.data_ptr(),
+        out_ptr=output.data_ptr(),
+        heads=heads,
+        total_tokens=total_tokens,
+        total_chunks=total_chunks,
+        sequences=sequences,
+        state_ptr=state.data_ptr(),
+    )
+
+
+def _build_chunk_recurrence_tensor_maps(
+    plan: dict[str, object],
+    args: tuple[object, ...],
+) -> tuple[torch.Tensor, tuple[int, int, int, int, int, int, int]]:
+    if plan.get("kind") != "chunk_recurrence_warp_dv4":
+        raise exc.BackendUnsupported("cute", "unsupported chunk-recurrence plan")
+    from helion._compiler.cute.chunk_recurrence_dv4_sm100 import ROLES
+    from helion._compiler.cute.chunk_recurrence_dv4_sm100 import (
+        build_recurrence_tensor_maps,
+    )
+
+    specs = _chunk_recurrence_tensor_map_specs(plan, args)
+    kd = _chunk_recurrence_plan_tensor(plan, args, "kd_idx")
+    try:
+        tensor_maps = build_recurrence_tensor_maps(specs, kd.device)
+    except (RuntimeError, ValueError) as error:
+        raise exc.BackendUnsupported(
+            "cute", f"chunk-recurrence tensor-map construction failed: {error}"
+        ) from error
+    return tensor_maps.storage, cast(
+        "tuple[int, int, int, int, int, int, int]",
+        tuple(tensor_maps.address(role) for role in ROLES),
+    )
 
 
 def _build_cute_schema_and_args(
@@ -4289,6 +5098,73 @@ def _build_cute_schema_and_args(
         schema.append(("wrapper_host_scalar", total_name, "int"))
         launch_args.append(total_clusters)
         owned_tensors.extend(metadata_result.tensors())
+
+    chunk_prepare_plans = [
+        cast("dict[str, object]", plan)
+        for plan in getattr(cast("Any", cute_kernel), "_helion_cute_wrapper_plans", ())
+        if plan.get("kind") == "chunk_prepare_tma"
+    ]
+    if len(chunk_prepare_plans) > 1:
+        raise exc.BackendUnsupported("cute", "multiple chunk-prepare wrapper plans")
+    if chunk_prepare_plans:
+        plan = chunk_prepare_plans[0]
+        storage, descriptors = _build_chunk_prepare_tensor_maps(plan, args)
+        desc_args = plan.get("desc_args")
+        if not isinstance(desc_args, (list, tuple)) or len(desc_args) != len(
+            descriptors
+        ):
+            raise exc.BackendUnsupported(
+                "cute", "invalid chunk-prepare descriptor arguments"
+            )
+        for name, address in zip(desc_args, descriptors, strict=True):
+            if not isinstance(name, str):
+                raise exc.BackendUnsupported(
+                    "cute", "invalid chunk-prepare descriptor argument name"
+                )
+            schema.append(("wrapper_host_scalar", name, "int"))
+            launch_args.append(address)
+        owned_tensors.append(storage)
+
+    chunk_recurrence_plans = [
+        cast("dict[str, object]", plan)
+        for plan in getattr(cast("Any", cute_kernel), "_helion_cute_wrapper_plans", ())
+        if plan.get("kind") == "chunk_recurrence_warp_dv4"
+    ]
+    if len(chunk_recurrence_plans) > 1:
+        raise exc.BackendUnsupported("cute", "multiple chunk-recurrence wrapper plans")
+    if chunk_recurrence_plans:
+        plan = chunk_recurrence_plans[0]
+        storage, descriptors = _build_chunk_recurrence_tensor_maps(plan, args)
+        desc_args = plan.get("desc_args")
+        if not isinstance(desc_args, (list, tuple)) or len(desc_args) != len(
+            descriptors
+        ):
+            raise exc.BackendUnsupported(
+                "cute", "invalid chunk-recurrence descriptor arguments"
+            )
+        for name, address in zip(desc_args, descriptors, strict=True):
+            if not isinstance(name, str):
+                raise exc.BackendUnsupported(
+                    "cute", "invalid chunk-recurrence descriptor argument name"
+                )
+            schema.append(("wrapper_host_scalar", name, "int"))
+            launch_args.append(address)
+        owned_tensors.append(storage)
+
+    sm100_recurrence_plans = [
+        cast("dict[str, object]", plan)
+        for plan in getattr(cast("Any", cute_kernel), "_helion_cute_wrapper_plans", ())
+        if plan.get("kind") == "chunk_recurrence_sm100"
+    ]
+    if len(sm100_recurrence_plans) > 1:
+        raise exc.BackendUnsupported("cute", "multiple SM100 recurrence plans")
+    if sm100_recurrence_plans:
+        # Reuse the strict packed-workspace and alias checks while the SM100
+        # path is brought up.  It constructs no raw descriptor storage here;
+        # the nested CuTe host creates TensorMaps from the validated views.
+        _chunk_recurrence_tensor_map_specs(
+            sm100_recurrence_plans[0], args, validate_only=True
+        )
 
     launch_args.extend(grid)
     # The stream is intentionally NOT appended here; it is sampled fresh per
@@ -4610,6 +5486,23 @@ def _cute_build_fast_relaunch(
     if _tcgen05_grouped_static_plans(cute_kernel):
         return None
     if _cute_dynamic_tensormap_contexts(cute_kernel, args):
+        return None
+    # These whole-root plans pass host-encoded TensorMap descriptor
+    # addresses as scalar wrapper arguments.  Their descriptor payload embeds
+    # the tensor data pointers, so patching only the ordinary tensor-pointer
+    # slots would leave a relaunch aimed at the first invocation's buffers.
+    # Keep them on the pointer-keyed launch cache until the fastpath can also
+    # rebuild or patch raw TensorMap descriptors.
+    wrapper_plans = getattr(cast("Any", cute_kernel), "_helion_cute_wrapper_plans", ())
+    if any(
+        plan.get("kind")
+        in {
+            "chunk_prepare_tma",
+            "chunk_recurrence_sm100",
+            "chunk_recurrence_warp_dv4",
+        }
+        for plan in wrapper_plans
+    ):
         return None
     device_index: int | None = None
     tensors: list[tuple[int, torch.Tensor]] = []

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
+import json
 import os
 import pickle
 from typing import TYPE_CHECKING
@@ -167,6 +168,17 @@ def _known_keys_strategy() -> st.SearchStrategy[dict[str, Any]]:
                 ["flat", "xyz", "persistent_blocked", "persistent_interleaved"]
             ),
             "cross_loop_schedule": st.sampled_from(["barrier", "static_pipeline"]),
+            "cute_chunk_recurrence_dv_partitions": st.sampled_from([2, 4]),
+            "cute_chunk_recurrence_register_cap": st.sampled_from([72, 76, 80]),
+            "cute_chunk_prepare_schedule": st.sampled_from(
+                [
+                    "split_alias_cpc1",
+                    "split_alias_cpc2",
+                    "split_alias_cpc3",
+                    "split_alias_cpc4",
+                    "split_alias_cpc5",
+                ]
+            ),
             "indexing": st.sampled_from(["pointer", "tensor_descriptor"]),
         }
     )
@@ -208,6 +220,9 @@ def _unknown_keys_strategy() -> st.SearchStrategy[dict[str, Any]]:
                     "num_stages",
                     "pid_type",
                     "cross_loop_schedule",
+                    "cute_chunk_recurrence_dv_partitions",
+                    "cute_chunk_recurrence_register_cap",
+                    "cute_chunk_prepare_schedule",
                     "indexing",
                 }
             )
@@ -412,6 +427,11 @@ class TestConfigAPI(TestCase):
             "cross_loop_schedule",
             "indexing",
         }
+        compiler_internal = {
+            "cute_chunk_recurrence_dv_partitions",
+            "cute_chunk_recurrence_register_cap",
+            "cute_chunk_prepare_schedule",
+        }
 
         sig = inspect.signature(helion.Config.__init__)
         kwonly = {
@@ -421,6 +441,7 @@ class TestConfigAPI(TestCase):
         }
         # Expected kwargs must be present as keyword-only
         self.assertTrue(expected.issubset(kwonly))
+        self.assertTrue(compiler_internal.isdisjoint(kwonly))
 
     def test_cross_loop_schedule_is_an_admitted_triton_field(self) -> None:
         from helion.autotuner.config_generation import ConfigGeneration
@@ -488,6 +509,134 @@ class TestConfigAPI(TestCase):
                 num_sm=1,
             )
             self.assertFalse(spec.supports_config_key("cross_loop_schedule"))
+
+    def test_cute_chunk_internal_config_mapping_serialization(self) -> None:
+        from helion.autotuner.local_cache import parse_cache_entry
+
+        values = {
+            "cute_chunk_recurrence_dv_partitions": 4,
+            "cute_chunk_recurrence_register_cap": 76,
+            "cute_chunk_prepare_schedule": "split_alias_cpc2",
+        }
+        config = helion.Config.from_dict(values)
+        self.assertEqual(dict(config), values)
+        self.assertEqual(dict(helion.Config.from_json(config.to_json())), values)
+        cache_entry = parse_cache_entry(
+            json.dumps(
+                {
+                    "key": {
+                        "fields": {
+                            "hardware": "test",
+                            "specialization_key": "test",
+                            "config_spec_hash": "test",
+                        }
+                    },
+                    "config": config.to_json(),
+                    "flat_config": json.dumps([4, 76, "split_alias_cpc2"]),
+                }
+            )
+        )
+        self.assertEqual(dict(cache_entry.config), values)
+
+    def test_cute_chunk_recurrence_register_cap_serialization_and_scope(self) -> None:
+        from helion._compiler.backend import CuteBackend
+        from helion.autotuner.config_generation import ConfigGeneration
+
+        config = helion.Config.from_dict(
+            {
+                "cute_chunk_recurrence_dv_partitions": 4,
+                "cute_chunk_recurrence_register_cap": 76,
+            }
+        )
+
+        spec = ConfigSpec(backend=CuteBackend())
+        with self.assertRaisesRegex(
+            exc.InvalidConfig,
+            "available only for matched BT16 chunk-recurrence kernels",
+        ):
+            spec.normalize(config)
+
+        spec.enable_cute_chunk_recurrence_search(preferred_partitions=2)
+        field = spec._flat_fields()["cute_chunk_recurrence_register_cap"]
+        self.assertIs(field, spec.cute_chunk_recurrence_register_cap)
+        self.assertEqual(field.choices, (None, 72, 76, 80))
+        self.assertIsNone(
+            spec.default_config().config.get("cute_chunk_recurrence_register_cap")
+        )
+        generation = ConfigGeneration(spec)
+        round_trip = generation.unflatten(generation.flatten(config))
+        self.assertEqual(round_trip["cute_chunk_recurrence_dv_partitions"], 4)
+        self.assertEqual(round_trip["cute_chunk_recurrence_register_cap"], 76)
+        with self.assertRaisesRegex(exc.InvalidConfig, "must be one of"):
+            spec.normalize(
+                helion.Config.from_dict({"cute_chunk_recurrence_register_cap": 64})
+            )
+
+        triton_spec = ConfigSpec(backend=TritonBackend())
+        with self.assertRaisesRegex(
+            exc.InvalidConfig,
+            "Unsupported config keys for backend 'triton'",
+        ):
+            triton_spec.normalize(
+                helion.Config.from_dict({"cute_chunk_recurrence_register_cap": 72})
+            )
+
+    def test_cute_chunk_recurrence_integer_knobs_require_exact_integers(self) -> None:
+        from helion._compiler.backend import CuteBackend
+
+        spec = ConfigSpec(backend=CuteBackend())
+        spec.enable_cute_chunk_recurrence_search(preferred_partitions=4)
+        for key, value, expected in (
+            ("cute_chunk_recurrence_dv_partitions", True, 4),
+            ("cute_chunk_recurrence_dv_partitions", 4.0, 4),
+            ("cute_chunk_recurrence_register_cap", False, None),
+            ("cute_chunk_recurrence_register_cap", 72.0, None),
+        ):
+            with self.subTest(key=key, value=value):
+                config = {key: value}
+                with self.assertRaisesRegex(exc.InvalidConfig, "must be one of"):
+                    spec.normalize(config)
+
+                spec.normalize(config, _fix_invalid=True)
+                self.assertEqual(config[key], expected)
+
+    def test_cute_chunk_prepare_schedule_serialization_and_scope(self) -> None:
+        from helion._compiler.backend import CuteBackend
+
+        config = helion.Config.from_dict(
+            {"cute_chunk_prepare_schedule": "split_alias_cpc2"}
+        )
+
+        spec = ConfigSpec(backend=CuteBackend())
+        with self.assertRaisesRegex(
+            exc.InvalidConfig,
+            "available only for matched BT16 chunk-prepare kernels",
+        ):
+            spec.normalize(config)
+
+        spec.enable_cute_chunk_prepare_schedule_search(
+            preferred_schedule="split_alias_cpc2"
+        )
+        field = spec._flat_fields()["cute_chunk_prepare_schedule"]
+        self.assertIs(field, spec.cute_chunk_prepare_schedule)
+        self.assertEqual(
+            field.choices,
+            (
+                "split_alias_cpc2",
+                "split_alias_cpc1",
+                "split_alias_cpc3",
+                "split_alias_cpc4",
+                "split_alias_cpc5",
+            ),
+        )
+        self.assertEqual(
+            spec.default_config()["cute_chunk_prepare_schedule"],
+            "split_alias_cpc2",
+        )
+        with self.assertRaisesRegex(exc.InvalidConfig, "must be one of"):
+            spec.normalize(
+                helion.Config.from_dict({"cute_chunk_prepare_schedule": "delayed_qk"})
+            )
 
     def test_warp_specialization_uses_effective_launcher_warp_count(self) -> None:
         backend = TritonBackend()

--- a/test/test_cute_chunk_prepare.py
+++ b/test/test_cute_chunk_prepare.py
@@ -1,0 +1,1150 @@
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import importlib
+import inspect
+import operator
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from benchmarks.cute.kda_prefill_kernels import BT
+from benchmarks.cute.kda_prefill_kernels import DK
+from benchmarks.cute.kda_prefill_kernels import KDA_PREPARE_CONFIG as _CONFIG
+from benchmarks.cute.kda_prefill_kernels import (
+    kda_chunk_prepare as _five_factor_prepare,
+)
+import pytest
+import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+import helion
+from helion import _compat
+from helion import exc
+from helion._compiler.autotuner_heuristics import compiler_seed_specialization_facts
+from helion._compiler.autotuner_heuristics.cute import CuteChunkPrepareHeuristic
+from helion._compiler.cute.chunk_prepare import _packed_workspace_is_exact
+from helion._compiler.cute.chunk_prepare import _preferred_split_alias_chunks_per_cta
+from helion._compiler.cute.chunk_prepare import _TensorRef
+from helion._testing import DEVICE
+from helion._testing import skipUnlessBackends
+from helion.runtime.cute.launcher import _chunk_prepare_expected_tensor_map_specs
+from helion.runtime.cute.launcher import _chunk_prepare_tensor_map_specs
+
+pytest.importorskip("cutlass")
+pytest.importorskip("cutlass.cute")
+pytestmark = skipUnlessBackends(["cute"])
+_split_alias_device = importlib.import_module(
+    "helion._compiler.cute.chunk_prepare_split_alias_device"
+)
+PREPARE_DEVICE_THREADS = _split_alias_device.PREPARE_DEVICE_THREADS
+emit_bt16_prepare = _split_alias_device.emit_bt16_prepare
+issue_chunk_tma = _split_alias_device.issue_chunk_tma
+mbar_spin_wait = _split_alias_device.mbar_spin_wait
+mma_blockdiag_8x8_f16 = _split_alias_device.mma_blockdiag_8x8_f16
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from helion._compiler.device_ir import DeviceIR
+
+
+def _fake_inputs(
+    *,
+    tokens: int = 128,
+    heads: int = 2,
+    chunks: int = 8,
+    gate_dtype: torch.dtype = torch.bfloat16,
+    packed_workspace: bool = True,
+) -> tuple[object, ...]:
+    rows = chunks * BT
+    with FakeTensorMode():
+        q = torch.empty((1, tokens, heads, DK), device=DEVICE, dtype=torch.bfloat16)
+        k = torch.empty_like(q)
+        gate = torch.empty((1, tokens, heads, DK), device=DEVICE, dtype=gate_dtype)
+        beta = torch.empty((1, tokens, heads), device=DEVICE, dtype=torch.bfloat16)
+        a_log = torch.empty((heads,), device=DEVICE, dtype=torch.float32)
+        dt_bias = torch.empty((heads, DK), device=DEVICE, dtype=torch.float32)
+        cu_seqlens = torch.empty((3,), device=DEVICE, dtype=torch.int32)
+        cu_chunks = torch.empty((3,), device=DEVICE, dtype=torch.int32)
+        chunk_to_seq = torch.empty((chunks,), device=DEVICE, dtype=torch.int32)
+        vector_bytes = heads * rows * DK * 2
+        aq_bytes = heads * chunks * BT * BT * 2
+        gt_bytes = heads * chunks * DK * 4
+        if packed_workspace:
+            workspace = torch.empty(
+                (3 * vector_bytes + aq_bytes + gt_bytes,),
+                device=DEVICE,
+                dtype=torch.uint8,
+            )
+            kd = workspace[:vector_bytes].view(torch.bfloat16).view(1, heads, rows, DK)
+            qd = (
+                workspace[vector_bytes : 2 * vector_bytes]
+                .view(torch.bfloat16)
+                .view(1, heads, rows, DK)
+            )
+            ak = (
+                workspace[2 * vector_bytes : 3 * vector_bytes]
+                .view(torch.bfloat16)
+                .view(1, heads, rows, DK)
+            )
+            aq = (
+                workspace[3 * vector_bytes : 3 * vector_bytes + aq_bytes]
+                .view(torch.bfloat16)
+                .view(1, heads, chunks, BT * BT)
+            )
+            g_total = (
+                workspace[3 * vector_bytes + aq_bytes :]
+                .view(torch.float32)
+                .view(1, heads, chunks, DK)
+            )
+        else:
+            kd = torch.empty((1, heads, rows, DK), device=DEVICE, dtype=torch.bfloat16)
+            qd = torch.empty_like(kd)
+            ak = torch.empty_like(kd)
+            aq = torch.empty(
+                (1, heads, chunks, BT * BT),
+                device=DEVICE,
+                dtype=torch.bfloat16,
+            )
+            g_total = torch.empty(
+                (1, heads, chunks, DK), device=DEVICE, dtype=torch.float32
+            )
+    return (
+        q,
+        k,
+        gate,
+        beta,
+        a_log,
+        dt_bias,
+        cu_seqlens,
+        cu_chunks,
+        chunk_to_seq,
+        kd,
+        qd,
+        ak,
+        aq,
+        g_total,
+        DK**-0.5,
+        -5.0 * 1.4426950408889634,
+    )
+
+
+def _code(
+    *,
+    tokens: int = 128,
+    heads: int = 2,
+    chunks: int = 8,
+    gate_dtype: torch.dtype = torch.bfloat16,
+    outputs_scaled: bool = True,
+    mutate: Callable[[DeviceIR], None] | None = None,
+    config: helion.Config = _CONFIG,
+    capability: tuple[int, int] = (10, 0),
+    packed_workspace: bool = True,
+) -> str:
+    with (
+        patch(
+            "helion.runtime.kernel.target_device_capability",
+            return_value=capability,
+        ),
+        patch(
+            "helion._compiler.compile_environment.target_device_capability",
+            return_value=capability,
+        ),
+        patch("helion.language.loops.use_tileir_tunables", return_value=False),
+        patch(
+            "helion.language.loops._supports_warp_specialize",
+            return_value=capability >= (10, 0),
+        ),
+        patch(
+            "helion._compat._supports_tensor_descriptor",
+            return_value=capability >= (9, 0),
+        ),
+        patch("helion._compat._min_dot_size", return_value=(16, 16, 16)),
+        patch("helion._compat._is_hip", return_value=False),
+    ):
+        inputs = _fake_inputs(
+            tokens=tokens,
+            heads=heads,
+            chunks=chunks,
+            gate_dtype=gate_dtype,
+            packed_workspace=packed_workspace,
+        )
+        if not outputs_scaled:
+            inputs = (*inputs[:-2], None, inputs[-1])
+        bound = _five_factor_prepare._bind_isolated(inputs)
+        if mutate is not None:
+            mutate(bound.host_function.device_ir)
+        bound.config_spec.target_device_capability = capability
+        return bound.to_triton_code(config)
+
+
+def test_five_factor_prepare_codegen() -> None:
+    code = _code()
+    assert code.count("emit_bt16_prepare(") == 1
+    assert "True, 0, 1, False)" in code
+    assert "block=(128, 1, 1)" in code
+    assert "'kind': 'chunk_prepare_tma'" in code
+    assert "'chunks_per_cta': 1" in code
+    assert "'schedule': 'split_alias_cpc1'" in code
+    assert "chunk_prepare_split_alias_device import emit_bt16_prepare" in code
+    assert "'outputs_scaled': True" in code
+    assert "'device_abi': 3" in code
+    assert "'smem_bytes': 21968" in code
+    assert "--override-directive-values --maxrregcount=48" in code
+    assert "'bf16_mma_count': 168" in code
+    assert "'fp16_mma_count': 24" in code
+    assert "'q_idx': 0" in code
+    assert "'a_log_idx': 4" in code
+    assert "'gt_idx': 13" in code
+    assert "_helion_cute_disable_bake_tensor_shapes" not in code
+    assert "cute.gemm(" not in code
+
+
+def test_prepare_device_exposes_only_the_matched_gate_contract() -> None:
+    source = inspect.getsource(emit_bt16_prepare)
+    assert "SAFE_GATE" not in source
+    assert "cute.math.log2" not in source
+
+
+def test_prepare_uses_shared_device_primitives() -> None:
+    from helion._compiler.cute import chunk_prepare_split_alias_device as device
+    from helion._compiler.cute import kda_device_primitives as primitives
+
+    for name in (
+        "mma_m16n8k16_bf16",
+        "movmatrix_b16",
+        "pack_bf16x2",
+        "store_vec8_bf16",
+        "tma_store_3d",
+        "tma_store_commit_group",
+        "tma_store_wait_read",
+        "vec4_f32",
+        "vec8_bf16",
+        "vec_at",
+        "warp_arrive",
+    ):
+        assert getattr(device, name) is getattr(primitives, name)
+
+
+def test_prepare_exact_lowering_requires_fast_math_policy() -> None:
+    with patch.object(_five_factor_prepare.settings, "fast_math", False):
+        plan = _captured_plan()
+    assert plan is None
+
+
+@pytest.mark.parametrize("guard", ("_linear_offsets_fit_i32", "_xyz_grid_fits"))
+def test_prepare_unsafe_index_or_launch_geometry_fails_closed(guard: str) -> None:
+    with patch(f"helion._compiler.cute.chunk_prepare.{guard}", return_value=False):
+        plan = _captured_plan()
+    assert plan is None
+
+
+@pytest.mark.parametrize(
+    ("collision", "expected"),
+    (
+        (
+            "emit_bt16_prepare",
+            (
+                "import emit_bt16_prepare as emit_bt16_prepare_1",
+                "    emit_bt16_prepare_1(",
+            ),
+        ),
+        (
+            "_chunk_prepare_arg_0",
+            ("_chunk_prepare_arg_1 = cute.make_tensor(_chunk_prepare_arg_0.iterator",),
+        ),
+        (
+            "_chunk_prepare_desc_q",
+            ("'desc_args': ('_chunk_prepare_desc_q_1',",),
+        ),
+    ),
+)
+def test_prepare_generated_names_do_not_shadow_tensor_arguments(
+    collision: str,
+    expected: tuple[str, ...],
+) -> None:
+    from helion._compiler.cute import chunk_prepare
+
+    original = chunk_prepare._host_tensor_ref
+
+    def colliding_name(node: object) -> object:
+        ref = original(node)
+        if ref is not None and ref.name == "q_rows":
+            return dataclasses.replace(ref, name=collision)
+        return ref
+
+    with patch.object(chunk_prepare, "_host_tensor_ref", side_effect=colliding_name):
+        code = _code()
+    assert all(snippet in code for snippet in expected)
+
+
+def test_fake_arch_codegen_preserves_process_capability_state() -> None:
+    capability_cache = _compat._target_device_capability
+    tensor_descriptor_cache = _compat._supports_tensor_descriptor
+    min_dot_cache = _compat._min_dot_size
+    is_hip_cache = _compat._is_hip
+    cache_info = (
+        capability_cache.cache_info(),
+        tensor_descriptor_cache.cache_info(),
+        min_dot_cache.cache_info(),
+        is_hip_cache.cache_info(),
+    )
+    get_device_capability = torch.cuda.get_device_capability
+
+    _code(capability=(10, 0))
+
+    assert (
+        capability_cache.cache_info(),
+        tensor_descriptor_cache.cache_info(),
+        min_dot_cache.cache_info(),
+        is_hip_cache.cache_info(),
+    ) == cache_info
+    assert torch.cuda.get_device_capability is get_device_capability
+
+
+def test_five_factor_prepare_cpc5_split_alias_codegen() -> None:
+    code = _code(tokens=8192, heads=12, chunks=515)
+    assert "'chunks_per_cta': 5" in code
+    assert "'schedule': 'split_alias_cpc5'" in code
+    assert "'smem_bytes': 21968" in code
+
+
+def test_five_factor_prepare_cpc4_split_alias_remains_available() -> None:
+    config = helion.Config.from_dict(
+        {**_CONFIG.config, "cute_chunk_prepare_schedule": "split_alias_cpc4"}
+    )
+    code = _code(tokens=8192, heads=12, chunks=515, config=config)
+    assert "'chunks_per_cta': 4" in code
+    assert "'schedule': 'split_alias_cpc4'" in code
+    assert "'smem_bytes': 21968" in code
+
+
+def test_prepare_autotuner_searches_all_split_alias_schedules() -> None:
+    from helion.autotuner.config_generation import ConfigGeneration
+
+    with (
+        patch(
+            "helion.runtime.kernel.target_device_capability",
+            return_value=(10, 0),
+        ),
+        patch(
+            "helion._compiler.compile_environment.target_device_capability",
+            return_value=(10, 0),
+        ),
+        patch("helion.language.loops.use_tileir_tunables", return_value=False),
+        patch("helion.language.loops._supports_warp_specialize", return_value=True),
+        patch("helion._compat._supports_tensor_descriptor", return_value=True),
+        patch("helion._compat._min_dot_size", return_value=(16, 16, 16)),
+        patch("helion._compat._is_hip", return_value=False),
+    ):
+        bound = _five_factor_prepare._bind_isolated(_fake_inputs())
+
+    fragment = bound.config_spec.cute_chunk_prepare_schedule
+    assert fragment is not None
+    expected = (
+        "split_alias_cpc1",
+        "split_alias_cpc2",
+        "split_alias_cpc3",
+        "split_alias_cpc4",
+        "split_alias_cpc5",
+    )
+    assert fragment.choices == expected
+    assert bound.config_spec.compiler_default_config is not None
+    assert (
+        bound.config_spec.compiler_default_config["cute_chunk_prepare_schedule"]
+        == "split_alias_cpc1"
+    )
+    seeded = [
+        config["cute_chunk_prepare_schedule"]
+        for config in bound.config_spec.compiler_seed_configs
+        if "cute_chunk_prepare_schedule" in config
+    ]
+    assert seeded == list(expected)
+    dimensions = [
+        dimension.values
+        for dimension in bound.config_spec.iter_search_dimensions()
+        if dimension.name == "cute_chunk_prepare_schedule"
+    ]
+    assert dimensions == [list(expected)]
+    generated = [
+        config["cute_chunk_prepare_schedule"]
+        for _flat, config in ConfigGeneration(
+            bound.config_spec
+        ).seed_flat_config_pairs()
+        if "cute_chunk_prepare_schedule" in config
+    ]
+    assert generated == list(expected)
+
+
+def test_five_factor_prepare_fp32_gate_codegen() -> None:
+    code = _code(gate_dtype=torch.float32)
+    assert code.count("emit_bt16_prepare(") == 1
+    assert ", True)" in code
+    assert "'gate_is_fp32': True" in code
+
+
+def test_five_factor_prepare_unscaled_workspace_codegen() -> None:
+    code = _code(outputs_scaled=False)
+    assert code.count("emit_bt16_prepare(") == 1
+    assert "False, 8, 1, False)" in code
+    assert "'outputs_scaled': False" in code
+    assert "'factor_key_xor': 8" in code
+    assert "'device_abi': 4" in code
+
+
+def _captured_plan(
+    *,
+    mutate: Callable[[DeviceIR], None] | None = None,
+    capability: tuple[int, int] = (10, 0),
+    packed_workspace: bool = True,
+) -> object:
+    from helion._compiler.cute import chunk_prepare
+
+    captured: list[object] = []
+    original = chunk_prepare._plan_chunk_prepare
+
+    def capture(graphs: object, tile_strategy: object) -> object:
+        result = original(graphs, tile_strategy)  # type: ignore[arg-type]
+        captured.append(result)
+        return result
+
+    with (
+        patch.object(chunk_prepare, "_plan_chunk_prepare", side_effect=capture),
+        contextlib.suppress(exc.BackendUnsupported),
+    ):
+        _code(
+            mutate=mutate,
+            capability=capability,
+            packed_workspace=packed_workspace,
+        )
+    assert len(captured) == 1
+    return captured[0]
+
+
+def _captured_plan_after_mutation(mutate: Callable[[DeviceIR], None]) -> object:
+    return _captured_plan(mutate=mutate)
+
+
+def test_prepare_rejects_changed_scan_axis() -> None:
+    from helion.language import scan_ops
+
+    def mutate(device_ir: DeviceIR) -> None:
+        scan = next(
+            node
+            for graph in device_ir.graphs
+            for node in graph.graph.nodes
+            if node.op == "call_function" and node.target is scan_ops._associative_scan
+        )
+        scan.args = (*scan.args[:2], 1, *scan.args[3:])
+
+    assert _captured_plan_after_mutation(mutate) is None
+
+
+def test_prepare_rejects_changed_ak_aq_permutation() -> None:
+    def mutate(device_ir: DeviceIR) -> None:
+        for graph in device_ir.graphs:
+            for node in graph.graph.nodes:
+                if (
+                    node.op == "call_function"
+                    and node.target is torch.ops.aten.bitwise_xor.Scalar
+                    and node.args[1] == 8
+                ):
+                    node.args = (node.args[0], 4)
+
+    assert _captured_plan_after_mutation(mutate) is None
+
+
+def test_prepare_rejects_changed_dot_accumulator_dtype() -> None:
+    from helion.language.matmul_ops import dot
+
+    def mutate(device_ir: DeviceIR) -> None:
+        candidate = next(
+            node
+            for graph in device_ir.graphs
+            for node in graph.graph.nodes
+            if node.op == "call_function" and node.target is dot
+        )
+        candidate.args = (*candidate.args[:3], torch.float16)
+
+    assert _captured_plan_after_mutation(mutate) is None
+
+
+def test_prepare_rejects_changed_chunk_guard() -> None:
+    from helion.language._tracing_ops import _if
+
+    def mutate(device_ir: DeviceIR) -> None:
+        loop_if = next(
+            node
+            for graph in device_ir.graphs
+            for node in graph.graph.nodes
+            if node.op == "call_function" and node.target is _if
+        )
+        predicate = loop_if.args[0]
+        assert isinstance(predicate, torch.fx.Node)
+        predicate.args = (predicate.args[0], 7)
+
+    assert _captured_plan_after_mutation(mutate) is None
+
+
+def _prepare_body_nodes(device_ir: DeviceIR) -> list[torch.fx.Node]:
+    from helion._compiler.device_ir import IfGraphInfo
+
+    body = next(graph for graph in device_ir.graphs if isinstance(graph, IfGraphInfo))
+    return list(body.graph.nodes)
+
+
+def _change_gate_clamp(device_ir: DeviceIR) -> None:
+    clamp = next(
+        node
+        for node in _prepare_body_nodes(device_ir)
+        if node.op == "call_function"
+        and node.target is torch.ops.aten.clamp_min.default
+        and node.args[1] == -126.0
+    )
+    clamp.args = (clamp.args[0], -120.0)
+
+
+def _change_norm_epsilon(device_ir: DeviceIR) -> None:
+    clamp = next(
+        node
+        for node in _prepare_body_nodes(device_ir)
+        if node.op == "call_function"
+        and node.target is torch.ops.aten.clamp_min.default
+        and node.args[1] == 1.0e-24
+    )
+    clamp.args = (clamp.args[0], 1.0e-20)
+
+
+def _change_tanh_coefficient(device_ir: DeviceIR) -> None:
+    tanh = next(
+        node
+        for node in _prepare_body_nodes(device_ir)
+        if node.op == "call_function" and node.target is torch.ops.aten.tanh.default
+    )
+    product = tanh.args[0]
+    product.args = (product.args[0], 0.25)
+
+
+def _bypass_a_log_exp2(device_ir: DeviceIR) -> None:
+    decay_exp2 = next(
+        node
+        for node in _prepare_body_nodes(device_ir)
+        if node.op == "call_function"
+        and node.target is torch.ops.aten.exp2.default
+        and isinstance(node.args[0], torch.fx.Node)
+        and node.args[0].target is torch.ops.aten.mul.Tensor
+    )
+    decay_exp2.target = torch.ops.aten.exp.default
+
+
+def _bypass_sigmoid_input_cast(device_ir: DeviceIR) -> None:
+    sigmoid = next(
+        node
+        for node in _prepare_body_nodes(device_ir)
+        if node.op == "call_function" and node.target is torch.ops.aten.sigmoid.default
+    )
+    converted = sigmoid.args[0]
+    sigmoid.args = (converted.args[0],)
+
+
+def _change_q_normalization_rounding(device_ir: DeviceIR) -> None:
+    from helion.language import memory_ops
+
+    nodes = _prepare_body_nodes(device_ir)
+    q_load = next(
+        node
+        for node in nodes
+        if node.op == "call_function"
+        and node.target is memory_ops.load
+        and node.args[0].args[0] == "q_rows"
+    )
+    q_raw = next(
+        node
+        for node in q_load.users
+        if node.target is torch.ops.prims.convert_element_type.default
+    )
+    norm_product = next(
+        node
+        for node in q_raw.users
+        if node.target is torch.ops.aten.mul.Tensor
+        and node.args[0] is q_raw
+        and node.args[1] is not None
+    )
+    rounding = next(
+        node
+        for node in norm_product.users
+        if node.target is torch.ops.prims.convert_element_type.default
+    )
+    rounding.args = (rounding.args[0], torch.float16)
+
+
+def _remove_beta_mask(device_ir: DeviceIR) -> None:
+    from helion.language import memory_ops
+
+    beta_load = next(
+        node
+        for node in _prepare_body_nodes(device_ir)
+        if node.op == "call_function"
+        and node.target is memory_ops.load
+        and node.args[0].args[0] == "beta_rows"
+    )
+    beta_load.args = (*beta_load.args[:2], None, beta_load.args[3])
+
+
+def _change_inverse_half_boundary(device_ir: DeviceIR) -> None:
+    boundary = next(
+        node
+        for node in _prepare_body_nodes(device_ir)
+        if node.op == "call_function"
+        and node.target is torch.ops.aten.ge.Scalar
+        and node.args[1] == 8
+    )
+    boundary.args = (boundary.args[0], 4)
+
+
+def _swap_causal_operands(device_ir: DeviceIR) -> None:
+    causal = next(
+        node
+        for node in _prepare_body_nodes(device_ir)
+        if node.op == "call_function" and node.target is torch.ops.aten.ge.Tensor
+    )
+    causal.args = (causal.args[1], causal.args[0])
+
+
+def _swap_strict_operands(device_ir: DeviceIR) -> None:
+    strict = next(
+        node
+        for node in _prepare_body_nodes(device_ir)
+        if node.op == "call_function" and node.target is torch.ops.aten.gt.Tensor
+    )
+    strict.args = (strict.args[1], strict.args[0])
+
+
+def _bypass_scan_helper_addition(device_ir: DeviceIR) -> None:
+    from helion._compiler.device_ir import HelperFunctionGraphInfo
+
+    helper = next(
+        graph
+        for graph in device_ir.graphs
+        if isinstance(graph, HelperFunctionGraphInfo)
+    )
+    first_placeholder = next(
+        node for node in helper.graph.nodes if node.op == "placeholder"
+    )
+    output = next(node for node in helper.graph.nodes if node.op == "output")
+    output.args = (first_placeholder,)
+
+
+def _offset_prepare_chunk_coordinate(device_ir: DeviceIR) -> None:
+    from helion._compiler.device_ir import ForLoopGraphInfo
+    from helion._compiler.device_ir import IfGraphInfo
+    from helion.language import memory_ops
+    from helion.language._tracing_ops import _if
+
+    loop = next(
+        graph for graph in device_ir.graphs if isinstance(graph, ForLoopGraphInfo)
+    )
+    loop_if = next(
+        node
+        for node in loop.graph.nodes
+        if node.op == "call_function" and node.target is _if
+    )
+    predicate = loop_if.args[0]
+    assert isinstance(predicate, torch.fx.Node)
+    chunk = predicate.args[0]
+    assert isinstance(chunk, torch.fx.Node)
+    chunk_value = chunk.meta["val"]
+    assert isinstance(chunk_value, torch.SymInt)
+    with loop.graph.inserting_before(predicate):
+        shifted = loop.graph.call_function(operator.add, (chunk, 1))
+    shifted.meta = dict(chunk.meta)
+    shifted.meta["val"] = chunk_value + 1
+    predicate.args = (shifted, predicate.args[1])
+
+    body = next(graph for graph in device_ir.graphs if isinstance(graph, IfGraphInfo))
+    chunk_load = next(
+        node
+        for node in body.graph.nodes
+        if node.op == "call_function"
+        and node.target is memory_ops.load
+        and node.args[0].args[0] == "chunk_to_seq"
+    )
+    body_chunk = chunk_load.args[1][0]
+    assert isinstance(body_chunk, torch.fx.Node)
+    shifted_value = shifted.meta["val"]
+    assert isinstance(shifted_value, torch.SymInt)
+    body_chunk.args = (str(shifted_value._sympy_()),)
+    body_chunk.meta["val"] = shifted_value
+
+
+def _permute_prepare_root_task_axes(device_ir: DeviceIR) -> None:
+    axes = list(device_ir.task_families[0].axes)
+    axes[0], axes[1] = axes[1], axes[0]
+    device_ir.task_families[0] = dataclasses.replace(
+        device_ir.task_families[0],
+        axes=tuple(axes),
+    )
+
+
+def _make_prepare_root_task_origin_noncanonical(device_ir: DeviceIR) -> None:
+    axes = list(device_ir.task_families[0].axes)
+    axes[0] = dataclasses.replace(axes[0], canonical_origin=False)
+    device_ir.task_families[0] = dataclasses.replace(
+        device_ir.task_families[0],
+        axes=tuple(axes),
+    )
+
+
+def _shorten_prepare_root_task_extent(device_ir: DeviceIR) -> None:
+    axes = list(device_ir.task_families[0].axes)
+    extent = axes[0].extent
+    assert extent is not None and not isinstance(extent, str)
+    axes[0] = dataclasses.replace(axes[0], extent=extent - 1)
+    device_ir.task_families[0] = dataclasses.replace(
+        device_ir.task_families[0],
+        axes=tuple(axes),
+    )
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    (
+        _change_gate_clamp,
+        _change_norm_epsilon,
+        _change_tanh_coefficient,
+        _bypass_a_log_exp2,
+        _bypass_sigmoid_input_cast,
+        _change_q_normalization_rounding,
+        _remove_beta_mask,
+        _change_inverse_half_boundary,
+        _swap_causal_operands,
+        _swap_strict_operands,
+        _bypass_scan_helper_addition,
+        _offset_prepare_chunk_coordinate,
+        _permute_prepare_root_task_axes,
+        _make_prepare_root_task_origin_noncanonical,
+        _shorten_prepare_root_task_extent,
+    ),
+)
+def test_prepare_rejects_semantic_mutations(
+    mutate: Callable[[DeviceIR], None],
+) -> None:
+    assert _captured_plan_after_mutation(mutate) is None
+
+
+@pytest.mark.parametrize(
+    "component",
+    ("rshift", "bitwise_and", "lshift", "divisor", "byte_multiplier"),
+)
+def test_prepare_rejects_changed_aq_physical_index_constants(
+    component: str,
+) -> None:
+    def mutate(device_ir: DeviceIR) -> None:
+        nodes = _prepare_body_nodes(device_ir)
+        pair_index = next(
+            node
+            for node in nodes
+            if node.op == "call_function"
+            and node.target is torch.ops.aten.div.Tensor_mode
+        )
+        pair_xor = pair_index.args[0]
+        byte_offset = pair_xor.args[0]
+        shifted = pair_xor.args[1]
+        masked = shifted.args[0]
+        rshift = masked.args[0]
+        targets = {
+            "rshift": (rshift, 6),
+            "bitwise_and": (masked, 3),
+            "lshift": (shifted, 3),
+            "divisor": (pair_index, 4),
+            "byte_multiplier": (byte_offset, 4),
+        }
+        node, replacement = targets[component]
+        node.args = (node.args[0], replacement)
+
+    assert _captured_plan_after_mutation(mutate) is None
+
+
+@pytest.mark.parametrize("tensor_name", ("q_rows", "k_rows", "gate_rows", "beta_rows"))
+def test_prepare_rejects_nondefault_masked_load_other(tensor_name: str) -> None:
+    from helion.language import memory_ops
+
+    def mutate(device_ir: DeviceIR) -> None:
+        load = next(
+            node
+            for node in _prepare_body_nodes(device_ir)
+            if node.op == "call_function"
+            and node.target is memory_ops.load
+            and node.args[0].args[0] == tensor_name
+        )
+        load.args = (*load.args[:3], 1.0)
+
+    assert _captured_plan_after_mutation(mutate) is None
+
+
+def test_prepare_rejects_sm80() -> None:
+    assert _captured_plan(capability=(8, 0)) is None
+
+
+def test_prepare_split_workspace_falls_back_during_planning() -> None:
+    assert _captured_plan(packed_workspace=False) is None
+
+
+def test_prepare_packed_workspace_contract() -> None:
+    args = _fake_inputs()
+    refs = tuple(
+        _TensorRef(args[index], name)
+        for index, name in zip(
+            range(9, 14), ("kd", "qd", "ak", "aq", "g_total"), strict=True
+        )
+    )
+    assert _packed_workspace_is_exact(*refs)
+    broken = (*refs[:1], _TensorRef(torch.empty_like(args[10]), "qd"), *refs[2:])
+    assert not _packed_workspace_is_exact(*broken)
+
+
+def test_prepare_schedule_static_contract() -> None:
+    assert PREPARE_DEVICE_THREADS == 128
+
+
+def test_prepare_fuses_raw_a_log_exp2_into_device_kernel() -> None:
+    source = inspect.getsource(emit_bt16_prepare)
+    assert "cutlass.Float32(ga_log[head])" in source
+    assert "* cutlass.Float32(LOG2_E), fastmath=True" in source
+
+
+def test_prepare_block_sparse_inverse_has_six_native_mmas() -> None:
+    emitter_source = inspect.getsource(emit_bt16_prepare)
+    inverse_source = emitter_source.split(
+        "The two diagonal 8x8 blocks share one native m16n8 issue", maxsplit=1
+    )[1].split("# step 7 of the design", maxsplit=1)[0]
+    assert inverse_source.count("mma_blockdiag_8x8_f16(") == 4
+    assert inverse_source.count("mma_m16n8k16_f16(") == 2
+    assert "mma_16x16_f16(" not in inverse_source
+    assert inspect.getsource(mma_blockdiag_8x8_f16).count("mma_m16n8k16_f16(") == 1
+
+
+def test_prepare_input_tma_is_three_full_width_transactions() -> None:
+    source = inspect.getsource(issue_chunk_tma)
+    assert source.count("tma_load_4d(") == 3
+    assert "tma_load_3d(" not in source
+
+
+def test_prepare_uses_tight_mbarrier_waits() -> None:
+    source = inspect.getsource(emit_bt16_prepare)
+    assert source.count("mbar_spin_wait(") == 14
+    assert "cute.arch.mbarrier_wait(" not in source
+    helper_source = inspect.getsource(mbar_spin_wait)
+    assert "mbarrier.try_wait.parity.shared::cta.b64" in helper_source
+    assert "nanosleep." not in helper_source.lower()
+
+
+def test_prepare_aliases_qd_ki_after_split_release() -> None:
+    source = inspect.getsource(emit_bt16_prepare)
+    assert "p_qd = p_q" in source
+    assert "p_ki = p_k" in source
+    assert "allocate_array(cutlass.Int64, 10)" in source
+    assert source.count("mbar_q_released") >= 4
+    assert source.count("mbar_k_released") >= 4
+
+
+@pytest.mark.parametrize(
+    ("total_chunks", "heads", "num_sm", "expected"),
+    (
+        (32, 12, 152, 1),
+        (192, 12, 152, 2),
+        (323, 12, 152, 4),
+        (515, 12, 152, 5),
+        (32, 12, 0, 4),
+    ),
+)
+def test_preferred_split_alias_chunks_per_cta(
+    total_chunks: int, heads: int, num_sm: int, expected: int
+) -> None:
+    assert (
+        _preferred_split_alias_chunks_per_cta(
+            total_chunks=total_chunks,
+            heads=heads,
+            num_sm=num_sm,
+        )
+        == expected
+    )
+
+
+def test_prepare_seed_cache_specializes_on_effective_sm_count() -> None:
+    assert compiler_seed_specialization_facts(
+        "cute", [CuteChunkPrepareHeuristic.name]
+    ) == frozenset({"config_num_sm", "input_tensor_metadata"})
+    assert {
+        num_sm: _preferred_split_alias_chunks_per_cta(
+            total_chunks=92,
+            heads=12,
+            num_sm=num_sm,
+        )
+        for num_sm in (132, 148)
+    } == {132: 2, 148: 1}
+
+
+@pytest.mark.parametrize(
+    ("gate_dtype", "gate_box"),
+    ((torch.bfloat16, (64, 16, 1, 2)), (torch.float32, (32, 16, 1, 4))),
+)
+def test_prepare_descriptor_geometry(
+    gate_dtype: torch.dtype,
+    gate_box: tuple[int, ...],
+) -> None:
+    specs = _chunk_prepare_expected_tensor_map_specs(
+        total_tokens=8192,
+        total_chunks=515,
+        heads=12,
+        q_ptr=0x1000,
+        k_ptr=0x2000,
+        gate_ptr=0x3000,
+        factor_ptr=0x4000,
+        gate_dtype=gate_dtype,
+    )
+    assert tuple(spec.global_dim for spec in specs[:3]) == (
+        (64, 8192, 12, 2),
+        (64, 8192, 12, 2),
+        ((32, 8192, 12, 4) if gate_dtype is torch.float32 else (64, 8192, 12, 2)),
+    )
+    assert specs[0].global_stride_bytes == (3072, 256, 128)
+    assert specs[0].box_dim == (64, 16, 1, 2)
+    assert specs[2].box_dim == gate_box
+    assert specs[3].global_dim == (128, 8240, 36)
+    assert specs[3].global_stride_bytes == (256, 2_109_440)
+    assert specs[3].box_dim == (64, 16, 1)
+
+
+def _runtime_plan() -> dict[str, object]:
+    plan: dict[str, object] = {
+        "kind": "chunk_prepare_tma",
+        "device_abi": 3,
+        "chunk_size": 16,
+        "key_size": 128,
+        "chunks_per_cta": 4,
+        "schedule": "split_alias_cpc4",
+        "outputs_scaled": True,
+        "factor_key_xor": 0,
+        "total_tokens": 128,
+        "total_chunks": 8,
+        "heads": 2,
+        "gate_is_fp32": False,
+    }
+    for index, name in enumerate(
+        (
+            "q",
+            "k",
+            "g",
+            "beta",
+            "a_log",
+            "dt",
+            "cu_seqlens",
+            "cu_chunks",
+            "chunk_to_seq",
+            "kd",
+            "qd",
+            "ak",
+            "aq",
+            "gt",
+        )
+    ):
+        plan[f"{name}_idx"] = index
+    return plan
+
+
+def _runtime_view_args() -> tuple[torch.Tensor, ...]:
+    args = _fake_inputs()
+    return (
+        args[0].view(256, 128),
+        args[1].view(256, 128),
+        args[2].view(256, 128),
+        args[3].view(256),
+        args[4],
+        args[5],
+        args[6],
+        args[7],
+        args[8],
+        args[9].view(256, 128),
+        args[10].view(256, 128),
+        args[11].view(256, 128),
+        args[12].view(16, 256),
+        args[13].view(16, 128),
+    )
+
+
+def test_prepare_runtime_validates_packed_workspace_and_specs() -> None:
+    from torch._subclasses.fake_tensor import FakeTensor
+
+    args = _runtime_view_args()
+    storage_bases = {
+        storage._cdata: 0x10_0000 + index * 0x100_0000
+        for index, storage in enumerate({tensor.untyped_storage() for tensor in args})
+    }
+
+    def storage_data_ptr(storage: object) -> int:
+        return storage_bases[storage._cdata]  # type: ignore[attr-defined]
+
+    def tensor_data_ptr(tensor: FakeTensor) -> int:
+        return (
+            storage_bases[tensor.untyped_storage()._cdata]
+            + tensor.storage_offset() * tensor.element_size()
+        )
+
+    expected_bases = tuple(
+        storage_bases[args[index].untyped_storage()._cdata] for index in (0, 1, 2, 9)
+    )
+    with (
+        patch.object(torch.storage.UntypedStorage, "data_ptr", storage_data_ptr),
+        patch.object(FakeTensor, "data_ptr", tensor_data_ptr),
+    ):
+        specs = _chunk_prepare_tensor_map_specs(_runtime_plan(), args)
+    assert tuple(spec.base_ptr for spec in specs) == expected_bases
+
+    cpc1_plan = _runtime_plan()
+    cpc1_plan["chunks_per_cta"] = 1
+    cpc1_plan["schedule"] = "split_alias_cpc1"
+    with (
+        patch.object(torch.storage.UntypedStorage, "data_ptr", storage_data_ptr),
+        patch.object(FakeTensor, "data_ptr", tensor_data_ptr),
+    ):
+        cpc1_specs = _chunk_prepare_tensor_map_specs(cpc1_plan, args)
+    assert cpc1_specs == specs
+
+    cpc5_plan = _runtime_plan()
+    cpc5_plan["chunks_per_cta"] = 5
+    cpc5_plan["schedule"] = "split_alias_cpc5"
+    with (
+        patch.object(torch.storage.UntypedStorage, "data_ptr", storage_data_ptr),
+        patch.object(FakeTensor, "data_ptr", tensor_data_ptr),
+    ):
+        cpc5_specs = _chunk_prepare_tensor_map_specs(cpc5_plan, args)
+    assert cpc5_specs == specs
+
+
+def test_prepare_runtime_rejects_split_factor_allocations() -> None:
+    from torch._subclasses.fake_tensor import FakeTensor
+
+    args = list(_runtime_view_args())
+    assert isinstance(args[10], FakeTensor)
+    with args[10].fake_mode:
+        args[10] = torch.empty_like(args[10])
+    storage_bases = {
+        storage._cdata: 0x10_0000 + index * 0x100_0000
+        for index, storage in enumerate({tensor.untyped_storage() for tensor in args})
+    }
+
+    def storage_data_ptr(storage: object) -> int:
+        return storage_bases[storage._cdata]  # type: ignore[attr-defined]
+
+    def tensor_data_ptr(tensor: FakeTensor) -> int:
+        return (
+            storage_bases[tensor.untyped_storage()._cdata]
+            + tensor.storage_offset() * tensor.element_size()
+        )
+
+    with (
+        patch.object(torch.storage.UntypedStorage, "data_ptr", storage_data_ptr),
+        patch.object(FakeTensor, "data_ptr", tensor_data_ptr),
+        pytest.raises(exc.BackendUnsupported, match="packed workspace ABI"),
+    ):
+        _chunk_prepare_tensor_map_specs(_runtime_plan(), tuple(args))
+
+
+@pytest.mark.parametrize(
+    ("chunks_per_cta", "grid_x", "schedule"),
+    (
+        (1, 8, "split_alias_cpc1"),
+        (2, 4, "split_alias_cpc2"),
+        (3, 3, "split_alias_cpc3"),
+        (4, 2, "split_alias_cpc4"),
+        (5, 2, "split_alias_cpc5"),
+    ),
+)
+def test_prepare_wrapper_overrides_grid_and_appends_descriptors(
+    chunks_per_cta: int, grid_x: int, schedule: str
+) -> None:
+    from helion.runtime.cute.launcher import _create_cute_wrapper
+
+    def dummy_kernel() -> None:
+        pass
+
+    dummy_kernel._helion_cute_wrapper_plans = [  # type: ignore[attr-defined]
+        {
+            "kind": "chunk_prepare_tma",
+            "desc_args": ("desc_q", "desc_k", "desc_g", "desc_factor"),
+            "total_chunks": 8,
+            "heads": 2,
+            "chunk_size": 16,
+            "key_size": 128,
+            "chunks_per_cta": chunks_per_cta,
+            "schedule": schedule,
+            "outputs_scaled": True,
+            "factor_key_xor": 0,
+            "smem_bytes": 21_968,
+            "bf16_mma_count": 168,
+            "fp16_mma_count": 24,
+            "device_abi": 3,
+        }
+    ]
+    schema = tuple(
+        ("wrapper_host_scalar", name, "int")
+        for name in ("desc_q", "desc_k", "desc_g", "desc_factor")
+    )
+    wrapper = _create_cute_wrapper(dummy_kernel, schema, (128, 1, 1))
+    source = inspect.getsource(wrapper)
+    assert f"grid_x = cutlass.Int32({grid_x})" in source
+    assert "grid_y = cutlass.Int32(2)" in source
+    assert "_kernel(desc_q, desc_k, desc_g, desc_factor).launch" in source
+    assert "block=(128, 1, 1)" in source
+
+
+def test_prepare_descriptor_args_enter_cached_launch_schema() -> None:
+    from helion.runtime.cute import launcher
+
+    def dummy_kernel(*_args: object) -> None:
+        pass
+
+    plan = {
+        "kind": "chunk_prepare_tma",
+        "desc_args": ("desc_q", "desc_k", "desc_g", "desc_factor"),
+    }
+    dummy_kernel._helion_cute_wrapper_plans = [plan]  # type: ignore[attr-defined]
+    tensor = torch.empty(1)
+    args = (*((tensor,) * 14), 0.125, -7.0)
+    descriptor_storage = torch.empty(512, dtype=torch.uint8)
+
+    def fake_imports() -> tuple[object, object, object]:
+        def make_ptr(
+            _dtype: object,
+            data_ptr: int,
+            _space: object,
+            *,
+            assumed_align: int,
+        ) -> tuple[str, int]:
+            assert assumed_align == 16
+            return "ptr", data_ptr
+
+        return object(), make_ptr, object()
+
+    with (
+        patch.object(launcher, "_validate_cute_launcher_tensor"),
+        patch.object(launcher, "_torch_dtype_to_cutlass", side_effect=str),
+        patch.object(launcher, "_get_cute_launcher_imports", side_effect=fake_imports),
+        patch.object(
+            launcher,
+            "_build_chunk_prepare_tensor_maps",
+            return_value=(descriptor_storage, (0x1000, 0x1080, 0x1100, 0x1180)),
+        ),
+    ):
+        built = launcher._build_cute_schema_and_args(dummy_kernel, args, (17, 1, 1))
+
+    assert built.schema[-4:] == (
+        ("wrapper_host_scalar", "desc_q", "int"),
+        ("wrapper_host_scalar", "desc_k", "int"),
+        ("wrapper_host_scalar", "desc_g", "int"),
+        ("wrapper_host_scalar", "desc_factor", "int"),
+    )
+    assert built.launch_args[-7:] == (0x1000, 0x1080, 0x1100, 0x1180, 17, 1, 1)
+    assert built.owned_tensors == (descriptor_storage,)

--- a/test/test_cute_chunk_recurrence.py
+++ b/test/test_cute_chunk_recurrence.py
@@ -1,0 +1,1351 @@
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import gc
+import inspect
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+import weakref
+
+from benchmarks.cute.kda_prefill_kernels import BT
+from benchmarks.cute.kda_prefill_kernels import DK
+from benchmarks.cute.kda_prefill_kernels import DV
+from benchmarks.cute.kda_prefill_kernels import KDA_RECURRENCE_CONFIG as _CONFIG
+from benchmarks.cute.kda_prefill_kernels import (
+    kda_chunk_recurrence as _bt16_resident_chain,
+)
+import pytest
+import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+import helion
+from helion import exc
+from helion._compiler.cute.chunk_recurrence import _select_sm100_dv_partitions
+from helion._testing import DEVICE
+from helion._testing import skipUnlessBackends
+from helion.autotuner.config_generation import ConfigGeneration
+from helion.runtime.cute.launcher import _chunk_recurrence_tensor_map_specs
+
+pytestmark = skipUnlessBackends(["cute"])
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _fake_inputs(
+    *,
+    tokens: int = 128,
+    heads: int = 12,
+    sequences: int = 2,
+    chunks: int = 8,
+    packed_workspace: bool = True,
+) -> tuple[torch.Tensor, ...]:
+    rows = chunks * BT
+    with FakeTensorMode():
+        vector_bytes = heads * rows * DK * 2
+        aq_bytes = heads * chunks * BT * BT * 2
+        gt_bytes = heads * chunks * DK * 4
+        if packed_workspace:
+            workspace = torch.empty(
+                (3 * vector_bytes + aq_bytes + gt_bytes,),
+                device=DEVICE,
+                dtype=torch.uint8,
+            )
+            kd = workspace[:vector_bytes].view(torch.bfloat16).view(1, heads, rows, DK)
+            qd = (
+                workspace[vector_bytes : 2 * vector_bytes]
+                .view(torch.bfloat16)
+                .view(1, heads, rows, DK)
+            )
+            ak = (
+                workspace[2 * vector_bytes : 3 * vector_bytes]
+                .view(torch.bfloat16)
+                .view(1, heads, rows, DK)
+            )
+            aq = (
+                workspace[3 * vector_bytes : 3 * vector_bytes + aq_bytes]
+                .view(torch.bfloat16)
+                .view(1, heads, chunks, BT * BT)
+            )
+            g_total = (
+                workspace[3 * vector_bytes + aq_bytes :]
+                .view(torch.float32)
+                .view(1, heads, chunks, DK)
+            )
+        else:
+            kd = torch.empty((1, heads, rows, DK), device=DEVICE, dtype=torch.bfloat16)
+            qd = torch.empty_like(kd)
+            ak = torch.empty_like(kd)
+            aq = torch.empty(
+                (1, heads, chunks, BT * BT),
+                device=DEVICE,
+                dtype=torch.bfloat16,
+            )
+            g_total = torch.empty(
+                (1, heads, chunks, DK), device=DEVICE, dtype=torch.float32
+            )
+        values = torch.empty(
+            (1, tokens, heads, DV), device=DEVICE, dtype=torch.bfloat16
+        )
+        output = torch.empty_like(values)
+        state = torch.empty(
+            (sequences, heads, DV, DK), device=DEVICE, dtype=torch.bfloat16
+        )
+        cu_seqlens = torch.empty((sequences + 1,), device=DEVICE, dtype=torch.int32)
+        cu_chunks = torch.empty_like(cu_seqlens)
+    return kd, qd, ak, aq, g_total, values, output, state, cu_seqlens, cu_chunks
+
+
+def _code(
+    mutate: Callable[[object], None] | None = None,
+    *,
+    tokens: int = 128,
+    heads: int = 12,
+    sequences: int = 2,
+    chunks: int = 8,
+    capability: tuple[int, int] = (10, 3),
+    num_sm: int = 152,
+    dv_partitions: int | None = None,
+    register_cap: int | None = None,
+    packed_workspace: bool = True,
+) -> str:
+    with (
+        patch(
+            "helion.runtime.kernel.target_device_capability",
+            return_value=capability,
+        ),
+        patch(
+            "helion._compiler.compile_environment.target_device_capability",
+            return_value=capability,
+        ),
+        patch("helion.language.loops.use_tileir_tunables", return_value=False),
+        patch(
+            "helion.language.loops._supports_warp_specialize",
+            return_value=capability >= (10, 0),
+        ),
+        patch(
+            "helion._compat._supports_tensor_descriptor",
+            return_value=capability >= (9, 0),
+        ),
+        patch("helion._compat._min_dot_size", return_value=(16, 16, 16)),
+        patch("helion._compat._is_hip", return_value=False),
+        patch("helion.runtime.get_num_sm", return_value=num_sm),
+    ):
+        bound = _bt16_resident_chain._bind_isolated(
+            (
+                *_fake_inputs(
+                    tokens=tokens,
+                    heads=heads,
+                    sequences=sequences,
+                    chunks=chunks,
+                    packed_workspace=packed_workspace,
+                ),
+                128**-0.5,
+            )
+        )
+        if mutate is not None:
+            mutate(bound.host_function.device_ir)
+        bound.config_spec.target_device_capability = capability
+        bound.config_spec.num_sm = num_sm
+        config_overrides: dict[str, object] = {}
+        if dv_partitions is not None:
+            config_overrides["cute_chunk_recurrence_dv_partitions"] = dv_partitions
+        if register_cap is not None:
+            config_overrides["cute_chunk_recurrence_register_cap"] = register_cap
+        config = helion.Config.from_dict({**_CONFIG.config, **config_overrides})
+        return bound.to_triton_code(config)
+
+
+def _captured_plan(
+    *,
+    mutate: Callable[[object], None] | None = None,
+    capability: tuple[int, int] = (10, 3),
+    packed_workspace: bool = True,
+) -> object:
+    from helion._compiler.cute import chunk_recurrence
+
+    captured: list[object] = []
+    original = chunk_recurrence._plan_chunk_recurrence
+
+    def capture(graphs: object, tile_strategy: object) -> object:
+        result = original(graphs, tile_strategy)  # type: ignore[arg-type]
+        captured.append(result)
+        return result
+
+    with (
+        patch.object(chunk_recurrence, "_plan_chunk_recurrence", side_effect=capture),
+        contextlib.suppress(exc.BackendUnsupported),
+    ):
+        _code(
+            mutate=mutate,
+            capability=capability,
+            packed_workspace=packed_workspace,
+        )
+    assert len(captured) == 1
+    return captured[0]
+
+
+def _config_spec(
+    *, tokens: int, heads: int, sequences: int, chunks: int, num_sm: int = 152
+) -> object:
+    with (
+        patch(
+            "helion.runtime.kernel.target_device_capability",
+            return_value=(10, 3),
+        ),
+        patch(
+            "helion._compiler.compile_environment.target_device_capability",
+            return_value=(10, 3),
+        ),
+        patch("helion.language.loops.use_tileir_tunables", return_value=False),
+        patch("helion.language.loops._supports_warp_specialize", return_value=True),
+        patch("helion._compat._supports_tensor_descriptor", return_value=True),
+        patch("helion._compat._min_dot_size", return_value=(16, 16, 16)),
+        patch("helion._compat._is_hip", return_value=False),
+        patch("helion.runtime.get_num_sm", return_value=num_sm),
+    ):
+        bound = _bt16_resident_chain._bind_isolated(
+            (
+                *_fake_inputs(
+                    tokens=tokens,
+                    heads=heads,
+                    sequences=sequences,
+                    chunks=chunks,
+                ),
+                128**-0.5,
+            )
+        )
+        bound.config_spec.num_sm = num_sm
+        return bound.config_spec
+
+
+def test_bt16_resident_chain_codegen() -> None:
+    code = _code()
+    assert "from helion._compiler.cute.chunk_recurrence_sm100 import" in code
+    assert "_prototype_bt16_chain" not in code
+    assert "'kind': 'chunk_recurrence_sm100'" in code
+    assert "'threads': 512" in code
+    assert "'smem_bytes': 138240" in code
+    assert "'input_stages': 8" in code
+    assert "'tma_stages': 6" in code
+    assert "'factor_tma_value_splits': 2" in code
+    assert "'output_acc_stages': 2" in code
+    assert "'output_smem_stages': 7" in code
+    assert "'output_store_wait_groups': 6" in code
+    assert "'tmem_cols': 512" in code
+    assert "'workspace_layout_version': 2" in code
+    assert "'factor_key_xor': 8" in code
+    assert "'outputs_scaled': False" in code
+    assert "'scale_idx': 10" in code
+    assert "--maxrregcount=" not in code
+    assert "cute.gemm(" not in code
+
+
+def test_tmem_dv2_exposes_only_the_matched_state_contract() -> None:
+    from helion._compiler.cute import chunk_recurrence_sm100 as device
+
+    source = inspect.getsource(device.kernel_chain_dv2)
+    kernel_parameters = inspect.signature(device.kernel_chain_dv2).parameters
+    host_parameters = inspect.signature(device.host_chain_dv2).parameters
+    for removed_parameter in (
+        "state_indices",
+        "initial_state",
+        "final_state",
+        "state_ckpt",
+        "cu_ckpts",
+        "checkpoint_stride_chunks",
+    ):
+        assert removed_parameter not in kernel_parameters
+        assert removed_parameter not in host_parameters
+    assert "checkpoint_read_done" not in source
+
+
+@pytest.mark.parametrize("guard", ("_linear_offsets_fit_i32", "_xyz_grid_fits"))
+def test_bt16_recurrence_unsafe_index_or_launch_geometry_fails_closed(
+    guard: str,
+) -> None:
+    with patch(f"helion._compiler.cute.chunk_recurrence.{guard}", return_value=False):
+        plan = _captured_plan()
+    assert plan is None
+
+
+@pytest.mark.parametrize(
+    ("collision", "expected"),
+    (
+        (
+            "_helion_sm100_warp_dv4_host",
+            "import _recurrence_entry as _helion_sm100_warp_dv4_host_1",
+        ),
+        (
+            "_chunk_recurrence_desc_factor",
+            "'desc_args': ('_chunk_recurrence_desc_factor_1',",
+        ),
+    ),
+)
+def test_bt16_recurrence_generated_names_do_not_shadow_tensor_arguments(
+    collision: str,
+    expected: str,
+) -> None:
+    from helion._compiler.cute import chunk_recurrence
+
+    original = chunk_recurrence._load_ref
+
+    def colliding_name(node: object) -> object:
+        ref = original(node)
+        if ref is not None and ref.name == "value_rows":
+            return dataclasses.replace(ref, name=collision)
+        return ref
+
+    with patch.object(chunk_recurrence, "_load_ref", side_effect=colliding_name):
+        code = _code(dv_partitions=4)
+    assert expected in code
+
+
+def _recurrence_loop_nodes(device_ir: object) -> list[torch.fx.Node]:
+    from helion._compiler.device_ir import ForLoopGraphInfo
+
+    loop = next(
+        graph
+        for graph in device_ir.graphs
+        if isinstance(graph, ForLoopGraphInfo)  # type: ignore[attr-defined]
+    )
+    return list(loop.graph.nodes)
+
+
+def _reverse_residual_subtraction(device_ir: object) -> None:
+    nodes = _recurrence_loop_nodes(device_ir)
+    subtraction = next(
+        node
+        for node in nodes
+        if node.op == "call_function" and node.target is torch.ops.aten.sub.Tensor
+    )
+    subtraction.args = (subtraction.args[1], subtraction.args[0])
+
+
+def _change_factor_feature_xor(device_ir: object) -> None:
+    nodes = _recurrence_loop_nodes(device_ir)
+    xor = next(
+        node
+        for node in nodes
+        if node.op == "call_function"
+        and node.target is torch.ops.aten.bitwise_xor.Scalar
+        and isinstance(node.args[0], torch.fx.Node)
+        and node.args[0].target is torch.ops.prims.iota.default
+        and node.args[1] == 8
+    )
+    xor.args = (xor.args[0], 4)
+
+
+def _change_ak_row_xor(device_ir: object) -> None:
+    nodes = _recurrence_loop_nodes(device_ir)
+    xors = [
+        node
+        for node in nodes
+        if node.op == "call_function"
+        and node.target is torch.ops.aten.bitwise_xor.Scalar
+        and isinstance(node.args[0], torch.fx.Node)
+        and node.args[0].target.__name__ == "tile_index"
+    ]
+    assert len(xors) == 1
+    xors[0].args = (xors[0].args[0], 4)
+
+
+def _change_aq_swizzle_constant(device_ir: object) -> None:
+    nodes = _recurrence_loop_nodes(device_ir)
+    shift = next(
+        node
+        for node in nodes
+        if node.op == "call_function"
+        and node.target is torch.ops.aten.__rshift__.Scalar
+    )
+    shift.args = (shift.args[0], 6)
+
+
+def _swap_update_operands(device_ir: object) -> None:
+    from helion.language.matmul_ops import dot
+
+    dots = [
+        node
+        for node in _recurrence_loop_nodes(device_ir)
+        if node.op == "call_function" and node.target is dot
+    ]
+    update = dots[-1]
+    update.args = (update.args[1], update.args[0], *update.args[2:])
+
+
+def _change_residual_rounding(device_ir: object) -> None:
+    nodes = _recurrence_loop_nodes(device_ir)
+    subtraction = next(
+        node
+        for node in nodes
+        if node.op == "call_function" and node.target is torch.ops.aten.sub.Tensor
+    )
+    rounding = next(
+        node
+        for node in subtraction.users
+        if node.target is torch.ops.prims.convert_element_type.default
+    )
+    rounding.args = (rounding.args[0], torch.float16)
+
+
+def _remove_output_mask(device_ir: object) -> None:
+    from helion.language import memory_ops
+
+    store = next(
+        node
+        for node in _recurrence_loop_nodes(device_ir)
+        if node.op == "call_function" and node.target is memory_ops.store
+    )
+    store.args = (*store.args[:3], None)
+
+
+def _reverse_loop_bound(device_ir: object) -> None:
+    from helion._compiler.device_ir import RootGraphInfo
+    from helion.language._tracing_ops import _for_loop
+
+    root = next(
+        graph
+        for graph in device_ir.graphs
+        if isinstance(graph, RootGraphInfo)  # type: ignore[attr-defined]
+    )
+    loop_call = next(
+        node
+        for node in root.graph.nodes
+        if node.op == "call_function" and node.target is _for_loop
+    )
+    extent = loop_call.args[2][0]
+    extent.args = (extent.args[1], extent.args[0])
+
+
+def _replace_state_head_with_sequence_coordinate(device_ir: object) -> None:
+    from helion._compiler.device_ir import RootGraphInfo
+    from helion.language import memory_ops
+
+    root = next(
+        graph
+        for graph in device_ir.graphs
+        if isinstance(graph, RootGraphInfo)  # type: ignore[attr-defined]
+    )
+    state_accesses = [
+        node
+        for node in root.graph.nodes
+        if node.op == "call_function"
+        and node.target in (memory_ops.load, memory_ops.store)
+        and node.args[0].args[0] == "state"
+    ]
+    assert len(state_accesses) == 2
+    sequence_coordinate = state_accesses[0].args[1][0]
+    for node in state_accesses:
+        indices = list(node.args[1])
+        indices[1] = sequence_coordinate
+        node.args = (node.args[0], indices, *node.args[2:])
+
+
+def _change_value_size_dimension(device_ir: object) -> None:
+    size = next(
+        node
+        for node in _recurrence_loop_nodes(device_ir)
+        if node.op == "call_function" and node.target is torch.ops.aten.sym_size.int
+    )
+    size.args = (size.args[0], 1)
+
+
+def _replace_state_value_with_head_coordinate(device_ir: object) -> None:
+    from helion._compiler.device_ir import RootGraphInfo
+    from helion.language import memory_ops
+
+    root = next(
+        graph
+        for graph in device_ir.graphs
+        if isinstance(graph, RootGraphInfo)  # type: ignore[attr-defined]
+    )
+    state_accesses = [
+        node
+        for node in root.graph.nodes
+        if node.op == "call_function"
+        and node.target in (memory_ops.load, memory_ops.store)
+        and node.args[0].args[0] == "state"
+    ]
+    assert len(state_accesses) == 2
+    head_coordinate = state_accesses[0].args[1][1]
+    for node in state_accesses:
+        indices = list(node.args[1])
+        indices[2] = head_coordinate
+        node.args = (node.args[0], indices, *node.args[2:])
+
+
+def _disconnect_token_tile_id_from_lane(device_ir: object) -> None:
+    from helion.language.tile_ops import tile_id
+    from helion.language.tile_ops import tile_index
+
+    nodes = _recurrence_loop_nodes(device_ir)
+    tile_ids = [node for node in nodes if node.target is tile_id]
+    tile_indices = [node for node in nodes if node.target is tile_index]
+    assert len(tile_ids) == 2
+    assert len(tile_indices) == 4
+    head_block_size = tile_ids[1].args[0]
+    assert isinstance(head_block_size, torch.fx.Node)
+    tile_ids[0].prepend(head_block_size)
+    tile_ids[0].args = (head_block_size,)
+
+
+def _permute_root_task_axes(device_ir: object) -> None:
+    axes = list(device_ir.task_families[0].axes)  # type: ignore[attr-defined]
+    axes[0], axes[1] = axes[1], axes[0]
+    device_ir.task_families[0] = dataclasses.replace(  # type: ignore[attr-defined]
+        device_ir.task_families[0],  # type: ignore[attr-defined]
+        axes=tuple(axes),
+    )
+
+
+def _make_root_task_origin_noncanonical(device_ir: object) -> None:
+    axes = list(device_ir.task_families[0].axes)  # type: ignore[attr-defined]
+    axes[0] = dataclasses.replace(axes[0], canonical_origin=False)
+    device_ir.task_families[0] = dataclasses.replace(  # type: ignore[attr-defined]
+        device_ir.task_families[0],  # type: ignore[attr-defined]
+        axes=tuple(axes),
+    )
+
+
+def _shorten_root_task_extent(device_ir: object) -> None:
+    axes = list(device_ir.task_families[0].axes)  # type: ignore[attr-defined]
+    extent = axes[0].extent
+    assert extent is not None and not isinstance(extent, str)
+    axes[0] = dataclasses.replace(axes[0], extent=extent - 1)
+    device_ir.task_families[0] = dataclasses.replace(  # type: ignore[attr-defined]
+        device_ir.task_families[0],  # type: ignore[attr-defined]
+        axes=tuple(axes),
+    )
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    (
+        _reverse_residual_subtraction,
+        _change_factor_feature_xor,
+        _change_ak_row_xor,
+        _change_aq_swizzle_constant,
+        _swap_update_operands,
+        _change_residual_rounding,
+        _remove_output_mask,
+        _reverse_loop_bound,
+        _replace_state_head_with_sequence_coordinate,
+        _change_value_size_dimension,
+        _replace_state_value_with_head_coordinate,
+        _disconnect_token_tile_id_from_lane,
+        _permute_root_task_axes,
+        _make_root_task_origin_noncanonical,
+        _shorten_root_task_extent,
+    ),
+)
+def test_bt16_recurrence_rejects_semantic_mutations(
+    mutate: Callable[[object], None],
+) -> None:
+    assert _captured_plan(mutate=mutate) is None
+
+
+def test_bt16_recurrence_rejects_sm80() -> None:
+    assert _captured_plan(capability=(8, 0)) is None
+
+
+def test_bt16_recurrence_split_workspace_falls_back_during_planning() -> None:
+    assert _captured_plan(packed_workspace=False) is None
+
+
+@pytest.mark.parametrize(
+    ("total_tokens", "total_chunks"),
+    ((0, 8), (128, 0)),
+)
+def test_bt16_recurrence_empty_geometry_falls_back_before_schedule_policy(
+    total_tokens: int, total_chunks: int
+) -> None:
+    from helion._compiler.cute import chunk_recurrence
+
+    original_match = chunk_recurrence._match_chunk_recurrence_graphs
+
+    def match_all_empty(graphs: object) -> object:
+        match = original_match(graphs)  # type: ignore[arg-type]
+        assert match is not None
+        return dataclasses.replace(
+            match,
+            total_tokens=total_tokens,
+            total_chunks=total_chunks,
+        )
+
+    with (
+        patch.object(
+            chunk_recurrence,
+            "_match_chunk_recurrence_graphs",
+            side_effect=match_all_empty,
+        ),
+        patch.object(chunk_recurrence, "_select_sm100_dv_partitions") as select,
+    ):
+        assert _captured_plan() is None
+
+    select.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("total_tokens", "total_chunks"),
+    ((0, 8), (128, 0)),
+)
+def test_bt16_recurrence_empty_geometry_disables_schedule_search(
+    total_tokens: int, total_chunks: int
+) -> None:
+    from helion._compiler.cute import chunk_recurrence
+
+    original_match = chunk_recurrence._match_chunk_recurrence_graphs
+
+    def match_all_empty(graphs: object) -> object:
+        match = original_match(graphs)  # type: ignore[arg-type]
+        assert match is not None
+        return dataclasses.replace(
+            match,
+            total_tokens=total_tokens,
+            total_chunks=total_chunks,
+        )
+
+    with (
+        patch.object(
+            chunk_recurrence,
+            "_match_chunk_recurrence_graphs",
+            side_effect=match_all_empty,
+        ),
+        patch.object(chunk_recurrence, "_select_sm100_dv_partitions") as select,
+    ):
+        _config_spec(tokens=128, heads=12, sequences=2, chunks=8)
+
+    select.assert_not_called()
+
+
+@pytest.mark.parametrize("register_cap", (72, 76, 80))
+def test_bt16_resident_chain_register_cap_reaches_compile_options(
+    register_cap: int,
+) -> None:
+    code = _code(dv_partitions=4, register_cap=register_cap)
+    assert f"--maxrregcount={register_cap}" in code
+
+
+def test_sm100_dv_partition_policy_is_geometry_derived() -> None:
+    assert (
+        _select_sm100_dv_partitions(total_chunks=32, sequences=1, heads=12, num_sm=152)
+        == 4
+    )
+    assert (
+        _select_sm100_dv_partitions(total_chunks=515, sequences=6, heads=12, num_sm=152)
+        == 2
+    )
+
+
+def test_bt16_recurrence_autotune_seeds_both_dv_schedules() -> None:
+    fixed = _config_spec(tokens=512, heads=12, sequences=1, chunks=32)
+    packed = _config_spec(tokens=8192, heads=12, sequences=6, chunks=515)
+    assert fixed.cute_chunk_recurrence_dv_partitions.choices == (4, 2)
+    assert packed.cute_chunk_recurrence_dv_partitions.choices == (2, 4)
+    assert fixed.cute_chunk_recurrence_register_cap.choices == (None, 72, 76, 80)
+    assert packed.cute_chunk_recurrence_register_cap.choices == (None, 72, 76, 80)
+    assert fixed.compiler_default_config.config == {
+        "cute_chunk_recurrence_dv_partitions": 4,
+        "cute_chunk_recurrence_register_cap": 72,
+    }
+    assert packed.compiler_default_config.config == {
+        "cute_chunk_recurrence_dv_partitions": 2,
+        "cute_chunk_recurrence_register_cap": None,
+    }
+    recurrence_keys = {
+        "cute_chunk_recurrence_dv_partitions",
+        "cute_chunk_recurrence_register_cap",
+    }
+    fixed_recurrence_seeds = [
+        seed
+        for seed in fixed.compiler_seed_configs
+        if set(seed.config) == recurrence_keys
+    ]
+    packed_recurrence_seeds = [
+        seed
+        for seed in packed.compiler_seed_configs
+        if set(seed.config) == recurrence_keys
+    ]
+    assert all(
+        seed.config["cute_chunk_recurrence_dv_partitions"] != 2
+        or seed.config["cute_chunk_recurrence_register_cap"] is None
+        for seed in (*fixed_recurrence_seeds, *packed_recurrence_seeds)
+    )
+    assert {
+        seed.config["cute_chunk_recurrence_register_cap"]
+        for seed in fixed_recurrence_seeds
+        if seed.config["cute_chunk_recurrence_dv_partitions"] == 4
+    } == {72, 76, 80, None}
+    fixed_seed_schedules = [
+        seed.config["cute_chunk_recurrence_dv_partitions"]
+        for seed in fixed_recurrence_seeds
+    ]
+    packed_seed_schedules = [
+        seed.config["cute_chunk_recurrence_dv_partitions"]
+        for seed in packed_recurrence_seeds
+    ]
+    assert list(dict.fromkeys(fixed_seed_schedules)) == [4, 2]
+    assert list(dict.fromkeys(packed_seed_schedules)) == [2, 4]
+    fixed_seed_caps = [
+        seed.config["cute_chunk_recurrence_register_cap"]
+        for seed in fixed_recurrence_seeds
+    ]
+    assert list(dict.fromkeys(fixed_seed_caps)) == [72, 76, 80, None]
+    generated_seed_schedules = [
+        config.config["cute_chunk_recurrence_dv_partitions"]
+        for _flat, config in ConfigGeneration(fixed).seed_flat_config_pairs()
+    ]
+    assert list(dict.fromkeys(generated_seed_schedules)) == [4, 2]
+    assert [
+        dimension.values
+        for dimension in packed.iter_search_dimensions()
+        if dimension.name == "cute_chunk_recurrence_dv_partitions"
+    ] == [[2, 4]]
+    assert [
+        dimension.values
+        for dimension in packed.iter_search_dimensions()
+        if dimension.name == "cute_chunk_recurrence_register_cap"
+    ] == [[None, 72, 76, 80]]
+    assert (
+        _select_sm100_dv_partitions(total_chunks=33, sequences=1, heads=12, num_sm=152)
+        == 2
+    )
+    assert (
+        _select_sm100_dv_partitions(total_chunks=32, sequences=1, heads=40, num_sm=152)
+        == 2
+    )
+
+
+def test_bt16_recurrence_dv_partition_config_is_strictly_scoped() -> None:
+    spec = _config_spec(tokens=512, heads=12, sequences=1, chunks=32)
+    with pytest.raises(
+        exc.InvalidConfig,
+        match="cute_chunk_recurrence_dv_partitions must be one of",
+    ):
+        spec.normalized_config(
+            helion.Config.from_dict(
+                {
+                    **_CONFIG.config,
+                    "cute_chunk_recurrence_dv_partitions": 3,
+                }
+            )
+        )
+
+    spec.cute_chunk_recurrence_dv_partitions = None
+    with pytest.raises(
+        exc.InvalidConfig,
+        match="available only for matched BT16 chunk-recurrence kernels",
+    ):
+        spec.normalized_config(
+            helion.Config.from_dict(
+                {
+                    **_CONFIG.config,
+                    "cute_chunk_recurrence_dv_partitions": 4,
+                }
+            )
+        )
+
+    repaired = helion.Config.from_dict(
+        {
+            **_CONFIG.config,
+            "cute_chunk_recurrence_dv_partitions": 4,
+        }
+    )
+    spec.normalize(repaired, _fix_invalid=True)
+    assert "cute_chunk_recurrence_dv_partitions" not in repaired.config
+
+
+def test_bt16_recurrence_register_cap_config_is_strictly_scoped() -> None:
+    spec = _config_spec(tokens=512, heads=12, sequences=1, chunks=32)
+    with pytest.raises(
+        exc.InvalidConfig,
+        match="cute_chunk_recurrence_register_cap must be one of",
+    ):
+        spec.normalized_config(
+            helion.Config.from_dict(
+                {
+                    **_CONFIG.config,
+                    "cute_chunk_recurrence_register_cap": 64,
+                }
+            )
+        )
+
+    spec.cute_chunk_recurrence_register_cap = None
+    with pytest.raises(
+        exc.InvalidConfig,
+        match="available only for matched BT16 chunk-recurrence kernels",
+    ):
+        spec.normalized_config(
+            helion.Config.from_dict(
+                {
+                    **_CONFIG.config,
+                    "cute_chunk_recurrence_register_cap": 72,
+                }
+            )
+        )
+
+    repaired = helion.Config.from_dict(
+        {
+            **_CONFIG.config,
+            "cute_chunk_recurrence_register_cap": 72,
+        }
+    )
+    spec.normalize(repaired, _fix_invalid=True)
+    assert "cute_chunk_recurrence_register_cap" not in repaired.config
+
+
+def test_bt16_recurrence_rejects_register_caps_for_tmem_dv2() -> None:
+    spec = _config_spec(tokens=8192, heads=12, sequences=6, chunks=515)
+    unsafe = helion.Config.from_dict(
+        {
+            **_CONFIG.config,
+            "cute_chunk_recurrence_dv_partitions": 2,
+            "cute_chunk_recurrence_register_cap": 72,
+        }
+    )
+
+    with pytest.raises(
+        exc.InvalidConfig,
+        match="must be None.*TMEM schedule dynamically reallocates registers",
+    ):
+        spec.normalized_config(unsafe)
+
+    spec.normalize(unsafe, _fix_invalid=True)
+    assert unsafe["cute_chunk_recurrence_dv_partitions"] == 2
+    assert unsafe["cute_chunk_recurrence_register_cap"] is None
+
+
+def test_bt16_resident_chain_selects_warp_dv4_when_short_and_underfilled() -> None:
+    code = _code(tokens=512, sequences=1, chunks=32, num_sm=152)
+    assert "chunk_recurrence_warp_dv4" in code
+    assert "chunk_recurrence_dv4_sm100 import _recurrence_entry" in code
+    assert "'threads': 192" in code
+    assert "'smem_bytes': 97536" in code
+    assert "'dv_partitions': 4" in code
+    assert "'workspace_layout_version': 2" in code
+    assert "'factor_key_xor': 8" in code
+    assert "'outputs_scaled': False" in code
+
+    forced_dv2 = _code(
+        tokens=512,
+        sequences=1,
+        chunks=32,
+        num_sm=152,
+        dv_partitions=2,
+    )
+    assert "'kind': 'chunk_recurrence_sm100'" in forced_dv2
+    assert "chunk_recurrence_warp_dv4" not in forced_dv2
+
+
+def test_bt16_resident_chain_keeps_tmem_dv2_for_packed_geometry() -> None:
+    code = _code(tokens=8192, sequences=6, chunks=515, num_sm=152)
+    assert "'kind': 'chunk_recurrence_sm100'" in code
+    assert "'threads': 512" in code
+    assert "'dv_partitions': 2" in code
+    assert "chunk_recurrence_warp_dv4" not in code
+
+    forced_dv4 = _code(
+        tokens=8192,
+        sequences=6,
+        chunks=515,
+        num_sm=152,
+        dv_partitions=4,
+    )
+    assert "chunk_recurrence_warp_dv4" in forced_dv4
+    assert "'dv_partitions': 4" in forced_dv4
+
+
+def test_dv4_uses_semantic_length_when_chunk_metadata_disagrees() -> None:
+    from helion._compiler.cute.chunk_recurrence_dv4_sm100 import emit_bt16_recurrence
+
+    # Adversarial metadata: the chunk offsets claim one chunk for 17 tokens.
+    # The Helion carrier and DV2 execute ceil(17 / 16) == 2 chunks, so DV4 must
+    # derive the same bound from sequence lengths instead of trusting the delta.
+    token_start, token_end = 0, 17
+    chunk_start, chunk_end = 0, 1
+    assert (token_end - token_start + BT - 1) // BT == 2
+    assert chunk_end - chunk_start == 1
+
+    source = inspect.getsource(emit_bt16_recurrence)
+    assert source.startswith("@cute.kernel\n")
+    assert "num_chunks = cute.ceil_div(token_end - token_start, BT)" in source
+    assert "gcu_chunks[seq + 1]" not in source
+
+
+def _runtime_plan(
+    *, tokens: int = 128, heads: int = 12, sequences: int = 2, chunks: int = 8
+) -> dict[str, object]:
+    plan: dict[str, object] = {
+        "kind": "chunk_recurrence_warp_dv4",
+        "workspace_layout_version": 2,
+        "outputs_scaled": False,
+        "factor_key_xor": 8,
+        "chunk_size": BT,
+        "key_size": DK,
+        "value_size": DV,
+        "total_tokens": tokens,
+        "total_chunks": chunks,
+        "heads": heads,
+        "sequences": sequences,
+    }
+    for index, name in enumerate(
+        (
+            "kd",
+            "qd",
+            "ak",
+            "aq",
+            "gt",
+            "v",
+            "out",
+            "state",
+            "cu_seqlens",
+            "cu_chunks",
+        )
+    ):
+        plan[f"{name}_idx"] = index
+    return plan
+
+
+def _runtime_view_args() -> tuple[torch.Tensor, ...]:
+    args = _fake_inputs()
+    return (
+        args[0].view(-1, DK),
+        args[1].view(-1, DK),
+        args[2].view(-1, DK),
+        args[3].view(-1, BT * BT),
+        args[4].view(-1, DK),
+        args[5].view(-1, DV),
+        args[6].view(-1, DV),
+        args[7],
+        args[8],
+        args[9],
+    )
+
+
+def _fake_pointer_patches(
+    args: tuple[torch.Tensor, ...],
+) -> tuple[object, object]:
+    from torch._subclasses.fake_tensor import FakeTensor
+
+    storage_bases = {
+        storage._cdata: 0x10_0000 + index * 0x100_0000
+        for index, storage in enumerate({tensor.untyped_storage() for tensor in args})
+    }
+
+    def storage_data_ptr(storage: object) -> int:
+        return storage_bases[storage._cdata]  # type: ignore[attr-defined]
+
+    def tensor_data_ptr(tensor: FakeTensor) -> int:
+        return (
+            storage_bases[tensor.untyped_storage()._cdata]
+            + tensor.storage_offset() * tensor.element_size()
+        )
+
+    return (
+        patch.object(torch.storage.UntypedStorage, "data_ptr", storage_data_ptr),
+        patch.object(FakeTensor, "data_ptr", tensor_data_ptr),
+    )
+
+
+def test_chunk_recurrence_runtime_validates_packed_workspace() -> None:
+    args = _runtime_view_args()
+    storage_patch, tensor_patch = _fake_pointer_patches(args)
+    with storage_patch, tensor_patch:
+        specs = _chunk_recurrence_tensor_map_specs(_runtime_plan(), args)
+    assert specs["factor"].global_dim == (128, 128, 36)
+    assert specs["aq"].global_dim == (256, 8, 12)
+    assert specs["gt"].global_dim == (128, 8, 12)
+    assert specs["v"].global_dim == (128, 128, 12)
+    assert specs["out"].global_dim == (128, 128, 12)
+    assert specs["state_in"].global_dim == (64, 256, 24)
+    assert specs["state_in"] == specs["state_out"]
+
+
+def test_chunk_recurrence_runtime_rejects_legacy_abi1() -> None:
+    args = _runtime_view_args()
+    plan = _runtime_plan()
+    plan.update(
+        {
+            "kind": "chunk_recurrence_tma",
+            "workspace_layout_version": 1,
+            "outputs_scaled": True,
+            "factor_key_xor": 0,
+        }
+    )
+    with pytest.raises(
+        exc.BackendUnsupported, match="unsupported chunk-recurrence ABI"
+    ):
+        _chunk_recurrence_tensor_map_specs(plan, args, validate_only=True)
+
+
+def test_chunk_recurrence_runtime_builds_dv4_tensor_map_geometry() -> None:
+    args = _runtime_view_args()
+    plan = _runtime_plan()
+    plan.update(
+        {
+            "kind": "chunk_recurrence_warp_dv4",
+            "workspace_layout_version": 2,
+            "outputs_scaled": False,
+            "factor_key_xor": 8,
+        }
+    )
+    storage_patch, tensor_patch = _fake_pointer_patches(args)
+    with storage_patch, tensor_patch:
+        specs = _chunk_recurrence_tensor_map_specs(plan, args)
+    assert specs["v"].box_dim == (32, 16, 1)
+    assert specs["out"].box_dim == (32, 16, 1)
+    assert specs["state_in"].box_dim == (64, 64, 1)
+    assert specs["state_in"] == specs["state_out"]
+
+
+def test_chunk_recurrence_runtime_validates_sm100_dv2_without_raw_descriptors() -> None:
+    args = _runtime_view_args()
+    plan = _runtime_plan()
+    plan.update({"kind": "chunk_recurrence_sm100", "dv_partitions": 2})
+    storage_patch, tensor_patch = _fake_pointer_patches(args)
+    with storage_patch, tensor_patch:
+        assert _chunk_recurrence_tensor_map_specs(plan, args, validate_only=True) == {}
+        with pytest.raises(
+            exc.BackendUnsupported,
+            match="raw chunk-recurrence TensorMaps require the warp-DV4 schedule",
+        ):
+            _chunk_recurrence_tensor_map_specs(plan, args)
+
+
+def test_chunk_recurrence_runtime_allows_exact_value_output_alias() -> None:
+    args = list(_runtime_view_args())
+    args[6] = args[5]
+    runtime_args = tuple(args)
+    storage_patch, tensor_patch = _fake_pointer_patches(runtime_args)
+    with storage_patch, tensor_patch:
+        specs = _chunk_recurrence_tensor_map_specs(_runtime_plan(), runtime_args)
+    assert specs["v"].base_ptr == specs["out"].base_ptr
+
+
+@pytest.mark.parametrize(
+    ("metadata_index", "metadata_name"),
+    ((8, "cu_seqlens"), (9, "cu_chunks")),
+)
+def test_chunk_recurrence_runtime_rejects_output_metadata_alias(
+    metadata_index: int,
+    metadata_name: str,
+) -> None:
+    args = list(_runtime_view_args())
+    original_output = args[6]
+    original_metadata = args[metadata_index]
+    assert isinstance(original_output, torch.Tensor)
+    assert isinstance(original_metadata, torch.Tensor)
+    with original_output.fake_mode:
+        storage = torch.empty(
+            original_output.numel() * original_output.element_size(),
+            dtype=torch.uint8,
+            device=original_output.device,
+        )
+        args[6] = storage.view(torch.bfloat16).view(original_output.shape)
+        args[metadata_index] = (
+            storage[: original_metadata.numel() * original_metadata.element_size()]
+            .view(torch.int32)
+            .view(original_metadata.shape)
+        )
+    runtime_args = tuple(args)
+    storage_patch, tensor_patch = _fake_pointer_patches(runtime_args)
+    with (
+        storage_patch,
+        tensor_patch,
+        pytest.raises(
+            exc.BackendUnsupported,
+            match=rf"chunk-recurrence output aliases {metadata_name}",
+        ),
+    ):
+        _chunk_recurrence_tensor_map_specs(_runtime_plan(), runtime_args)
+
+
+def test_chunk_recurrence_sm100_dv2_enters_launch_schema() -> None:
+    from helion.runtime.cute import launcher
+
+    def dummy_kernel(*_args: object) -> None:
+        pass
+
+    args = _runtime_view_args()
+    plan = _runtime_plan()
+    plan.update({"kind": "chunk_recurrence_sm100", "dv_partitions": 2})
+    dummy_kernel._helion_cute_wrapper_plans = [plan]  # type: ignore[attr-defined]
+
+    def fake_imports() -> tuple[object, object, object]:
+        def make_ptr(
+            _dtype: object,
+            data_ptr: int,
+            _space: object,
+            *,
+            assumed_align: int,
+        ) -> tuple[str, int]:
+            assert assumed_align == 16
+            return "ptr", data_ptr
+
+        return object(), make_ptr, object()
+
+    storage_patch, tensor_patch = _fake_pointer_patches(args)
+    with (
+        storage_patch,
+        tensor_patch,
+        patch.object(launcher, "_get_cute_launcher_imports", side_effect=fake_imports),
+        patch.object(launcher, "_torch_dtype_to_cutlass", side_effect=str),
+    ):
+        built = launcher._build_cute_schema_and_args(dummy_kernel, args, (17, 12, 1))
+
+    assert len(built.schema) == len(args)
+    assert not any(entry[0] == "wrapper_host_scalar" for entry in built.schema)
+    assert built.launch_args[-3:] == (17, 12, 1)
+    assert built.owned_tensors == ()
+
+
+def test_chunk_recurrence_dv4_wrapper_uses_external_host_schedule() -> None:
+    from helion.runtime.cute.launcher import _create_cute_wrapper
+
+    def dummy_kernel(*_args: object) -> None:
+        pass
+
+    descriptor_names = tuple(f"desc_{index}" for index in range(7))
+    plan = _runtime_plan(tokens=512, heads=12, sequences=1, chunks=32)
+    plan.update(
+        {
+            "kind": "chunk_recurrence_warp_dv4",
+            "desc_args": descriptor_names,
+            "workspace_layout_version": 2,
+            "outputs_scaled": False,
+            "factor_key_xor": 8,
+            "threads": 192,
+            "smem_bytes": 97_536,
+            "device_abi": 3,
+            "input_stages": 6,
+            "tma_stages": 6,
+            "factor_tma_value_splits": 1,
+            "output_acc_stages": 2,
+            "output_smem_stages": 3,
+            "output_store_wait_groups": 0,
+            "tmem_cols": 0,
+            "dv_partitions": 4,
+            "scale_idx": 10,
+        }
+    )
+    dummy_kernel._helion_cute_wrapper_plans = [plan]  # type: ignore[attr-defined]
+    tensor_schema = tuple(("tensor", torch.bfloat16, 1, (1,), (1,)) for _ in range(10))
+    schema = (
+        *tensor_schema,
+        ("scalar", "float"),
+        *(("wrapper_host_scalar", name, "int") for name in descriptor_names),
+    )
+    wrapper = _create_cute_wrapper(dummy_kernel, schema, (320, 1, 1))
+    source = inspect.getsource(wrapper)
+    assert "grid_x = cutlass.Int32(4)" in source
+    assert "grid_y = cutlass.Int32(12)" in source
+    assert "_helion_sm100_warp_dv4_host(" in source
+    assert "cutlass.Float32(arg10)" in source
+    assert "block=(320, 1, 1)" not in source
+
+
+def test_chunk_recurrence_runtime_rejects_split_factor_storage() -> None:
+    args = list(_runtime_view_args())
+    with args[1].fake_mode:
+        args[1] = torch.empty_like(args[1])
+    runtime_args = tuple(args)
+    storage_patch, tensor_patch = _fake_pointer_patches(runtime_args)
+    with (
+        storage_patch,
+        tensor_patch,
+        pytest.raises(exc.BackendUnsupported, match="packed workspace ABI"),
+    ):
+        _chunk_recurrence_tensor_map_specs(_runtime_plan(), runtime_args)
+
+
+def _require_dv4_runtime() -> torch.device:
+    from helion._compat import requires_cuda_version
+
+    if not torch.cuda.is_available() or not requires_cuda_version("13"):
+        pytest.skip("DV4 CUDA-graph runtime test requires CUDA >= 13")
+    pytest.importorskip("cutlass.cute")
+    device = torch.device("cuda", torch.cuda.current_device())
+    if torch.cuda.get_device_capability(device)[0] != 10:
+        pytest.skip("DV4 CUDA-graph runtime test requires SM100")
+    return device
+
+
+def _dv4_runtime_args(
+    device: torch.device,
+    *,
+    value: float,
+    decay: float,
+    identity_aq: bool,
+) -> tuple[object, ...]:
+    from benchmarks.cute.kda_prefill_staged import allocate_kda_factor_workspace
+
+    heads = 1
+    tokens = 2 * BT
+    chunks = 2
+    workspace = allocate_kda_factor_workspace(heads, chunks, device)
+    workspace.kd.zero_()
+    workspace.qd.zero_()
+    workspace.ak.zero_()
+    workspace.aq.zero_()
+    workspace.g_total.fill_(decay)
+    if identity_aq:
+        lane = torch.arange(BT, dtype=torch.int64, device=device)
+        byte_offset = 2 * (lane[:, None] * BT + (lane[None, :] ^ 8))
+        pair_index = (byte_offset ^ (((byte_offset >> 7) & 1) << 4)) // 2
+        workspace.aq.view(-1, BT * BT)[:, pair_index] = torch.eye(
+            BT, dtype=torch.bfloat16, device=device
+        )
+    value_output = torch.full(
+        (1, tokens, heads, DV), value, dtype=torch.bfloat16, device=device
+    )
+    state = torch.full((1, heads, DV, DK), 0.25, dtype=torch.bfloat16, device=device)
+    cu_seqlens = torch.tensor((0, tokens), dtype=torch.int32, device=device)
+    cu_chunks = torch.tensor((0, chunks), dtype=torch.int32, device=device)
+    return (
+        workspace.kd,
+        workspace.qd,
+        workspace.ak,
+        workspace.aq,
+        workspace.g_total,
+        value_output,
+        value_output,
+        state,
+        cu_seqlens,
+        cu_chunks,
+        2.0,
+    )
+
+
+def test_dv4_cuda_graph_descriptor_lifetime_after_launch_cache_eviction() -> None:
+    """Captured raw TensorMap pointers survive launch-cache eviction."""
+
+    from helion.runtime.cute import launcher
+
+    device = _require_dv4_runtime()
+    original_args = _dv4_runtime_args(device, value=0.125, decay=0.5, identity_aq=True)
+    config = helion.Config.from_dict(
+        {
+            **_CONFIG.config,
+            "cute_chunk_recurrence_dv_partitions": 4,
+        }
+    )
+    bound = _bt16_resident_chain.bind(original_args)
+    compiled = bound.compile_config(config)
+    cute_kernel = compiled.__globals__["_helion_kda_chunk_recurrence"]
+    assert cute_kernel._helion_cute_wrapper_plans[0]["kind"] == (
+        "chunk_recurrence_warp_dv4"
+    )
+
+    def exercise_capture(*, managed: bool) -> None:
+        for attribute in (
+            "_helion_cute_launch_arg_cache",
+            "_helion_cute_last_launch_cache",
+            "_helion_cute_capture_owned_launch_tensors",
+        ):
+            cute_kernel.__dict__.pop(attribute, None)
+
+        value_output = original_args[5]
+        state = original_args[7]
+        assert isinstance(value_output, torch.Tensor)
+        assert value_output is original_args[6]
+        assert isinstance(state, torch.Tensor)
+
+        value_output.fill_(0.125)
+        state.fill_(0.25)
+        compiled(*original_args)
+        torch.cuda.synchronize(device)
+        torch.testing.assert_close(
+            value_output,
+            torch.full_like(value_output, 0.25),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            state,
+            torch.full_like(state, 0.0625),
+            rtol=0,
+            atol=0,
+        )
+
+        launch_cache = cute_kernel._helion_cute_launch_arg_cache
+        assert len(launch_cache) == 1
+        captured_entry = next(iter(launch_cache.values()))
+        assert len(captured_entry.owned_tensors) == 1
+        descriptor = captured_entry.owned_tensors[0]
+        descriptor_ref = weakref.ref(descriptor)
+        descriptor_ptr = descriptor.data_ptr()
+
+        capture_stream = torch.cuda.Stream(device=device)
+        if managed:
+            with launcher.cute_cuda_graph(stream=capture_stream) as graph:
+                compiled(*original_args)
+        else:
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph, stream=capture_stream):
+                compiled(*original_args)
+        torch.cuda.synchronize(device)
+
+        capture_cache = cute_kernel._helion_cute_capture_owned_launch_tensors
+        assert len(capture_cache) == 1
+        assert any(
+            tensor is descriptor
+            for tensors in capture_cache.values()
+            for tensor in tensors.values()
+        )
+
+        alternate_args = [
+            _dv4_runtime_args(
+                device,
+                value=float(signature),
+                decay=0.75,
+                identity_aq=False,
+            )
+            for signature in range(1, launcher._CUTE_LAUNCH_ARG_CACHE_LIMIT + 2)
+        ]
+        for args in alternate_args:
+            compiled(*args)
+        torch.cuda.synchronize(device)
+
+        assert len(launch_cache) == launcher._CUTE_LAUNCH_ARG_CACHE_LIMIT
+        assert all(entry is not captured_entry for entry in launch_cache.values())
+        del captured_entry, descriptor
+        gc.collect()
+        retained_descriptor = descriptor_ref()
+        assert retained_descriptor is not None
+        assert retained_descriptor.data_ptr() == descriptor_ptr
+        del retained_descriptor
+
+        value_output.fill_(0.25)
+        state.fill_(0.25)
+        torch.cuda.synchronize(device)
+        graph.replay()
+        torch.cuda.synchronize(device)
+        torch.testing.assert_close(
+            value_output,
+            torch.full_like(value_output, 0.5),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            state,
+            torch.full_like(state, 0.0625),
+            rtol=0,
+            atol=0,
+        )
+
+        del graph
+        gc.collect()
+        if managed:
+            assert capture_cache == {}
+            assert descriptor_ref() is None
+        else:
+            # Raw torch.cuda.graph does not expose its owner to the launcher,
+            # so its descriptor remains conservatively retained.
+            assert descriptor_ref() is not None
+            capture_cache.clear()
+            gc.collect()
+            assert descriptor_ref() is None
+
+    exercise_capture(managed=True)
+    exercise_capture(managed=False)

--- a/test/test_cute_warp_dv_partition.py
+++ b/test/test_cute_warp_dv_partition.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+
+from helion._testing import skipUnlessBackends
+
+pytest.importorskip("cutlass")
+pytest.importorskip("cutlass.cute")
+pytestmark = skipUnlessBackends(["cute"])
+decomp = importlib.import_module("helion._compiler.cute.chunk_recurrence_dv4_sm100")
+primitives = importlib.import_module("helion._compiler.cute.kda_device_primitives")
+
+
+def test_warp_dv4_geometry_and_arena() -> None:
+    assert decomp.RECURRENCE_DV_PARTITIONS == 4
+    assert decomp.DV_HALF == 32
+    assert decomp.COMPUTE_WARPS == 4
+    assert decomp.REC_THREADS == 192
+    assert decomp.INPUT_STAGES == 6
+    assert decomp.VO_VECTORS_PER_ROW == 4
+    assert decomp.OUTPUT_TAIL_TASKS == 64
+    assert decomp.OUTPUT_TAIL_ROUNDS == 2
+    assert decomp.SMEM_DYNAMIC_BYTES == 97_536
+
+
+def test_warp_dv4_tensor_map_geometry() -> None:
+    specs = decomp.recurrence_tensor_map_specs(
+        kd_ptr=0x100000,
+        aq_ptr=0x200000,
+        gt_ptr=0x300000,
+        v_ptr=0x400000,
+        out_ptr=0x500000,
+        heads=12,
+        total_tokens=8192,
+        total_chunks=515,
+        sequences=6,
+        state_ptr=0x600000,
+    )
+    assert specs["v"].box_dim == (32, 16, 1)
+    assert specs["v"].swizzle == "NONE"
+    assert specs["out"].box_dim == (32, 16, 1)
+    assert specs["state_in"].box_dim == (64, 64, 1)
+    assert specs["state_in"] == specs["state_out"]
+
+    # The diagnostic DV32 schedule uses a linear V/O stage to isolate its
+    # fragment mapping from the S64 TensorMap swizzle.
+    for row in range(16):
+        for column in range(32):
+            assert decomp.vo_idx(row, column) == row * 32 + column
+
+
+def test_v2_workspace_factor_key_permutation() -> None:
+    for lane in range(32):
+        matrix_id = lane // 8
+        row = lane % 8 + 8 * (matrix_id % 2)
+        for key_block in range(8):
+            logical_key = key_block * 16 + 8 * (matrix_id // 2)
+            assert decomp.factor_a_fragment_ptr(lane, key_block) == (
+                decomp.factor_idx(row, logical_key ^ 8)
+            )
+
+
+def test_warp_dv4_uses_shared_device_primitives() -> None:
+    for name in (
+        "ldmatrix_x2",
+        "ldmatrix_x2_trans",
+        "ldmatrix_x4_trans",
+        "mma_m16n8k16_bf16",
+        "movmatrix_b16",
+        "pack_bf16x2",
+        "stmatrix_x2",
+        "stmatrix_x2_trans",
+        "store_vec8_bf16",
+        "tma_load_3d",
+        "tma_store_3d",
+        "tma_store_commit_group",
+        "tma_store_wait_read",
+        "vec8_bf16",
+        "warp_arrive",
+    ):
+        assert getattr(decomp, name) is getattr(primitives, name)
+
+
+def test_warp_dv4_exposes_only_the_matched_state_contract() -> None:
+    source = inspect.getsource(decomp.emit_bt16_recurrence)
+    entry_source = inspect.getsource(decomp._recurrence_entry)
+    spec_parameters = inspect.signature(decomp.recurrence_tensor_map_specs).parameters
+    for removed_parameter in (
+        "FACTOR_KEY_XOR",
+        "HAS_STATE_IN",
+        "HAS_STATE_OUT",
+        "STATE_FP32",
+    ):
+        assert removed_parameter not in source
+        assert removed_parameter not in entry_source
+    assert "state_ptr" in spec_parameters
+    assert "state_in_ptr" not in spec_parameters
+    assert "state_out_ptr" not in spec_parameters
+    assert "state_dtype" not in spec_parameters

--- a/test/test_kda_prefill_staged.py
+++ b/test/test_kda_prefill_staged.py
@@ -1,16 +1,26 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+import math
 from typing import Any
 
 from benchmarks.cute import kda_prefill_staged
+from benchmarks.cute.kda_prefill_kernels import KDA_PREPARE_CONFIG
+from benchmarks.cute.kda_prefill_kernels import KDA_RECURRENCE_CONFIG
+from benchmarks.cute.kda_prefill_kernels import kda_chunk_prepare
+from benchmarks.cute.kda_prefill_kernels import kda_chunk_recurrence
 from benchmarks.cute.kda_prefill_staged import CuteOriginAuxDag
 from benchmarks.cute.kda_prefill_staged import KdaStagedResources
 from benchmarks.cute.kda_prefill_staged import allocate_kda_factor_workspace
+from benchmarks.cute.kda_prefill_staged import create_staged_kda_resources
 from benchmarks.cute.kda_prefill_staged import kda_group_host_metadata
 from benchmarks.cute.kda_prefill_staged import staged_longest_partition
 import pytest
 import torch
+
+import helion
+from helion._testing import skipUnlessBackends
+from helion.runtime.cute.launcher import cute_cuda_graph
 
 
 @pytest.mark.parametrize(
@@ -427,3 +437,198 @@ def _safe_gate_token_reference(
             state = state.to(torch.bfloat16).float()
 
     return output, state.to(torch.bfloat16)
+
+
+@pytest.mark.parametrize(
+    ("dv_partitions", "expected_kind"),
+    (
+        (2, "chunk_recurrence_sm100"),
+        (4, "chunk_recurrence_warp_dv4"),
+    ),
+)
+@skipUnlessBackends(["cute"])
+def test_fixed_h12_t512_staged_prefill_numerical_cuda(
+    dv_partitions: int,
+    expected_kind: str,
+) -> None:
+    device = _require_sm100_runtime()
+    generator = torch.Generator(device=device).manual_seed(20260907)
+    tokens = 512
+    heads = 12
+    width = 128
+    shape = (1, tokens, heads, width)
+
+    def random_bf16(tensor_shape: tuple[int, ...]) -> torch.Tensor:
+        return torch.randn(
+            tensor_shape,
+            generator=generator,
+            dtype=torch.float32,
+            device=device,
+        ).to(torch.bfloat16)
+
+    q = random_bf16(shape)
+    k = random_bf16(shape)
+    q[:, 0].fill_(1.0e-5)
+    k[:, 0].fill_(1.0e-5)
+    gate = random_bf16(shape)
+    beta_logits = random_bf16(shape[:-1])
+    values = random_bf16(shape)
+    a_log = torch.rand(heads, generator=generator, dtype=torch.float32, device=device)
+    dt_bias = torch.rand(
+        (heads, width), generator=generator, dtype=torch.float32, device=device
+    )
+    initial_state = (
+        torch.randn(
+            (1, heads, width, width),
+            generator=generator,
+            dtype=torch.float32,
+            device=device,
+        )
+        * 0.25
+    ).to(torch.bfloat16)
+    state = initial_state.clone()
+    output = torch.empty_like(values)
+    scale = width**-0.5
+    lower_bound = -5.0
+    gate_scale_log2 = lower_bound * math.log2(math.e)
+
+    expected_output, expected_state = _safe_gate_token_reference(
+        q,
+        k,
+        gate,
+        beta_logits,
+        a_log,
+        dt_bias,
+        values,
+        initial_state,
+        lower_bound=lower_bound,
+        scale=scale,
+    )
+    resources = create_staged_kda_resources((0, tokens), heads=heads, device=device)
+    group = resources.critical
+    metadata = group.metadata
+    workspace = group.workspace
+    prepare_args = (
+        q,
+        k,
+        gate,
+        beta_logits,
+        a_log,
+        dt_bias,
+        metadata.cu_seqlens,
+        metadata.cu_chunks,
+        metadata.chunk_to_seq,
+        workspace.kd,
+        workspace.qd,
+        workspace.ak,
+        workspace.aq,
+        workspace.g_total,
+        None,
+        gate_scale_log2,
+    )
+    recurrence_args = (
+        workspace.kd,
+        workspace.qd,
+        workspace.ak,
+        workspace.aq,
+        workspace.g_total,
+        values,
+        output,
+        state,
+        metadata.cu_seqlens,
+        metadata.cu_chunks,
+        scale,
+    )
+    prepare = kda_chunk_prepare.bind(prepare_args).compile_config(
+        helion.Config.from_dict(
+            {
+                **KDA_PREPARE_CONFIG.config,
+                "cute_chunk_prepare_schedule": "split_alias_cpc2",
+            }
+        ),
+        allow_print=False,
+    )
+    recurrence_config = {
+        **KDA_RECURRENCE_CONFIG.config,
+        "cute_chunk_recurrence_dv_partitions": dv_partitions,
+    }
+    if dv_partitions == 4:
+        recurrence_config["cute_chunk_recurrence_register_cap"] = 72
+    recurrence = kda_chunk_recurrence.bind(recurrence_args).compile_config(
+        helion.Config.from_dict(recurrence_config),
+        allow_print=False,
+    )
+    prepare_device = prepare.__globals__["_helion_kda_chunk_prepare"]
+    recurrence_device = recurrence.__globals__["_helion_kda_chunk_recurrence"]
+    assert prepare_device._helion_cute_wrapper_plans[0]["kind"] == "chunk_prepare_tma"
+    assert recurrence_device._helion_cute_wrapper_plans[0]["kind"] == expected_kind
+
+    actual_output, actual_state = kda_prefill_staged.launch_staged_kda_prefill(
+        resources,
+        q=q,
+        k=k,
+        gate=gate,
+        beta_logits=beta_logits,
+        a_log=a_log,
+        dt_bias=dt_bias,
+        values=values,
+        output=output,
+        state=state,
+        scale=scale,
+        gate_scale_log2=gate_scale_log2,
+        prepare_kernels=(prepare,),
+        recurrence_kernels=(recurrence,),
+    )
+    torch.cuda.synchronize(device)
+
+    assert actual_output is output
+    assert actual_state is state
+    torch.testing.assert_close(
+        actual_output.float(), expected_output, atol=2e-2, rtol=1e-2
+    )
+    torch.testing.assert_close(
+        actual_state.float(), expected_state.float(), atol=2e-2, rtol=1e-2
+    )
+
+    state.copy_(initial_state)
+    with cute_cuda_graph() as captured:
+        kda_prefill_staged.launch_staged_kda_prefill(
+            resources,
+            q=q,
+            k=k,
+            gate=gate,
+            beta_logits=beta_logits,
+            a_log=a_log,
+            dt_bias=dt_bias,
+            values=values,
+            output=output,
+            state=state,
+            scale=scale,
+            gate_scale_log2=gate_scale_log2,
+            prepare_kernels=(prepare,),
+            recurrence_kernels=(recurrence,),
+        )
+    # The captured prepare launch must read and transform raw A_log on every
+    # replay; a host-precomputed decay buffer would silently stay stale here.
+    a_log.add_(0.75)
+    mutated_output, mutated_state = _safe_gate_token_reference(
+        q,
+        k,
+        gate,
+        beta_logits,
+        a_log,
+        dt_bias,
+        values,
+        initial_state,
+        lower_bound=lower_bound,
+        scale=scale,
+    )
+    state.copy_(initial_state)
+    output.fill_(float("nan"))
+    captured.replay()
+    torch.cuda.synchronize(device)
+
+    torch.testing.assert_close(output.float(), mutated_output, atol=2e-2, rtol=1e-2)
+    torch.testing.assert_close(
+        state.float(), mutated_state.float(), atol=2e-2, rtol=1e-2
+    )


### PR DESCRIPTION
Stacked PRs:
 * __->__#3591
 * #3590
 * #3589
 * #3588
 * #3587


--- --- ---

### [cutedsl] Add exact KDA chunk kernels

This adds the CuTe device paths used by KDA prefill: chunk preparation with
split/alias schedules, SM100 chunk recurrence with DV partitioning, shared KDA
device primitives, staged-resource and graph ownership support, and the tuning
controls for topology, preparation, partitions, and register caps.

The path is structurally matched and fail-closed, but intentionally exact:
BT16, DK=DV=128, and SM100-family targets. It is a KDA-specific whole-root
specialization rather than a general chunk-recurrence IR.

#### Latest GB300 prefill results

| Workload | Baseline | Baseline (µs) | Helion (µs) | Speedup |
| --- | --- | ---: | ---: | ---: |
| Fixed T512 H12 | CAKE | 33.520 | 29.408 | **1.1398×** |
| Fixed T512 H12 | FlashInfer CuTe | 37.632 | 29.424 | **1.2790×** |
| Packed-mixed H12 | CAKE | 142.048 | 123.040 | **1.1545×** |
| Packed-mixed H12 | FlashInfer CuTe | 139.968 | 123.040 | **1.1376×** |

Against the fastest tested baseline, Helion is **13.98% faster** on fixed T512
and **13.76% faster** on packed-mixed prefill.

These are the latest clean prefill measurements on an NVIDIA GB300 at 1400 W.
The search covered all 25 fixed-shape and 250 packed-mixed candidates. Winners
were then checked in a fresh process with four private graph slots per provider,
cold L2, balanced ordering, thermal cooldown, and a shared correctness oracle.
The committed benchmark replays the winning configurations; the exhaustive
search orchestration itself is not included in this stack.

The SM100 recurrence code is adapted from FlashInfer's NVIDIA BSD-3-Clause
implementation, with its attribution and license headers retained. Maintainers
should confirm whether a repository-level third-party notice is also wanted.
Raw `torch.cuda.graph` captures keep descriptor owners for process lifetime;
`cute_cuda_graph.reset()` releases them deterministically. A small dedicated
packed-mixed runtime regression would still be useful in follow-up.