### PR TITLE
[Pallas] Bound each TPU bridge kernel so one slow kernel cannot lose the sweep

### DIFF
--- a/.github/workflows/benchmark_tpu_bridge.yml
+++ b/.github/workflows/benchmark_tpu_bridge.yml
@@ -91,12 +91,26 @@ jobs:
           popd
           popd
 
+      # Backstop under the 6h job limit: a job cancelled at that limit skips
+      # every remaining step, so the results collected so far are lost. Failing
+      # the step instead keeps the upload below reachable. Kept well under 6h
+      # because setup builds torch_tpu from source, which is only fast on a
+      # remote-cache hit.
       - name: Run TPU Benchmark (bridge)
+        timeout-minutes: 240
         run: |
           rm -rf /tmp/torchinductor_*/ || true
           source .venv/bin/activate
           TEST_REPORTS_DIR=$(pwd)/test/test-reports
           mkdir -p "$TEST_REPORTS_DIR"
+
+          # Wall-clock the kernel loop may consume, leaving room under the
+          # step's timeout-minutes to still report and upload. Per-kernel caps
+          # are clamped to what remains so a few slow kernels cannot starve the
+          # rest.
+          SWEEP_BUDGET_S=$(( 200 * 60 ))
+          sweep_start=$SECONDS
+          incomplete_kernels=()
 
           KERNEL_LIST="${{ inputs.kernels }}"
           for kernel in ${KERNEL_LIST//,/ }; do
@@ -131,7 +145,31 @@ jobs:
             case "$kernel" in
               kl_div|welford) PRECISION=fp32 ;;
             esac
+            # Cap each kernel at HELION_BENCHMARK_KERNEL_TIMEOUT. The bridge
+            # shells out to tritonbench's runner, which never reads that
+            # variable (only run_tpu.py does), so enforce it here with
+            # `timeout`. A kernel whose autotune runs long is abandoned and the
+            # sweep moves on, instead of consuming the whole job's budget and
+            # taking every other kernel's results down with it.
+            # --kill-after escalates to SIGKILL: a run wedged inside an XLA
+            # compile does not necessarily service SIGTERM.
+            #
+            # Resolve the duration in a subshell that has env-vars applied.
+            # Bash expands a command's arguments before applying that command's
+            # own scoped assignments, so writing `env-vars timeout "$VAR"`
+            # directly would always use the job default and silently drop a
+            # caller's override.
+            kernel_timeout=$(${{ inputs.env-vars }} bash -c 'printf %s "$HELION_BENCHMARK_KERNEL_TIMEOUT"')
+            remaining=$(( SWEEP_BUDGET_S - (SECONDS - sweep_start) ))
+            if (( remaining <= 60 )); then
+              echo "⏭️ $kernel skipped: sweep budget exhausted"
+              incomplete_kernels+=("$kernel(skipped)")
+              continue
+            fi
+            (( kernel_timeout > remaining )) && kernel_timeout=$remaining
+            kernel_status=0
             ${{ inputs.env-vars }} HELION_PRINT_OUTPUT_CODE=1 HELION_MEASURE_COMPILE_TIME=1 \
+              timeout --kill-after=60 "$kernel_timeout" \
               python benchmarks/run.py \
                 --op $kernel \
                 --device tpu \
@@ -147,8 +185,22 @@ jobs:
                 --rtol 1e-2 \
                 --output "$TEST_REPORTS_DIR/helionbench.json" \
                 --append-to-output \
-                --keep-going
-            echo "✅ $kernel"
+                --keep-going || kernel_status=$?
+            # 124 = timeout fired; 137 = SIGKILL, either timeout's escalation or
+            # an OOM kill, so report the code rather than asserting a cause.
+            if (( kernel_status == 124 || kernel_status == 137 )); then
+              echo "⏱️ $kernel did not finish within ${kernel_timeout}s (exit $kernel_status)"
+              incomplete_kernels+=("$kernel")
+            elif (( kernel_status != 0 )); then
+              echo "❌ $kernel exited $kernel_status"
+              incomplete_kernels+=("$kernel")
+            else
+              echo "✅ $kernel"
+            fi
+            # Reap any survivor still holding the chip; otherwise every later
+            # kernel fails to acquire it. Bracket the pattern so the match
+            # cannot hit this shell.
+            pkill -9 -f "[b]enchmarks/run.py" || true
           done
 
           if [[ ! -s "$TEST_REPORTS_DIR/helionbench.json" ]]; then
@@ -157,8 +209,22 @@ jobs:
           fi
           cat "$TEST_REPORTS_DIR/helionbench.json"
 
+          # Fail once the results are on disk: the upload step runs regardless,
+          # so the kernels that did finish still reach the dashboard, but a
+          # dropped kernel stays visible instead of passing as a green run with
+          # a silently missing column.
+          if (( ${#incomplete_kernels[@]} > 0 )); then
+            echo "❌ did not complete: ${incomplete_kernels[*]}"
+            exit 1
+          fi
+
+      # Upload whatever the sweep produced, including when a kernel timed out or
+      # failed above: results are appended per kernel, so a partial sweep still
+      # carries every kernel that finished.
       - name: Upload the benchmark results to GitHub
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: benchmark-results-${{ inputs.alias }}
           path: test/test-reports
+          if-no-files-found: warn


### PR DESCRIPTION
The bridge runs every kernel in a single bash loop and uploads `helionbench.json` in one step after the loop finishes. `HELION_BENCHMARK_KERNEL_TIMEOUT` is declared in the job env, but only `run_tpu.py` reads it, so nothing bounded a kernel on the bridge path.

Welford stopped publishing to the dashboard after 2026-08-05, while the rest of the bridge stayed healthy — it is still flagged `infra_missing` there today. On 2026-09-01 its autotune became slow enough to consume the whole job budget rather than just dropping its own column. It ran until the 6h GitHub job limit, and because reaching that limit *cancels* the job, every remaining step is skipped — so the upload never ran and all seven kernels' results were lost rather than just welford's.

The dashboard shows the blast radius: `gemm` and the other healthy kernels have daily data through 2026-08-31, then nothing from 2026-09-01 to 2026-09-07, then daily data again from 2026-09-08. Seven days of six healthy kernels lost to one slow one. Publishing resumed on its own — no workflow change was involved, `kernels_tpu_bridge` still lists welford, and welford still has not published since 2026-08-05 — so the trap is intact and will fire again the next time any kernel runs long.

This makes the declared timeout real and keeps a partial sweep useful:

- each kernel runs under `timeout`, so one that runs long is abandoned and the sweep continues
- the per-kernel cap is clamped to the sweep's remaining budget, so a few slow kernels cannot starve the ones behind them
- the run step gets its own `timeout-minutes` below the 6h job cap, so it *fails* instead of being cancelled, which keeps the upload reachable
- the step still fails when any kernel was dropped, so a partial sweep does not pass as a green run with a silently missing dashboard column

### Why not just drop welford from the list?

That fixes today's symptom and leaves the trap armed: any kernel that later runs long takes the whole sweep down with it, silently. Losing six healthy kernels was caused by the missing per-kernel bound and the all-or-nothing upload, not by welford specifically. Welford's own cost is worth addressing separately.

### Note for reviewers

This workflow is `on: workflow_call`, reached only through `benchmark_dispatch.yml`, so no pull-request check exercises the changed file — CI status on this PR is not evidence either way.

A dispatch run on this branch (`kernels_tpu_bridge="welford,gemm"`, welford ordered first) exercised the path end to end instead: welford was abandoned after 60m07s with `⏱️ welford did not finish within 3600s (exit 124)`, gemm then ran to completion in 12.5 minutes — confirming the chip is reacquirable after the kill — the step failed with `❌ did not complete: welford`, and the upload step still ran and produced an artifact containing gemm's results. The job finished in 1h16m rather than reaching the 6h cap; the same sweep on main uploads nothing. Not covered by that run: the step-level `timeout-minutes` and the budget-exhaustion path, since neither triggers in a short sweep.

Overriding `HELION_BENCHMARK_KERNEL_TIMEOUT` via `env-vars` needs the duration resolved in a subshell that has those overrides applied: bash expands a command's arguments before applying that command's own scoped assignments, so passing the variable directly would silently use the job default.


