### PR TITLE
Fix range pipelining alias analysis for tensor metadata

### DIFF
--- a/helion/_compiler/ast_read_writes.py
+++ b/helion/_compiler/ast_read_writes.py
@@ -6,11 +6,36 @@ import typing
 from typing import TYPE_CHECKING
 from typing import TypeVar
 
+from .ast_extension import ExtendedAST
+
 if TYPE_CHECKING:
     _A = TypeVar("_A", bound=ast.AST)
 
 
 HELION_LANE_LOOP_VAR_ATTR = "_helion_lane_loop_var"
+
+# Accessing these tensor attributes only reads host-side metadata, not tensor
+# storage.  Keep counting them as ordinary reads for liveness, but identify them
+# separately for analyses that specifically care about memory dependencies.
+# Keep this list conservative: unknown tensor attributes remain storage reads.
+_TENSOR_METADATA_ATTRIBUTES = frozenset(
+    {"device", "dim", "dtype", "ndim", "ndimension", "shape", "size", "stride"}
+)
+
+
+def _is_tensor_metadata_read(node: ast.Attribute) -> bool:
+    if (
+        not isinstance(node.ctx, ast.Load)
+        or node.attr not in _TENSOR_METADATA_ATTRIBUTES
+        or not isinstance(node.value, ExtendedAST)
+    ):
+        return False
+
+    # Import lazily: type_info imports CompileEnvironment, whose finalization
+    # imports this module after type propagation has annotated the AST.
+    from .type_info import TensorType
+
+    return isinstance(node.value._type_info, TensorType)
 
 
 # TODO(oulgen): This visitor is extremely primitive, does not consider alpha renaming or scopes
@@ -18,6 +43,7 @@ class _ReadWriteVisitor(ast.NodeVisitor):
     def __init__(self) -> None:
         super().__init__()
         self.rw = ReadWrites(
+            collections.Counter(),
             collections.Counter(),
             collections.Counter(),
             collections.Counter(),
@@ -33,6 +59,11 @@ class _ReadWriteVisitor(ast.NodeVisitor):
 
     def visit_Name(self, node: ast.Name) -> None:
         self._update(node.id, node.ctx)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if _is_tensor_metadata_read(node) and isinstance(node.value, ast.Name):
+            self.rw.tensor_metadata_reads[node.value.id] += 1
+        self.generic_visit(node)
 
     def visit_Subscript(self, node: ast.Subscript) -> None:
         if isinstance(node.value, ast.Name):
@@ -86,6 +117,9 @@ class ReadWrites(typing.NamedTuple):
     # methods inside kernels (e.g. x.copy_(), x.fill_()), the visitor should
     # be updated to detect those as well.
     inplace_writes: dict[str, int]
+    # Reads of tensor shape/type/device metadata do not access tensor storage.
+    # They remain present in ``reads`` for general dependency tracking.
+    tensor_metadata_reads: dict[str, int]
     # AugAssign targets are reads semantically, but branch argument ordering
     # historically placed them with writes. Keep that ordering stable while
     # exposing the read to analyses that consume ``reads`` directly.

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -898,10 +898,13 @@ class CompileEnvironment:
             if not isinstance(node, ast.For) or not isinstance(node, ExtendedAST):
                 continue
             rw = ReadWrites.from_list(node.body)
+            # Name traversal sees the target passed to an in-place store and
+            # host-side tensor metadata as reads, but neither reads storage.
             reads = {
                 canonical_host_tensor_name(name, aliases)
                 for name, count in rw.reads.items()
-                if count > rw.inplace_writes.get(name, 0)
+                if count
+                > rw.inplace_writes.get(name, 0) + rw.tensor_metadata_reads.get(name, 0)
             }
             reads.update(
                 canonical_host_tensor_name(name, aliases) for name in rw.atomic_reads

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -107,6 +107,29 @@ def atomic_then_independent_reduction(
     return x, out
 
 
+@helion.kernel()
+def store_with_output_metadata(x: torch.Tensor, out: torch.Tensor) -> None:
+    for tile in hl.tile(x.size(0), block_size=1):
+        _metadata = (
+            out.device,
+            out.dim(),
+            out.dtype,
+            out.ndim,
+            out.ndimension(),
+            out.shape,
+            out.size(),
+            out.stride(),
+        )
+        hl.store(out, [tile], x[tile].to(out.dtype))
+
+
+@helion.kernel()
+def store_with_output_read(x: torch.Tensor, out: torch.Tensor) -> None:
+    for tile in hl.tile(x.size(0), block_size=1):
+        prior = hl.load(out, [tile])
+        hl.store(out, [tile], (x[tile] + prior).to(out.dtype))
+
+
 @onlyBackends(["triton", "cute", "pallas"])
 class TestLoops(RefEagerTestBase, TestCase):
     @skipIfRefEager("StaticLoopUnroller unit test does not execute a kernel")
@@ -1042,6 +1065,26 @@ class TestLoops(RefEagerTestBase, TestCase):
         args = (torch.randn([16, 16], device=DEVICE),)
         spec = nested_loop_kernel.bind(args).config_spec
         self.assertGreater(len(spec.range_num_stages), 0)
+
+    @xfailIfPallas("range_num_stages is Triton-specific")
+    @skipIfTileIR("tileir backend will ignore `range_num_stages` hint")
+    @skipIfRefEager("not supported in ref eager mode")
+    def test_output_metadata_read_does_not_disable_range_num_stages(self):
+        x = torch.randn([16], device=DEVICE)
+        out = torch.empty_like(x)
+        spec = store_with_output_metadata.bind((x, out)).config_spec
+        self.assertGreater(len(spec.range_num_stages), 0)
+        normalized = spec.normalized_config(
+            helion.Config(pid_type="persistent_blocked", range_num_stages=[1])
+        )
+        self.assertEqual(normalized.range_num_stages, [1])
+
+    @skipIfRefEager("not supported in ref eager mode")
+    def test_output_data_read_disables_range_num_stages(self):
+        x = torch.randn([16], device=DEVICE)
+        out = torch.empty_like(x)
+        spec = store_with_output_read.bind((x, out)).config_spec
+        self.assertEqual(len(spec.range_num_stages), 0)
 
     @skipIfRefEager("not supported in ref eager mode")
     def test_range_num_stages_removed_for_inplace_kernel(self):


### PR DESCRIPTION
Fixes the B200 kda_varlen benchmark failure:

  InvalidConfig: Too many values for config['range_num_stages'], expected 0, got 1

  _disable_range_num_stages_for_aliasing() incorrectly treated metadata access in:

  hl.store(out, ..., value.to(out.dtype))

  as a tensor-data read, making the loop appear read/write and disabling its valid pipelining configuration.

  This change:

  - Tracks metadata reads separately for typed tensor attributes.
  - Keeps unknown attributes conservatively classified as reads.
  - Preserves pipelining for metadata-only access.
  - Still disables pipelining for actual loads and atomics.
