### PR TITLE
[Pallas] Benchmark rms_norm-bwd at fp32 on the TPU bridge

### DIFF
--- a/.github/workflows/benchmark_tpu_bridge.yml
+++ b/.github/workflows/benchmark_tpu_bridge.yml
@@ -120,16 +120,26 @@ jobs:
             # args where a default shape exceeds TPU vmem.
             #
             # Precision follows the canonical helion examples per kernel: bf16
-            # for gemm/softmax/layer_norm/rms_norm (examples/rms_norm.py runs
-            # both fwd and bwd at bf16), and fp32 for kl_div and welford
-            # (examples/kl_div.py and examples/welford.py use fp32 inputs).
-            # kl_div keeps its loss reduction in fp32; welford's bf16 layer-norm
-            # output drifts ~1 ULP on near-zero values and trips the 1e-2
-            # accuracy tolerance for every correct impl. Force fp32 for those two
-            # so each impl isn't compared against a downcast bf16 baseline.
+            # for gemm/softmax/layer_norm and rms_norm forward, fp32 for kl_div
+            # and welford (examples/kl_div.py and examples/welford.py use fp32
+            # inputs). kl_div keeps its loss reduction in fp32; welford's bf16
+            # layer-norm output drifts ~1 ULP on near-zero values and trips the
+            # 1e-2 accuracy tolerance for every correct impl.
+            #
+            # rms_norm-bwd fails differently: dweight reduces over all M rows,
+            # and the eager baseline runs that accumulation in bf16, where
+            # cancellation moves individual elements tens of percent away from
+            # the true gradient. examples/rms_norm.py already accumulates
+            # grad_weight in fp32, so at bf16 each impl is measured against a
+            # baseline noisier than itself and no correct impl can pass. dx is
+            # elementwise and stays in tolerance either way, and rms_norm
+            # forward has no cross-row reduction, so it stays bf16.
+            #
+            # Forcing fp32 for these keeps each impl from being compared
+            # against a downcast bf16 baseline.
             PRECISION=bf16
             case "$kernel" in
-              kl_div|welford) PRECISION=fp32 ;;
+              kl_div|welford|rms_norm-bwd) PRECISION=fp32 ;;
             esac
             ${{ inputs.env-vars }} HELION_PRINT_OUTPUT_CODE=1 HELION_MEASURE_COMPILE_TIME=1 \
               python benchmarks/run.py \


### PR DESCRIPTION
`rms_norm-bwd` has reported accuracy 0 on the TPU dashboard for every implementation — helion and `torch_compile` alike — for over a month, while `rms_norm` forward reports 1. Sharing one backward `grad_output` across implementations did not change it.

The failure is confined to the **weight** gradient. `dweight` reduces over all M rows, and the eager baseline runs that accumulation in bf16, where cancellation moves individual elements far from the true gradient. `dx` is elementwise, has no cross-row reduction, and passes at either precision — which is why only tensor 1 was ever reported as mismatched.

Measured on a TPU at M=2048, H=1024, per-element `dweight` ratio against the eager baseline:

| precision | helion | torch_compile |
|---|---|---|
| bf16 | 0.68 – 1.29 | 0.48 – 1.80 |
| fp32 | 0.999988 – 1.000010 | 0.999996 – 1.000002 |

Tolerance is 1e-2, so bf16 is off by tens of percent and fp32 is comfortably inside. Absolute means agree closely in both cases (3.66458 vs 3.66568 at bf16), so this is accumulation noise rather than an algebraic error.

`examples/rms_norm.py` already accumulates `grad_weight` in fp32 and only downcasts at the end, so the kernel is *more* accurate than the baseline it is scored against. At bf16 no correct implementation can pass, which is exactly what the dashboard shows.

This also brings the TPU row in line with the GPU nightly: `--precision` defaults to `bypass`, the rms_norm operator defines no `DEFAULT_PRECISION`, and `benchmark.yml` passes no `--precision`, so GPU already benchmarks `rms_norm` and `rms_norm-bwd` at fp32. The remaining TPU/GPU difference is the *forward* row (bf16 on TPU, fp32 on GPU), which is pre-existing and left alone here — forward has no cross-row reduction and passes at bf16.

### Dashboard impact

bf16 `rms_norm-bwd` latency is no longer measured on TPU, and the forward (bf16) and backward (fp32) rows are no longer latency-comparable to each other. Accuracy goes from a permanent 0 to a real signal, which seems the better trade.

Worth watching on the first nightly: fp32 doubles the bytes for these shapes, and kl_div previously needed a shape cap for TPU vmem, so H=2048 is the one to check for an OOM.
