### PR TITLE
fix(test) relax BMM autodiff tolerance on A10G

### DIFF
--- a/test/test_autodiff.py
+++ b/test/test_autodiff.py
@@ -1219,7 +1219,9 @@ class TestAutodiff(RefEagerTestDisabled, TestCase):
             ],
             grad_shape=(B, M, N),
             rtol=1e-2,
-            atol=1e-2,
+            # A10G TF32 reduction order can leave an isolated gradient element
+            # just above 1e-2 absolute error.
+            atol=2e-2,
         )
 
     def test_example_bmm_square(self):


### PR DESCRIPTION
the autodiff bmm test is flaky because its tolerance is too low