### PR TITLE
Make cross-loop readiness tests worker-count agnostic

### DIFF
--- a/test/test_cross_loop_codegen.py
+++ b/test/test_cross_loop_codegen.py
@@ -658,6 +658,13 @@ class TestCrossLoopCodegenHelpers(TestCase):
 
 @onlyBackends(["triton"])
 class TestCrossLoopCodegen(RefEagerTestBase, TestCase):
+    def assertUsesExactReadiness(self, code: str) -> None:
+        self.assertTrue(
+            "tile_dependency_continuation_previous" in code
+            or "tile_dependency_readiness_wait" in code,
+            "expected a final-arrival continuation or an exact readiness wait",
+        )
+
     @skipIfNotCUDA()
     @skipIfRefEager("persistent tile-dependency codegen is unavailable")
     def test_nested_producer_iterations_publish_readiness(self) -> None:
@@ -760,7 +767,7 @@ class TestCrossLoopCodegen(RefEagerTestBase, TestCase):
                     torch.testing.assert_close(out, ((x + launch) + 1) * 2)
                 self.assertNotIn("tile_dependency_root_barrier", code)
                 if producer_width < consumer_width:
-                    self.assertIn("tile_dependency_continuation_previous", code)
+                    self.assertUsesExactReadiness(code)
                     self.assertNotIn("tile_dependency_task_wait", code)
                 else:
                     self.assertIn("tile_dependency_readiness_wait", code)
@@ -806,20 +813,23 @@ class TestCrossLoopCodegen(RefEagerTestBase, TestCase):
                 num_warps=1,
             )
             torch.testing.assert_close(out, torch.sum(x + launch + 1).reshape(1))
-        self.assertGreaterEqual(code.count("tile_dependency_continuation_previous"), 2)
         continuation_lines = [
             line
             for line in code.splitlines()
             if "tile_dependency_continuation_previous" in line
             and "tl.atomic_add" in line
         ]
-        self.assertEqual(len(continuation_lines), 2)
+        self.assertGreaterEqual(len(continuation_lines), 1)
+        self.assertLessEqual(len(continuation_lines), 2)
         for line in continuation_lines:
             self.assertIn(f"* {_CROSS_LOOP_COUNTER_ALIGNMENT_WORDS}", line)
-        self.assertIn(
-            f"+ {16 * _CROSS_LOOP_COUNTER_ALIGNMENT_WORDS} +",
-            continuation_lines[1],
-        )
+        if len(continuation_lines) == 2:
+            self.assertIn(
+                f"+ {16 * _CROSS_LOOP_COUNTER_ALIGNMENT_WORDS} +",
+                continuation_lines[1],
+            )
+        else:
+            self.assertIn("tile_dependency_readiness_wait", code)
         self.assertNotIn("tile_dependency_task_wait", code)
         self.assertIn("tile_dependency_root_barrier_wait", code)
 
@@ -1039,7 +1049,7 @@ class TestCrossLoopCodegen(RefEagerTestBase, TestCase):
 
                 torch.testing.assert_close(out, (x + 1) * 2)
                 self.assertNotIn("tile_dependency_task_wait", code)
-                self.assertIn("tile_dependency_continuation_previous", code)
+                self.assertUsesExactReadiness(code)
                 self.assertNotIn("tile_dependency_root_barrier", code)
 
     @skipIfNotCUDA()
@@ -1402,6 +1412,6 @@ class TestCrossLoopCodegen(RefEagerTestBase, TestCase):
         ).reshape(1, 128) @ w2.float()
         torch.testing.assert_close(out, expected, rtol=3e-2, atol=3e-2)
         self.assertNotIn("tile_dependency_root_barrier", code)
-        self.assertIn("tile_dependency_continuation_previous", code)
+        self.assertUsesExactReadiness(code)
         self.assertIn("tile_dependency_nested_loop_wait", code)
         self.assertNotIn("tile_dependency_cohort_wait", code)

--- a/test/test_cross_loop_scheduler.py
+++ b/test/test_cross_loop_scheduler.py
@@ -2360,6 +2360,39 @@ class TestCrossLoopScheduler(TestCase):
             frozenset(),
         )
 
+    def test_idle_tail_capacity_changes_exact_readiness_strategy(self) -> None:
+        dependency_graph = _dependency_graph(
+            [[10], [20]],
+            _access(root=0, kind="store", shape=(256,), block_ids=(10,)),
+            _access(root=1, kind="load", shape=(256,), block_ids=(20,)),
+        )
+        kwargs = {
+            "dependency_graph": dependency_graph,
+            "root_domains": (
+                _domain((10, 16, 16)),
+                _domain((20, 8, 32)),
+            ),
+            "axis_geometry": {10: (16, 16), 20: (8, 32)},
+        }
+
+        tail_overlap = _configured_static_pipeline_plan(
+            **kwargs,
+            worker_count=14,
+        )
+        full_wave = _configured_static_pipeline_plan(
+            **kwargs,
+            worker_count=16,
+        )
+
+        (tail_counter,) = tail_overlap.readiness_counters
+        (full_wave_counter,) = full_wave.readiness_counters
+        self.assertIsNone(tail_counter.continuation_consumer)
+        self.assertIsNotNone(placement(tail_overlap.worker_schedule, 1, 0))
+        self.assertIsNotNone(full_wave_counter.continuation_consumer)
+        self.assertIsNone(placement(full_wave.worker_schedule, 1, 0))
+        self.assertEqual(tail_overlap.root_barrier_edges, frozenset())
+        self.assertEqual(full_wave.root_barrier_edges, frozenset())
+
     def test_nested_split_nested_loop_at_readiness_follow_worker_readiness(
         self,
     ) -> None:


### PR DESCRIPTION
  Cross-loop scheduling may legitimately choose either a final-arrival continuation or an exact readiness wait depending on the available worker count.    
  Several GPU tests assumed the continuation strategy, causing failures on 14-SM configurations.

  This change:

  - Accepts either valid strategy in hardware-dependent codegen tests.
  - Preserves validation of emitted continuation-counter alignment.
  - Adds deterministic scheduler coverage showing the readiness-wait choice at 14 workers and continuation choice at 16 workers.
  - Makes no production-code changes.
