### PR TITLE
fix(ci) place NVSHMEM bitcode in venv search path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,8 +133,8 @@ jobs:
               # library and install only the older wheel's device bitcode separately.
               NVSHMEM_DEVICE_ROOT="$RUNNER_TEMP/nvshmem-device"
               UV_DEFAULT_INDEX= UV_INDEX= uv pip install --target "$NVSHMEM_DEVICE_ROOT" --no-deps nvidia-nvshmem-cu13==3.4.5 --index-url "$NIGHTLY_INDEX"
-              export NVSHMEM_LIB_DIR="$NVSHMEM_DEVICE_ROOT/nvidia/nvshmem/lib"
-              echo "NVSHMEM_LIB_DIR=$NVSHMEM_LIB_DIR" >> "$GITHUB_ENV"
+              NVSHMEM_LIB_DIR="$(python -c 'import sysconfig; print(sysconfig.get_path("purelib"))')/nvidia/nvshmem/lib"
+              cp "$NVSHMEM_DEVICE_ROOT/nvidia/nvshmem/lib/libnvshmem_device.bc" "$NVSHMEM_LIB_DIR/"
               python -c "from torch.distributed._symmetric_memory._nvshmem_triton import NvshmemLibFinder; print(f'NVSHMEM device library: {NvshmemLibFinder.find_device_library()}')"
             fi
           fi


### PR DESCRIPTION
#3599 didnt quite fix it. Copy `libnvshmem_device.bc` into NVSHMEM’s standard venv library directory instead of relying on `NVSHMEM_LIB_DIR`.

The previous fix exported `NVSHMEM_LIB_DIR` during the PyTorch installation step and wrote it to `$GITHUB_ENV`. Its preflight passed in that step, but the variable was absent from the later distributed pytest subprocesses. PyTorch therefore used its default search paths and failed to locate the bitcode.

Placing the bitcode in the default venv location makes it visible to both the parent process and every spawned rank without relying on cross-step environment propagation.

  This retains the ABI-compatible NVSHMEM 3.7.2 host libraries while adding only the device bitcode required by PyTorch’s Triton integration.