### PR TITLE
[metal] honor begin and step for scalar root grids

### DIFF
--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -52,6 +52,8 @@ if TYPE_CHECKING:
     from ..tile_strategy import TileStrategy
     from .attention_plan import AttentionScorePlan
 
+    SymIntLike = torch.SymInt | int
+
     InductorOpOverrides = OpsHandler[Any]
 
 
@@ -2364,6 +2366,7 @@ class CuteBackend(Backend):
         from ..host_function import HostFunction
         from ..tile_strategy import PerThreadFlattenedTileStrategy
         from ..tile_strategy import PerThreadNDTileStrategy
+        from ..variable_origin import GridOrigin
 
         env = CompileEnvironment.current()
         device_ir = HostFunction.current().device_ir
@@ -2382,6 +2385,16 @@ class CuteBackend(Backend):
         )
         has_dynamic_shape = any(env.block_sizes[i].size is None for i in block_ids)
         grid_ids = {bid for ids in device_ir.grid_block_ids for bid in ids}
+        scalar_noncanonical_grid = (
+            len(block_ids) == 1
+            and block_ids in device_ir.grid_block_ids
+            and block_ids[0] in device_ir.noncanonical_task_origin_block_ids
+            and any(
+                type(origin.origin) is GridOrigin
+                and origin.origin.block_id == block_ids[0]
+                for origin in HostFunction.current().expr_to_origin.values()
+            )
+        )
         num_threads_config = [
             int(env.config_spec.num_threads.config_get(config.num_threads, block_id, 0))
             for block_id in block_ids
@@ -2452,7 +2465,8 @@ class CuteBackend(Backend):
                 if num_threads_config[i] == 0 and block_id not in grid_ids:
                     num_threads_config[i] = 1
         if (
-            has_device_loops
+            scalar_noncanonical_grid
+            or has_device_loops
             or has_dynamic_shape
             or len(device_ir.grid_block_ids) != 1
             or (len(block_ids) > 1 and not flattened)
@@ -2467,7 +2481,16 @@ class CuteBackend(Backend):
                     return known_equal(lhs, rhs)
                 return bool(lhs == rhs)
 
-            nd_block_size = [bs.from_config_assert(config) for bs in block_size_infos]
+            nd_block_size: list[SymIntLike] = [
+                bs.from_config_assert(config) for bs in block_size_infos
+            ]
+            if scalar_noncanonical_grid:
+                # A scalar grid has one logical operation per program.  Its
+                # configured "block size" is the range step, not a tile width;
+                # treating it as a thread extent can create synthetic lanes and
+                # execute the loop body more than once per grid trip.
+                nd_block_size = [1]
+                num_threads_config = [1]
             original_num_threads_config = list(num_threads_config)
             mma_candidate = _is_mma_candidate_loop(
                 fn,

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -165,7 +165,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         )
         torch.testing.assert_close(result, grid_2d_pytorch(args[0], args[1]))
 
-    @skipIfMetal("BUG: hl.grid begin/end broken with PerThreadNDTileStrategy on Metal")
     def test_grid_begin_end(self):
         @helion.kernel(autotune_effort="none")
         def grid_begin_end(x: torch.Tensor) -> torch.Tensor:
@@ -186,7 +185,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(grid_begin_end, (x,))
         torch.testing.assert_close(result, grid_begin_end_pytorch(x))
 
-    @skipIfMetal("BUG: hl.grid begin/end broken with PerThreadNDTileStrategy on Metal")
     def test_grid_begin_end_step(self):
         @helion.kernel(autotune_effort="none")
         def grid_begin_end_step(x: torch.Tensor) -> torch.Tensor:
@@ -207,7 +205,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(grid_begin_end_step, (x,))
         torch.testing.assert_close(result, grid_begin_end_step_pytorch(x))
 
-    @skipIfMetal("BUG: hl.grid begin/end broken with PerThreadNDTileStrategy on Metal")
     def test_grid_end_step_kwarg(self):
         @helion.kernel(autotune_effort="none")
         def grid_end_step_kwarg(x: torch.Tensor) -> torch.Tensor:
@@ -227,6 +224,49 @@ class TestGrid(RefEagerTestBase, TestCase):
         x = torch.randn([16], device=DEVICE, dtype=torch.float32)
         code, result = code_and_output(grid_end_step_kwarg, (x,))
         torch.testing.assert_close(result, grid_end_step_kwarg_pytorch(x))
+
+    @xfailIfPallas("hl.grid step lowering produces a traced dynamic_slice size")
+    def test_grid_step_indivisible_trip_count(self):
+        @helion.kernel(autotune_effort="none")
+        def grid_step_10_4(x: torch.Tensor) -> torch.Tensor:
+            out = torch.zeros_like(x)
+            for i in hl.grid(0, 10, 4):
+                out[i] = x[i] * 2
+            return out
+
+        @helion.kernel(autotune_effort="none")
+        def grid_step_3_17_5(x: torch.Tensor) -> torch.Tensor:
+            out = torch.zeros_like(x)
+            for i in hl.grid(3, 17, 5):
+                out[i] = x[i] * 2
+            return out
+
+        @helion.kernel(autotune_effort="none")
+        def grid_step_4097_4096(x: torch.Tensor) -> torch.Tensor:
+            out = torch.zeros_like(x)
+            for i in hl.grid(0, 4097, 4096):
+                out[i] = x[i] * 2
+            return out
+
+        def pytorch_ref(x: torch.Tensor, begin: int, end: int, step: int):
+            out = torch.zeros_like(x)
+            for i in range(begin, end, step):
+                out[i] = x[i] * 2
+            return out
+
+        x = torch.randn([10], device=DEVICE, dtype=torch.float32)
+        _code, result = code_and_output(grid_step_10_4, (x,))
+        torch.testing.assert_close(result, pytorch_ref(x, 0, 10, 4))
+
+        x = torch.randn([17], device=DEVICE, dtype=torch.float32)
+        _code, result = code_and_output(grid_step_3_17_5, (x,))
+        torch.testing.assert_close(result, pytorch_ref(x, 3, 17, 5))
+
+        x = torch.randn([4097], device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(grid_step_4097_4096, (x,))
+        torch.testing.assert_close(result, pytorch_ref(x, 0, 4097, 4096))
+        if "metal_jit" in code:
+            self.assertIn("_block_dims=(1, 1, 1)", code)
 
     def test_grid_multidim_begin_end(self):
         @helion.kernel(autotune_effort="none")
@@ -293,7 +333,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(tile_begin_end, (x,), block_size=4)
         torch.testing.assert_close(result, tile_begin_end_pytorch(x))
 
-    @skipIfMetal("Metal does not support loop_index_expr for grid loops")
     def test_range_as_grid_basic(self):
         """Test that range() works as an alias for hl.grid() in device code."""
 
@@ -314,7 +353,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(range_kernel, (x,))
         torch.testing.assert_close(result, expected)
 
-    @skipIfMetal("Metal does not support loop_index_expr for grid loops")
     def test_range_with_begin_end(self):
         """Test that range(begin, end) works as alias for hl.grid(begin, end)."""
 
@@ -335,7 +373,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(range_begin_end_kernel, (x,))
         torch.testing.assert_close(result, expected)
 
-    @skipIfMetal("Metal does not support loop_index_expr for grid loops")
     @xfailIfPallas(
         "range(begin, end, step) lowers to _for_loop_step which has no "
         "emit_pipeline codegen"
@@ -362,7 +399,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(range_step_kernel, (x,))
         torch.testing.assert_close(result, expected)
 
-    @skipIfMetal("Metal does not support loop_index_expr for grid loops")
     def test_range_with_tensor_size(self):
         """Test that range(tensor.size(dim)) works with dynamic tensor dimensions."""
 


### PR DESCRIPTION
Metal and CuTe normally use the flattened per-thread strategy for one-dimensional root grids. That strategy exposes the raw flattened thread offset through GridOrigin, so nonzero begin values and non-unit steps produce incorrect tensor indices.

Route noncanonical scalar root grids through the existing per-thread N-D strategy, which already computes begin + pid * step. Force a one-thread block for this path because a grid block size represents the step rather than a tile width; this also prevents surplus or synthetic lanes from executing the loop body.

Unskip the affected Metal grid and nested-range tests, and add coverage for indivisible trip counts and a large step that would otherwise trigger lane splitting.