### PR TITLE
[ci] enable MKL determinism in Pallas interpreter mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -275,6 +275,9 @@ jobs:
           if [[ "${{ matrix.backend }}" == "tileir" ]]; then export ENABLE_TILE=1; fi
           if [[ "${{ matrix.alias }}" == "pallas-interpret" ]]; then export HELION_PALLAS_INTERPRET=1; fi
           export HELION_BACKEND=${{ matrix.backend }}
+          # Enable numerical reproducibility in MKL. Otherwise results from the
+          # reference implementation can be non-deterministic.
+          export MKL_CBWR=AVX2
           # Disable TorchTPU build cache to prevent running out of disk space.
           export TORCH_TPU_INTERNAL_TIER2_COMPILATION_CACHE=disabled
           # -rf: print failed tests


### PR DESCRIPTION
This fixes some flakes in interpreter mode that I've seen for test_control_flow.py::test_constant_branch_false_simple, where torch.sin(x) sometimes returns values with low precision.

MKL Docs on this: https://www.intel.com/content/www/us/en/docs/onemkl/developer-guide-linux/2023-0/get-started-with-conditional-num-reproducibility.html

Repro (it repro's in a TPU VM. On my local machine it does not):

```
import torch
torch.set_num_threads(4)
x = torch.randn(512, 512)
print((torch.sin(x) - torch.sin(x)).abs().max().item())
```

```
$ for i in $(seq 40); do python repro.py; done | sort | uniq -c
     27 0.0
     13 0.00015044212341308594
$ for i in $(seq 40); do MKL_CBWR=AVX2 python repro.py; done | sort | uniq -c
     40 0.0
```

FWIW I've tried with MKL_CBWR=AUTO and MKL_CBWR=AVX512, but they don't help.