### PR TITLE
[metal] Enable autotuning

### DIFF
--- a/helion/_compiler/metal/autotune.py
+++ b/helion/_compiler/metal/autotune.py
@@ -1,0 +1,218 @@
+"""Benchmarking for Metal autotuning.
+
+Neither shared benchmark works here.  The module-level ``do_bench`` is Triton's
+CUDA-event timer and Triton is not installed on macOS, so every candidate
+raises.  ``do_bench_generic`` runs, but it times one call between two
+synchronizations, and dispatching a Metal kernel from Python costs an
+appreciable fraction of what these kernels take -- so most of a sample is
+overhead and configs that differ by 15% measure the same.  Each sample here
+times a batch of back-to-back calls instead.
+
+A cold kernel's first dispatches run several times slower than its steady
+state, and it is the estimate that fixes the batch size for every sample after
+it, so the kernel is warmed before it is probed (see ``_WARMUP_CALLS``).
+
+Neither function resolves differences below a few percent, but they fail
+differently.  :func:`do_bench_metal` scores every candidate as it is compiled
+and the search's surrogate is fitted on those numbers, so a config it scores
+badly is never explored again.  :func:`interleaved_bench_metal` re-ranks the
+survivors with drift held common across them; it decides which one wins, but
+never sees what the first function dropped.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+from typing import Any
+
+from ...autotuner.benchmarking import _summarize_statistics_fallback
+from ...autotuner.benchmarking import synchronize_device
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+#: Target duration of one timed sample.
+#:
+#: A sample carries a fixed cost of roughly 0.25ms (two synchronizations plus
+#: the first call after one) that ``_time_batch_ms`` divides across the batch
+#: but never removes, so the target must sit past where a kernel's measured
+#: time converges: 20ms lands a typical kernel on batch 60-90, within a couple
+#: of percent of its batch-256 reading, for ~250ms per config against ~4.4s of
+#: MSL compilation.
+#:
+#: This raises the ceiling on resolution; it does not make the harness exact.
+#: Below a few percent, ranking is a coin flip (see
+#: ``test_identical_candidates_measure_the_same``).
+_SAMPLE_TARGET_MS = 20.0
+
+#: Upper bound on calls per sample, so a pathologically cheap kernel cannot
+#: make a single sample run away.
+_MAX_BATCH = 512
+
+#: Burn-in before estimating, as a call count and a time budget -- whichever is
+#: smaller.  A cold probe reads several times high and would fix the batch size
+#: too small for every sample after it.  The time bound keeps an expensive
+#: kernel from spending seconds here for no benefit; it gets ``batch == 1``
+#: regardless.
+_WARMUP_CALLS = 32
+_WARMUP_MS = 25.0
+
+#: Floors on the number of samples, independent of the caller's budget.
+#:
+#: The autotuner asks for ``warmup=1, rep=50`` -- budgets written for
+#: event-timed CUDA kernels measured one call at a time.  Divided by a 20ms
+#: sample they round down to one warmup sample and two timed ones, which is
+#: not enough to take a median over.  The budgets are honored when they ask
+#: for *more* than this.
+_MIN_WARMUP_SAMPLES = 2
+_MIN_SAMPLES = 8
+
+#: Floor on interleaved rounds, for the same reason (see
+#: :func:`interleaved_bench_metal`, where ``repeat`` is a call budget).
+_MIN_ROUNDS = 3
+
+
+def _batch_size_for(per_call_ms: float) -> int:
+    """Number of back-to-back calls that make up one timed sample."""
+    if per_call_ms <= 0:
+        return _MAX_BATCH
+    return max(1, min(_MAX_BATCH, int(_SAMPLE_TARGET_MS / per_call_ms)))
+
+
+def _time_batch_ms(fn: Callable[[], Any], batch: int) -> float:
+    """Mean per-call time over ``batch`` back-to-back calls and one sync."""
+    synchronize_device()
+    start = time.perf_counter()
+    output = None
+    for _ in range(batch):
+        output = fn()
+    synchronize_device()
+    del output
+    return (time.perf_counter() - start) * 1000 / batch
+
+
+def _warm_up(fn: Callable[[], Any]) -> None:
+    """Bring ``fn`` to steady state before anything is measured from it."""
+    fn()
+    synchronize_device()
+    # The first call reads high, being cold, which is exactly the right bias
+    # for sizing a burn-in: it over-estimates the cost and so under-shoots the
+    # budget rather than blowing through it.
+    cold_ms = _time_batch_ms(fn, 1)
+    calls = max(1, min(_WARMUP_CALLS, int(_WARMUP_MS / max(cold_ms, 1e-6))))
+    _time_batch_ms(fn, calls)
+
+
+def _estimate_per_call_ms(fn: Callable[[], Any], runs: int = 5) -> float:
+    """Estimate the amortized per-call cost, to size the timed batch.
+
+    Assumes ``fn`` is already warm (see :func:`_warm_up`); this is a sizing
+    probe, not a measurement.  A short probe reads high, which picks too small
+    a batch, which keeps it high, so each pass re-times at the implied batch
+    and keeps the ``min`` (noise only adds time).
+    """
+    estimate = _time_batch_ms(fn, runs)
+    batch = runs
+    for _ in range(2):
+        refined_batch = _batch_size_for(estimate)
+        if refined_batch <= batch:
+            break
+        estimate = min(estimate, _time_batch_ms(fn, refined_batch))
+        batch = refined_batch
+    return estimate
+
+
+def do_bench_metal(
+    fn: Callable[[], Any],
+    warmup: int = 25,
+    rep: int = 100,
+    grad_to_none: object = None,
+    quantiles: list[float] | None = None,
+    return_mode: str = "median",
+    process_group_name: str | None = None,
+    *,
+    default_cudagraph: bool = False,  # accepted for API symmetry
+) -> float | tuple[float, ...]:
+    """Time ``fn`` on MPS, amortizing per-launch host overhead.
+
+    ``warmup`` and ``rep`` are millisecond budgets, as in the shared
+    benchmarks, but are spent in whole batches rather than single calls.
+    """
+    assert return_mode in ["min", "max", "mean", "median", "all"]
+
+    _warm_up(fn)
+
+    per_call_ms = _estimate_per_call_ms(fn)
+    batch = _batch_size_for(per_call_ms)
+    sample_ms = max(per_call_ms * batch, 1e-6)
+    n_warmup = max(_MIN_WARMUP_SAMPLES, int(warmup / sample_ms))
+    n_repeat = max(_MIN_SAMPLES, int(rep / sample_ms))
+
+    for _ in range(n_warmup):
+        _time_batch_ms(fn, batch)
+
+    times = [_time_batch_ms(fn, batch) for _ in range(n_repeat)]
+    return _summarize_statistics_fallback(times, quantiles, return_mode)
+
+
+def interleaved_bench_metal(
+    fns: list[Callable[[], object]],
+    *,
+    repeat: int,
+    desc: str | None = None,
+    default_cudagraph: bool = False,  # accepted for API symmetry
+    max_total_ms: float | None = None,
+) -> list[float]:
+    """Interleaved counterpart of :func:`do_bench_metal`.
+
+    Interleaving holds slow drift (thermal, other GPU work) common across
+    candidates; batching removes the per-launch overhead that would otherwise
+    compress the differences between them.
+
+    Each candidate gets its **own** batch size: ``_time_batch_ms`` already
+    returns a per-call time, so a shared batch equalizes nothing and only
+    drags every candidate down to the slowest one's overhead residual.
+
+    The visit order is fixed; with per-candidate batches there is no
+    measurable predecessor penalty.
+
+    ``min`` is a fair summary across candidates: each is sampled once per
+    round, so the order-statistic bias is common to them.
+    """
+    from ...autotuner.benchmarking import iter_with_progress
+
+    estimates = []
+    batches = []
+    for fn in fns:
+        _warm_up(fn)
+        estimates.append(_estimate_per_call_ms(fn))
+        batches.append(_batch_size_for(estimates[-1]))
+    all_times: list[list[float]] = [[] for _ in fns]
+
+    # ``repeat`` is a budget in *calls*, matching the shared benchmarks (one
+    # call per candidate per round).  Here a round is a whole batch, so rounds
+    # are ``repeat // max(batches)`` -- spending ``repeat`` rounds would
+    # overshoot the budget by the batch size.  The cheapest candidate sets the
+    # count; ``_MIN_ROUNDS`` bounds it from below.
+    rounds = max(_MIN_ROUNDS, repeat // max(batches, default=1))
+    if max_total_ms is not None:
+        # The caller (``BaseSearch.rebenchmark``) caps the whole pass near
+        # the sequential-window budget it replaced.  Without this the
+        # keyword it always passes has nowhere to land.
+        per_round_ms = sum(b * e for b, e in zip(batches, estimates, strict=True))
+        rounds = max(
+            _MIN_ROUNDS, min(rounds, int(max_total_ms / max(per_round_ms, 1e-6)))
+        )
+
+    iterator = iter_with_progress(
+        range(rounds),
+        total=rounds,
+        description=desc,
+        enabled=desc is not None,
+    )
+    for _ in iterator:
+        for j, fn in enumerate(fns):
+            all_times[j].append(_time_batch_ms(fn, batches[j]))
+
+    return [min(times) for times in all_times]

--- a/helion/_compiler/metal/backend.py
+++ b/helion/_compiler/metal/backend.py
@@ -18,15 +18,30 @@ from ._constants import MAX_THREAD_AXES
 from ._constants import MAX_THREADS_PER_THREADGROUP
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from torch._inductor.ops_handler import OpsHandler
 
     from ...runtime.config import Config
     from ...runtime.kernel import BoundKernel
+    from ..compile_environment import CompileEnvironment
     from ..device_function import Argument
     from ..device_function import DeviceFunction
     from ..tile_strategy import TileStrategy
 
     InductorOpOverrides = OpsHandler[Any]
+
+
+def _is_threadgroup_too_large(err: BaseException) -> bool:
+    """Recognize Metal's pipeline-state error for an oversized threadgroup."""
+    return "exceeds the maximum total threads per threadgroup" in str(err)
+
+
+#: Wall-clock ceiling for a Metal autotune run, unless the caller sets
+#: ``autotune_budget_seconds`` or asks for ``autotune_effort="full"``.  Every
+#: candidate pays an MSL compile, so an unbounded search is slow enough to be
+#: surprising.
+_DEFAULT_AUTOTUNE_BUDGET_SECONDS = 300
 
 
 class MetalBackend(Backend):
@@ -474,8 +489,61 @@ class MetalBackend(Backend):
             )
         return strategy
 
+    # ------------------------------------------------------------------
+    # Autotuning
+    # ------------------------------------------------------------------
+
     def supports_precompile(self) -> bool:
+        # There is no Triton-style out-of-process precompile for MSL; the
+        # autotuner compiles and benchmarks each config inline.
         return False
+
+    def get_do_bench(self) -> Callable[..., float | tuple[float, ...]]:
+        # See metal/autotune.py for why neither shared benchmark works here.
+        from .autotune import do_bench_metal
+
+        return do_bench_metal
+
+    def get_interleaved_bench(self) -> Callable[..., list[float]]:
+        # Same rationale as get_do_bench, for the interleaved compare path.
+        from .autotune import interleaved_bench_metal
+
+        return interleaved_bench_metal
+
+    def classify_autotune_exception(self, err: BaseException) -> str | None:
+        # A config the backend cannot express (an unsupported reduction
+        # layout, a threadgroup that does not fit) is an ordinary search miss:
+        # log it and move on.  A shader that fails to compile is reported by
+        # torch.mps as a SyntaxError and is almost always a real codegen bug,
+        # so surface that at warn level without aborting the search.
+        if isinstance(err, exc.BackendUnsupported):
+            return "debug"
+        if isinstance(err, RuntimeError) and _is_threadgroup_too_large(err):
+            # Same category as BackendUnsupported -- the config simply does not
+            # fit -- but Metal only notices when it builds the pipeline state,
+            # long after codegen, so it arrives as a RuntimeError from the
+            # launcher rather than a compile failure.  It is routine: 19% of a
+            # sampled matmul space with explicit thread counts lands here, and
+            # logging a fifth of the search at warn level would bury the
+            # failures that do deserve attention.
+            return "debug"
+        if isinstance(err, SyntaxError):
+            # torch.mps reports a shader that fails to compile as a
+            # SyntaxError.  That is almost always a real codegen bug, so it is
+            # surfaced without aborting the search.
+            return "warn"
+        # Anything else -- an MPS driver error, a pipeline-state failure we do
+        # not have a pattern for -- is still just one bad candidate, but it is
+        # not one we recognize, so say so.  Without a catch-all the shared
+        # fallback is ``classify_triton_exception``, which returns "raise" for
+        # any message it does not know; it knows no MPS message and Triton is
+        # not even installed here, so an unfamiliar driver error would abort
+        # the entire search.  Warn and move on, as the CuTe backend does --
+        # and, like CuTe, leave non-``Exception`` BaseExceptions
+        # (KeyboardInterrupt, SystemExit) to propagate.
+        if isinstance(err, Exception):
+            return "warn"
+        return None
 
     def autotune(
         self,
@@ -485,7 +553,19 @@ class MetalBackend(Backend):
         force: bool = True,
         **kwargs: object,
     ) -> Config:
-        return bound_kernel.config_spec.default_config()
+        # Every candidate is compiled inline (no precompile) and MSL
+        # compilation dominates, so bound the search unless the caller asked
+        # for "full" or set an explicit budget.  Mirrors CuteBackend.autotune.
+        settings = bound_kernel.settings
+        original_budget = settings.autotune_budget_seconds
+        if settings.autotune_budget_seconds is None and (
+            settings.autotune_effort != "full"
+        ):
+            settings.autotune_budget_seconds = _DEFAULT_AUTOTUNE_BUDGET_SECONDS
+        try:
+            return super().autotune(bound_kernel, args, force=force, **kwargs)
+        finally:
+            settings.autotune_budget_seconds = original_budget
 
     def transform_host_arg(
         self,
@@ -544,9 +624,12 @@ class MetalBackend(Backend):
         threads explicitly is rejected.  Users hitting that rejection should
         lower ``num_threads`` or ``block_sizes``.
         """
+        # Claim the MPP matmul's threads before the tiles take the whole budget.
         config = self._config_with_mpp_thread_budget(fn, block_ids, config)
         # Cap tile thread counts so the reduction axes still fit alongside them.
         config = self._config_with_reduction_thread_budget(block_ids, config)
+        # Re-clamp any count the passes above left not dividing its block size.
+        config = self._config_with_divisible_thread_counts(block_ids, config)
         # pyrefly: ignore[bad-argument-type]
         strategy = CuteBackend.create_loop_strategy(self, fn, block_ids, config)
         self._reject_dynamic_thread_extents(strategy)
@@ -590,6 +673,79 @@ class MetalBackend(Backend):
                 "compile the kernel with static_shapes=True",
             )
 
+    def _mutable_num_threads(self, config: Config) -> list[int]:
+        """Mutable copy of ``config.num_threads`` for the passes below.
+
+        Extended with auto (``0``) sentinels to the spec length, so a
+        config that leaves trailing axes unset can still be indexed by
+        ``block_id_to_index``.
+        """
+        from ..compile_environment import CompileEnvironment
+
+        env = CompileEnvironment.current()
+        num_threads = list(config.num_threads)
+        if len(num_threads) < len(env.config_spec.num_threads):
+            num_threads.extend(
+                [0] * (len(env.config_spec.num_threads) - len(num_threads))
+            )
+        return num_threads
+
+    def _record_thread_count(
+        self,
+        env: CompileEnvironment,
+        num_threads: list[int],
+        block_id: int,
+        chosen: int,
+    ) -> bool:
+        """Write an explicit thread count; return True if it changed anything."""
+        config_index = env.config_spec.num_threads.block_id_to_index(block_id)
+        if num_threads[config_index] != chosen:
+            num_threads[config_index] = chosen
+            return True
+        return False
+
+    def _finalize_thread_config(
+        self, config: Config, num_threads: list[int], changed: bool
+    ) -> Config:
+        """Return the original config when no axis changed, else a copy."""
+        if not changed:
+            return config
+        from ...runtime.config import Config
+
+        return Config.from_dict({**config.config, "num_threads": num_threads})
+
+    def _config_with_divisible_thread_counts(
+        self, block_ids: list[int], config: Config
+    ) -> Config:
+        """Round each explicit ``num_threads`` down to a divisor of its block size.
+
+        The shared loop strategy requires ``block_size % num_threads == 0`` and
+        raises otherwise.  Autotuning draws ``num_threads`` from the tensor
+        extent rather than the chosen block size, so a meaningful slice of the
+        search space would otherwise be spent on configs that cannot compile --
+        and a batch that happens to contain only such configs aborts the whole
+        search.  Clamping keeps every config in the space legal, in the same
+        spirit as the two thread-budget passes above.
+        """
+        from ..compile_environment import CompileEnvironment
+
+        env = CompileEnvironment.current()
+        num_threads = list(config.num_threads)
+        changed = False
+        for block_id in block_ids:
+            configured = int(
+                env.config_spec.num_threads.config_get(config.num_threads, block_id, 0)
+            )
+            if configured <= 0:
+                continue  # 0 means "use the block size"
+            block_size = env.block_sizes[block_id].from_config(config)
+            if not isinstance(block_size, int) or block_size % configured == 0:
+                continue
+            chosen = _largest_divisor_at_most(block_size, configured)
+            if self._record_thread_count(env, num_threads, block_id, chosen):
+                changed = True
+        return self._finalize_thread_config(config, num_threads, changed)
+
     def _reserved_reduction_threads(self, config: Config) -> int:
         """Threads the reduction axes will claim from the threadgroup.
 
@@ -621,37 +777,33 @@ class MetalBackend(Backend):
     def _config_with_reduction_thread_budget(
         self, block_ids: list[int], config: Config
     ) -> Config:
-        """Cap auto tile thread counts so the reduction axes still fit.
+        """Cap tile thread counts so the reduction axes still fit.
 
         Tile strategies are built before reduction strategies
         (``TileStrategyDispatch.__init__``), so without this the tiles claim
         the whole 1024-thread budget and ``adjust_reduction_thread_count``
-        would shrink the reduction below the extent it has to cover.
+        would shrink the reduction below the extent it has to cover -- which
+        Metal cannot recover from mid-planning the way CuTe's lane-loop
+        machinery does, so ``create_reduction_strategy`` rejects the config.
+
+        Autotuning makes that a search-efficiency problem as well as a
+        correctness one: it sets ``num_threads`` explicitly, so capping only
+        the *auto* axes left a slice of the space unable to compile.  Explicit
+        counts are capped too.
         """
         reserved = self._reserved_reduction_threads(config)
         if reserved <= 1:
             return config
 
-        from ...runtime.config import Config
         from ..compile_environment import CompileEnvironment
 
         env = CompileEnvironment.current()
-        num_threads = list(config.num_threads)
-        if len(num_threads) < len(env.config_spec.num_threads):
-            num_threads.extend(
-                [0] * (len(env.config_spec.num_threads) - len(num_threads))
-            )
+        num_threads = self._mutable_num_threads(config)
 
         used = reserved
         changed = False
         tunable = set(env.config_spec.num_threads.valid_block_ids())
         for block_id in block_ids:
-            configured = int(
-                env.config_spec.num_threads.config_get(config.num_threads, block_id, 0)
-            )
-            if configured > 0:
-                used *= configured
-                continue
             axis_size = env.block_sizes[block_id].from_config(config)
             if not isinstance(axis_size, int):
                 continue
@@ -664,20 +816,21 @@ class MetalBackend(Backend):
                 # rejects the config with a diagnostic.
                 used *= axis_size
                 continue
+            configured = int(
+                env.config_spec.num_threads.config_get(config.num_threads, block_id, 0)
+            )
+            # 0 means "use the block size"; anything larger than the block size
+            # is capped there because the axis has no more work than that.
+            requested = min(configured, axis_size) if configured > 0 else axis_size
             budget = max(1, MAX_THREADS_PER_THREADGROUP // max(1, used))
-            chosen = _largest_divisor_at_most(axis_size, budget)
-            if chosen >= axis_size:
-                used *= chosen
-                continue
-            config_index = env.config_spec.num_threads.block_id_to_index(block_id)
-            if num_threads[config_index] != chosen:
-                num_threads[config_index] = chosen
-                changed = True
+            chosen = _largest_divisor_at_most(axis_size, min(requested, budget))
             used *= chosen
+            if configured == 0 and chosen >= axis_size:
+                continue  # leave the auto sentinel alone
+            if self._record_thread_count(env, num_threads, block_id, chosen):
+                changed = True
 
-        if not changed:
-            return config
-        return Config.from_dict({**config.config, "num_threads": num_threads})
+        return self._finalize_thread_config(config, num_threads, changed)
 
     def _config_with_mpp_thread_budget(
         self, fn: DeviceFunction, block_ids: list[int], config: Config
@@ -709,16 +862,11 @@ class MetalBackend(Backend):
         if len(block_ids) < 2:
             return config
 
-        from ...runtime.config import Config
         from ..compile_environment import CompileEnvironment
         from ..cute.thread_budget import MAX_THREADS_PER_BLOCK
 
         env = CompileEnvironment.current()
-        num_threads = list(config.num_threads)
-        if len(num_threads) < len(env.config_spec.num_threads):
-            num_threads.extend(
-                [0] * (len(env.config_spec.num_threads) - len(num_threads))
-            )
+        num_threads = self._mutable_num_threads(config)
 
         first_block_id = block_ids[0]
         first_axis_size = env.block_sizes[first_block_id].from_config(config)
@@ -741,15 +889,27 @@ class MetalBackend(Backend):
         used_threads = max(mpp_threads, first_axis_threads)
         changed = False
 
-        # Walk the remaining axes in launch order.  Explicit num_threads
-        # consume budget as-is; auto axes are reduced to the largest divisor
-        # that keeps the total threadgroup size under Metal's limit.
+        # Walk the remaining axes in launch order.  Auto axes are reduced to the
+        # largest divisor that keeps the total threadgroup size under Metal's
+        # limit; an explicit count is taken as given, but is rejected if the
+        # product cannot launch.  Metal only refuses an oversized threadgroup
+        # when it builds the pipeline state, so without this the config costs a
+        # full MSL compile before failing -- 15-45% of a sampled matmul search
+        # space, depending on seed.
         for block_id in block_ids[1:]:
             configured = int(
                 env.config_spec.num_threads.config_get(config.num_threads, block_id, 0)
             )
             if configured > 0:
                 used_threads *= configured
+                if used_threads > MAX_THREADS_PER_BLOCK:
+                    raise exc.BackendUnsupported(
+                        self.name,
+                        f"threadgroup of {used_threads} threads "
+                        f"(max {MAX_THREADS_PER_BLOCK}); MPP claims "
+                        f"{mpp_threads} on tid[0] and the explicit num_threads "
+                        "on the remaining axes do not fit alongside it",
+                    )
                 continue
 
             axis_size = env.block_sizes[block_id].from_config(config)
@@ -758,12 +918,8 @@ class MetalBackend(Backend):
 
             budget = max(1, MAX_THREADS_PER_BLOCK // max(1, used_threads))
             chosen = _largest_divisor_at_most(axis_size, budget)
-            config_index = env.config_spec.num_threads.block_id_to_index(block_id)
-            if num_threads[config_index] != chosen:
-                num_threads[config_index] = chosen
+            if self._record_thread_count(env, num_threads, block_id, chosen):
                 changed = True
             used_threads *= chosen
 
-        if not changed:
-            return config
-        return Config.from_dict({**config.config, "num_threads": num_threads})
+        return self._finalize_thread_config(config, num_threads, changed)

--- a/helion/_compiler/metal/metal_jit.py
+++ b/helion/_compiler/metal/metal_jit.py
@@ -56,6 +56,21 @@ class _MetalKernel:
         self._name = fn.__name__
         self.msl_source: str | None = None
         self.required_threads_per_threadgroup: tuple[int, int, int] | None = None
+        self._compiled: dict[object, tuple[object, str]] = {}
+
+    def _signature_key(self, args: tuple[object, ...]) -> tuple[object, ...]:
+        """Everything the generated MSL depends on, besides the (fixed) body.
+
+        The body AST and module globals are constant for a given generated
+        module, so only the argument shapes/dtypes, the values of non-tensor
+        (constexpr) arguments, and the launcher-supplied threadgroup size can
+        change the emitted source.
+        """
+        arg_keys = tuple(
+            (arg.dtype, arg.ndim) if isinstance(arg, torch.Tensor) else (type(arg), arg)
+            for arg in args
+        )
+        return (self.required_threads_per_threadgroup, arg_keys)
 
     def __call__(self, *args: object) -> tuple[object, str]:
         """Return (compiled_lib, kernel_name) for the launcher.
@@ -63,7 +78,15 @@ class _MetalKernel:
         Args are the kernel arguments (tensors and scalars) — used to
         infer dtypes for the MSL kernel signature.
 
+        Results are memoized: re-deriving the MSL means re-parsing the source
+        AST and re-running ``torch.mps.compile_shader``'s header embedding, a
+        few milliseconds that would otherwise be paid on every launch.
         """
+        key = self._signature_key(args)
+        cached = self._compiled.get(key)
+        if cached is not None:
+            return cached
+
         # Parse the function source to get the AST
         source = inspect.getsource(self._fn)
         source = textwrap.dedent(source)
@@ -85,7 +108,9 @@ class _MetalKernel:
 
         # Compile MSL to a Metal shader library
         lib = torch.mps.compile_shader(self.msl_source)  # type: ignore[attr-defined]
-        return lib, self._name
+        result = (lib, self._name)
+        self._compiled[key] = result
+        return result
 
 
 def _generate_msl(
@@ -145,6 +170,8 @@ def _generate_msl(
             # A host-side constexpr the launcher passes positionally (e.g. a
             # rolled reduction's ``_REDUCTION_BLOCK_*``).  ``default_metal_launcher``
             # only binds tensors as buffers, so bake the value into the shader.
+            # ``_MetalKernel._signature_key`` includes these values, so a
+            # different one recompiles rather than reusing a stale shader.
             scalar_preamble.append(f"    {_constexpr_decl(name, arg)}")
             continue
         if arg.dtype not in DTYPE_TO_METAL:

--- a/test/test_metal.py
+++ b/test/test_metal.py
@@ -2118,5 +2118,566 @@ class TestMetalReductions(unittest.TestCase):
                 self._check(row_prod, (x,), x.prod(-1), rtol=1e-2, atol=1e-2)
 
 
+# ---------------------------------------------------------------------------
+# Autotuning
+# ---------------------------------------------------------------------------
+
+#: Autotuning compiles and benchmarks each candidate inline, so keep the tests
+#: to a small budget and small tensors.
+_AUTOTUNE_KWARGS = {"autotune_effort": "quick", "autotune_budget_seconds": 5}
+
+
+@_requires_darwin
+class TestMetalAutotune(unittest.TestCase):
+    """Autotuning is enabled for Metal; these pin the plumbing it needs."""
+
+    def test_benchmark_hooks_are_batched(self) -> None:
+        from helion._compiler.metal.autotune import do_bench_metal
+        from helion._compiler.metal.autotune import interleaved_bench_metal
+        from helion._compiler.metal.backend import MetalBackend
+
+        backend = MetalBackend()
+        self.assertIs(backend.get_do_bench(), do_bench_metal)
+        self.assertIs(backend.get_interleaved_bench(), interleaved_bench_metal)
+        self.assertFalse(backend.supports_precompile())
+
+    def test_interleaved_bench_batches_each_candidate_separately(self) -> None:
+        """A cheap candidate must not be measured at an expensive one's batch.
+
+        ``_time_batch_ms`` already returns a per-call time, so a shared batch
+        equalizes nothing -- it just drags every candidate down to the slowest
+        one's batch size, which is where per-sample overhead is least
+        amortized.  One expensive candidate in the list used to collapse the
+        batch to 1 for all of them, i.e. batching switched off.
+        """
+        from helion._compiler.metal.autotune import do_bench_metal
+        from helion._compiler.metal.autotune import interleaved_bench_metal
+
+        small = torch.randn(512, 512, device=DEVICE)
+        big = torch.randn(2048, 2048, device=DEVICE)
+        cheap = lambda: small + 1.0  # noqa: E731
+        pricey = lambda: torch.mm(big, big)  # noqa: E731
+
+        truth = float(do_bench_metal(pricey)) / float(do_bench_metal(cheap))
+        t_cheap, t_pricey = interleaved_bench_metal([cheap, pricey], repeat=5)
+        measured = t_pricey / t_cheap
+
+        self.assertGreater(measured, 1.0)
+        # Generous, because the point is the order of magnitude: a shared batch
+        # reported ~1.2x where the true gap was ~7x.
+        self.assertGreater(measured, truth / 3.0)
+
+    def test_identical_candidates_measure_the_same(self) -> None:
+        """The self-test: N copies of one kernel must rank as a tie.
+
+        This needs no reference timing -- the true ratio is exactly 1 by
+        construction -- which makes it the one calibration check here that
+        cannot be undermined by a drifting baseline.  It is also a direct
+        probe of the bug this function had: sharing one batch across
+        candidates handed them different amounts of per-sample overhead, and
+        any per-candidate asymmetry (batch, position in the round) shows up
+        here as spread.
+
+        The operand size is load-bearing.  At 1024x1024 a call costs ~0.03ms, so
+        the batch saturates at ``_MAX_BATCH`` and ``repeat`` stops controlling
+        anything: every candidate is summarized from the ``_MIN_ROUNDS`` floor of
+        three samples, and the assertion becomes a coin flip on a busy machine.
+        At 4096x4096 a call is ~0.9ms, the batch lands around 22, and ``repeat``
+        buys ~18 rounds -- enough for the ``min`` to mean something.
+
+        Best of three attempts even so, because this is wall-clock on a shared
+        GPU.  The defect it exists to catch is not subtle: sharing one batch
+        across candidates mismeasured a 7.4x difference as 1.2x and collapsed one
+        candidate's batch to a single call, which fails all three attempts.
+        """
+        from helion._compiler.metal.autotune import interleaved_bench_metal
+
+        x = torch.randn(4096, 4096, device=DEVICE)
+        y = torch.randn(4096, 4096, device=DEVICE)
+        same = lambda: x + y  # noqa: E731
+
+        for count in (2, 4):
+            with self.subTest(candidates=count):
+                spreads = []
+                for _ in range(3):
+                    times = interleaved_bench_metal([same] * count, repeat=400)
+                    self.assertEqual(len(times), count)
+                    spreads.append(max(times) / min(times))
+                self.assertLess(min(spreads), 1.25, f"spreads={spreads}")
+
+    def test_interleaved_repeat_is_a_call_budget_not_a_round_count(self) -> None:
+        """``repeat`` counts calls in the shared benchmarks, not rounds.
+
+        Callers derive it as ``target_ms / per_call_ms`` and the shared
+        implementations invoke each candidate once per round.  A round here is
+        a whole batch, so spending ``repeat`` rounds overshoots the requested
+        budget by the batch size -- which is what made final-pick verification
+        take longer than the search it was verifying.
+        """
+        from helion._compiler.metal import autotune as metal_autotune
+
+        batches: list[int] = []
+
+        def spy(fn: object, batch: int) -> float:
+            batches.append(batch)
+            return 1.0
+
+        def run(repeat: int) -> int:
+            """Timed rounds for ``repeat``, with warmup and probing stubbed out."""
+            batches.clear()
+            with (
+                patch.object(metal_autotune, "_warm_up", lambda fn: None),
+                patch.object(metal_autotune, "_estimate_per_call_ms", lambda fn: 1.0),
+                patch.object(metal_autotune, "_time_batch_ms", spy),
+            ):
+                metal_autotune.interleaved_bench_metal([lambda: None], repeat=repeat)
+            return len(batches)
+
+        # 1ms per call against a 20ms sample target -> batch of 20.
+        batch = int(metal_autotune._SAMPLE_TARGET_MS)
+        self.assertEqual(run(1000), 1000 // batch)
+        self.assertEqual(set(batches), {batch})
+        # The floor applies when the budget is smaller than a single batch.
+        self.assertEqual(run(1), metal_autotune._MIN_ROUNDS)
+
+    def test_interleaved_honors_max_total_ms(self) -> None:
+        """The rebenchmark path always passes ``max_total_ms``.
+
+        ``BaseSearch.rebenchmark`` binds it via ``functools.partial``
+        before calling the backend hook, so a hook that does not accept
+        it fails every final verification with a TypeError.
+        """
+        import functools
+
+        from helion._compiler.metal import autotune as metal_autotune
+
+        batches: list[int] = []
+
+        def spy(fn: object, batch: int) -> float:
+            batches.append(batch)
+            return 1.0
+
+        def run(bench_fn: object, *args: object, **kwargs: object) -> object:
+            batches.clear()
+            with (
+                patch.object(metal_autotune, "_warm_up", lambda fn: None),
+                patch.object(metal_autotune, "_estimate_per_call_ms", lambda fn: 1.0),
+                patch.object(metal_autotune, "_time_batch_ms", spy),
+            ):
+                return bench_fn(*args, **kwargs)  # type: ignore[operator]
+
+        # 1ms per call -> batch of 20 -> 20ms per round; a 100ms budget
+        # buys 5 rounds out of the 50 that ``repeat`` alone would allow,
+        # invoked the way the caller invokes it.
+        bench = functools.partial(
+            metal_autotune.interleaved_bench_metal, max_total_ms=100.0
+        )
+        self.assertEqual(run(bench, [lambda: None], repeat=1000), [1.0])
+        self.assertEqual(len(batches), 5)
+        # No budget: the repeat-derived count stands.
+        run(metal_autotune.interleaved_bench_metal, [lambda: None], repeat=1000)
+        self.assertEqual(len(batches), 50)
+
+    def test_warmup_budget_is_spent_in_whole_batches(self) -> None:
+        """``warmup`` is a millisecond budget, like ``rep``.
+
+        It used to run ``warmup / sample_ms`` *single* calls, so it actually
+        covered ``warmup / batch`` ms -- a 25ms request bought under 3ms of
+        warmup, and the 1000ms the rebenchmark path asks for bought ~10ms.
+        """
+        from helion._compiler.metal import autotune as metal_autotune
+
+        calls = 0
+
+        def counted() -> None:
+            nonlocal calls
+            calls += 1
+
+        seen: list[int] = []
+        real_time_batch_ms = metal_autotune._time_batch_ms
+
+        def spy(fn: object, batch: int) -> float:
+            seen.append(batch)
+            return real_time_batch_ms(fn, batch)
+
+        with patch.object(metal_autotune, "_time_batch_ms", spy):
+            metal_autotune.do_bench_metal(counted, warmup=25, rep=100)
+
+        # Every timed loop -- estimate, warmup and rep -- goes through
+        # _time_batch_ms, so no call is left un-batched.
+        self.assertTrue(seen)
+        self.assertEqual(calls, sum(seen) + 1)  # +1 for the initial correctness call
+        self.assertGreater(max(seen), 1)
+
+    def test_rejects_an_unknown_return_mode(self) -> None:
+        """Summarizing is delegated to the shared fallback, so only the
+        argument check is Metal's to make."""
+        from helion._compiler.metal.autotune import do_bench_metal
+
+        with self.assertRaises(AssertionError):
+            do_bench_metal(lambda: None, return_mode="bogus")
+
+    def test_unsupported_config_is_a_search_miss_not_a_crash(self) -> None:
+        from helion._compiler.metal.backend import MetalBackend
+
+        backend = MetalBackend()
+        self.assertEqual(
+            backend.classify_autotune_exception(exc.BackendUnsupported("metal", "x")),
+            "debug",
+        )
+        self.assertEqual(
+            backend.classify_autotune_exception(SyntaxError("bad MSL")), "warn"
+        )
+        # Anything else is still one bad candidate, not a reason to stop.  With
+        # no catch-all the shared fallback is classify_triton_exception, which
+        # answers "raise" for messages it does not recognize -- and it
+        # recognizes no MPS message, so an unfamiliar driver error would kill
+        # the search.
+        self.assertEqual(
+            backend.classify_autotune_exception(RuntimeError("some MPS error")), "warn"
+        )
+        # ...but an interrupt is not a search miss.
+        self.assertIsNone(backend.classify_autotune_exception(KeyboardInterrupt()))
+
+    def test_num_threads_is_clamped_to_a_divisor_of_the_block_size(self) -> None:
+        """The shared loop strategy needs block_size % num_threads == 0.
+
+        num_threads is drawn from the tensor extent, not the chosen block size,
+        so the search space contains combinations that cannot compile. They are
+        clamped rather than skipped, which keeps the whole space usable.
+        """
+
+        @helion.kernel(
+            backend="metal",
+            configs=[helion.Config(block_sizes=[64], num_threads=[1024])],
+        )
+        def scaled_copy(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] * 2.0
+            return out
+
+        x = torch.randn(4096, device=DEVICE)
+        torch.testing.assert_close(scaled_copy(x), x * 2.0)
+        # Pin the value, not just "it compiled": the clamp picks the largest
+        # divisor of the block size that is <= the requested count, and since
+        # both are powers of two an over-large request always lands on exactly
+        # the block size.  Asserting correctness alone would pass for any legal
+        # divisor, including 1.
+        self.assertIn("_block_dims=(64, 1, 1)", scaled_copy.bind((x,)).to_code())
+
+    def test_autotuned_elementwise_1d_is_correct(self) -> None:
+        @helion.kernel(backend="metal", **_AUTOTUNE_KWARGS)
+        def vector_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + y[tile]
+            return out
+
+        x = torch.randn(8192, device=DEVICE)
+        y = torch.randn(8192, device=DEVICE)
+        torch.testing.assert_close(vector_add(x, y), x + y)
+
+    def test_autotuned_elementwise_2d_is_correct(self) -> None:
+        """2D tiling is where autotuning actually pays: the default
+        ``block_sizes=[32, 32]`` is rarely the best tile shape."""
+
+        @helion.kernel(backend="metal", **_AUTOTUNE_KWARGS)
+        def add2d(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tm, tn in hl.tile([x.size(0), x.size(1)]):
+                out[tm, tn] = x[tm, tn] + y[tm, tn]
+            return out
+
+        x = torch.randn(256, 256, device=DEVICE)
+        y = torch.randn(256, 256, device=DEVICE)
+        torch.testing.assert_close(add2d(x, y), x + y)
+
+    def test_autotuned_reduction_is_correct(self) -> None:
+        @helion.kernel(backend="metal", **_AUTOTUNE_KWARGS)
+        def row_sum(x: torch.Tensor) -> torch.Tensor:
+            n, _ = x.size()
+            out = torch.empty([n], dtype=x.dtype, device=x.device)
+            for tile_n in hl.tile(n):
+                out[tile_n] = torch.sum(x[tile_n, :], dim=-1)
+            return out
+
+        x = torch.randn(256, 512, device=DEVICE)
+        torch.testing.assert_close(row_sum(x), x.sum(-1), rtol=1e-3, atol=1e-3)
+
+    def test_autotuned_softmax_is_correct(self) -> None:
+        """Two reductions over one dimension, each with its own scratch."""
+
+        @helion.kernel(backend="metal", **_AUTOTUNE_KWARGS)
+        def softmax(x: torch.Tensor) -> torch.Tensor:
+            n, _ = x.size()
+            out = torch.empty_like(x)
+            for tile_n in hl.tile(n):
+                values = x[tile_n, :]
+                amax = torch.amax(values, dim=1, keepdim=True)
+                exp_v = torch.exp(values - amax)
+                out[tile_n, :] = exp_v / torch.sum(exp_v, dim=1, keepdim=True)
+            return out
+
+        x = torch.randn(128, 512, device=DEVICE)
+        torch.testing.assert_close(
+            softmax(x), torch.softmax(x, dim=-1), rtol=1e-3, atol=1e-3
+        )
+
+    def test_reduction_loops_is_searchable(self) -> None:
+        """The reduction span is the knob worth tuning, so it must be in the space."""
+
+        @helion.kernel(backend="metal", autotune_effort="none")
+        def row_sum(x: torch.Tensor) -> torch.Tensor:
+            n, _ = x.size()
+            out = torch.empty([n], dtype=x.dtype, device=x.device)
+            for tile_n in hl.tile(n):
+                out[tile_n] = torch.sum(x[tile_n, :], dim=-1)
+            return out
+
+        spec = row_sum.bind((torch.randn(256, 1024, device=DEVICE),)).config_spec
+        self.assertTrue(spec.reduction_loops.valid_block_ids())
+        self.assertIn("reduction_loops", spec.default_config().config)
+
+    def test_explicit_tile_threads_do_not_starve_a_reduction(self) -> None:
+        """Autotuning sets num_threads explicitly, unlike the default config.
+
+        A persistent reduction needs one live thread per element, and Metal has
+        no lane-loop fallback to cover a shortfall the way CuTe does, so a
+        tile that claims the whole threadgroup used to make the config
+        unbuildable.  The tile's thread count is capped instead.
+        """
+
+        @helion.kernel(
+            backend="metal",
+            configs=[
+                helion.Config(
+                    block_sizes=[64], num_threads=[1024], reduction_loops=[None]
+                )
+            ],
+        )
+        def row_sum(x: torch.Tensor) -> torch.Tensor:
+            n, _ = x.size()
+            out = torch.empty([n], dtype=x.dtype, device=x.device)
+            for tile_n in hl.tile(n):
+                out[tile_n] = torch.sum(x[tile_n, :], dim=-1)
+            return out
+
+        x = torch.randn(256, 1024, device=DEVICE)
+        torch.testing.assert_close(row_sum(x), x.sum(-1), rtol=1e-3, atol=1e-3)
+
+    def test_autotuned_matmul_is_correct(self) -> None:
+        """Matmul is where tuning matters most: the default 16x16x16 tile
+        badly underuses MPP's cooperative matmul."""
+
+        @helion.kernel(backend="metal", **_AUTOTUNE_KWARGS)
+        def matmul(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc
+            return out
+
+        x = torch.randn(128, 128, device=DEVICE)
+        y = torch.randn(128, 128, device=DEVICE)
+        torch.testing.assert_close(matmul(x, y), x @ y, rtol=1e-3, atol=1e-3)
+
+    def test_oversized_threadgroup_is_a_search_miss(self) -> None:
+        """An over-budget threadgroup is routine, not noteworthy.
+
+        Metal only rejects one when it builds the pipeline state, so it arrives
+        as a RuntimeError from the launcher.  It is the same category as
+        BackendUnsupported -- the config does not fit -- and it is common, so it
+        is classified alongside the other expected misses rather than warned
+        about.
+        """
+        from helion._compiler.metal.backend import MetalBackend
+        from helion._compiler.metal.backend import _is_threadgroup_too_large
+
+        backend = MetalBackend()
+        err = RuntimeError(
+            "Failed to created pipeline state object, error: Specified total "
+            "max threads per threadgroup (8192) exceeds the maximum total "
+            "threads per threadgroup supported (1024)"
+        )
+        self.assertTrue(_is_threadgroup_too_large(err))
+        self.assertFalse(_is_threadgroup_too_large(RuntimeError("unrelated")))
+
+        # The recognizer has to change the outcome, or it is dead code behind
+        # the catch-all: recognized -> "debug", unrecognized -> "warn".
+        self.assertEqual(backend.classify_autotune_exception(err), "debug")
+        self.assertEqual(
+            backend.classify_autotune_exception(RuntimeError("unrelated")), "warn"
+        )
+
+    def test_accuracy_check_guards_the_mpp_matmul(self) -> None:
+        """Matmul autotuning depends on candidate validation being on.
+
+        ``mpp::tensor_ops::matmul2d`` returns silently wrong results for
+        strongly asymmetric tiles at low ``execution_simdgroups<N>`` -- 8:1
+        needs N>=2 and 1:8 needs N>=4 on an M4 Pro -- with no compile or
+        runtime error.  That predates this backend and reproduces in plain MSL
+        with no Helion involved.  Those tile shapes are exactly what a tuner
+        reaches for on non-square problems, so the search relies on
+        ``autotune_accuracy_check`` rejecting them.
+        """
+        from helion.runtime.settings import Settings
+
+        self.assertTrue(Settings().autotune_accuracy_check)
+
+    def test_effort_none_uses_the_default_config(self) -> None:
+        @helion.kernel(backend="metal", autotune_effort="none")
+        def scaled(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] * 3.0
+            return out
+
+        x = torch.randn(1024, device=DEVICE)
+        torch.testing.assert_close(scaled(x), x * 3.0)
+        bound = scaled.bind((x,))
+        self.assertEqual(bound._config, bound.config_spec.default_config())
+
+    def test_explicit_threads_with_a_rolled_reduction_are_correct(self) -> None:
+        """Regression: this config silently returned a wrong sum.
+
+        Clamping ``num_threads`` to a divisor of the block size let configs
+        compile that the loop strategy had previously rejected.  For a *rolled*
+        reduction that was not a win: the tile then claimed enough of the
+        threadgroup that ``adjust_reduction_thread_count`` shrank the reduction
+        span below the chunk size, so each iteration reduced only the first
+        ``span`` of its 64 elements.  No error -- just a plausible wrong
+        answer.  Only the autotuner produced these, because they need an
+        explicit tile ``num_threads`` and an explicit ``reduction_loops``
+        together, which no hand-written test config combined.
+        """
+
+        @helion.kernel(
+            backend="metal",
+            configs=[
+                helion.Config(block_sizes=[32], num_threads=[256], reduction_loops=[64])
+            ],
+        )
+        def row_sum(x: torch.Tensor) -> torch.Tensor:
+            m, _ = x.size()
+            out = torch.empty([m], dtype=x.dtype, device=x.device)
+            for tm in hl.tile(m):
+                out[tm] = x[tm, :].sum(-1)
+            return out
+
+        x = torch.randn(64, 256, device=DEVICE)
+        torch.testing.assert_close(row_sum(x), x.sum(-1), rtol=3e-3, atol=3e-3)
+
+    def test_autotune_budget_bounded_restored_and_bypassed(self) -> None:
+        """The search budget defaults, passes through, and is restored.
+
+        ``autotune()`` mutates shared settings, so it must leave them as
+        found; the 300 s default must apply unless the caller sets a budget
+        or asks for full effort.  The spy stands in for the real search, so
+        this tests the settings handling without running one.
+        """
+        from typing import TYPE_CHECKING
+        from typing import Any
+
+        from helion._compiler import backend as compiler_backend
+        from helion._compiler.metal.backend import _DEFAULT_AUTOTUNE_BUDGET_SECONDS
+        from helion._compiler.metal.backend import MetalBackend
+
+        if TYPE_CHECKING:
+            from helion.runtime.config import Config
+            from helion.runtime.kernel import BoundKernel
+
+        seen: list[object] = []
+
+        def spy(
+            backend: MetalBackend,
+            bound_kernel: BoundKernel[Any],
+            *args: object,
+            **kwargs: object,
+        ) -> Config:
+            seen.append(bound_kernel.settings.autotune_budget_seconds)
+            return bound_kernel.config_spec.default_config()
+
+        x = torch.randn(1024, device=DEVICE)
+        for effort, budget, expected in [
+            ("quick", None, _DEFAULT_AUTOTUNE_BUDGET_SECONDS),
+            ("full", None, None),
+            ("quick", 7, 7),
+        ]:
+            with self.subTest(effort=effort, budget=budget):
+
+                @helion.kernel(
+                    backend="metal",
+                    autotune_effort=effort,
+                    autotune_budget_seconds=budget,
+                )
+                def scaled(x: torch.Tensor) -> torch.Tensor:
+                    out = torch.empty_like(x)
+                    for tile in hl.tile(x.size(0)):
+                        out[tile] = x[tile] * 3.0
+                    return out
+
+                bound = scaled.bind((x,))
+                seen.clear()
+                with patch.object(compiler_backend.Backend, "autotune", spy):
+                    MetalBackend().autotune(bound, (x,))
+                self.assertEqual(seen, [expected])
+                self.assertEqual(bound.settings.autotune_budget_seconds, budget)
+
+    def test_oversized_explicit_threadgroup_rejected_before_codegen(self) -> None:
+        """Explicit counts that cannot launch raise instead of compiling.
+
+        Metal refuses an oversized threadgroup only at pipeline-state build,
+        so without this pre-check the config would cost a full MSL compile
+        first.  128 (MPP) * 64 (explicit) exceeds the 1024-thread limit.
+        """
+
+        @helion.kernel(
+            backend="metal",
+            configs=[helion.Config(block_sizes=[64, 64, 32], num_threads=[32, 64])],
+        )
+        def matmul(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc
+            return out
+
+        x = torch.randn(128, 128, device=DEVICE)
+        y = torch.randn(128, 128, device=DEVICE)
+        with self.assertRaisesRegex(exc.BackendUnsupported, "threadgroup"):
+            matmul(x, y)
+
+    def test_signature_key_covers_constexpr_values(self) -> None:
+        """The shader memo must recompile when a constexpr changes.
+
+        Non-tensor launch arguments (e.g. a rolled reduction's
+        ``_REDUCTION_BLOCK_*``) are baked into the shader, so two launches
+        differing only in one must not share a compiled shader; launches
+        differing only in tensor *values* must.  Asserts the key contract
+        directly, without compiling anything.
+        """
+        from helion._compiler.metal.metal_jit import _MetalKernel
+
+        def dummy() -> None: ...
+
+        kernel = _MetalKernel(dummy)
+        x = torch.randn(16, device=DEVICE)
+        base = kernel._signature_key((x, 1024))
+        self.assertEqual(base, kernel._signature_key((torch.zeros_like(x), 1024)))
+        self.assertNotEqual(base, kernel._signature_key((x, 512)))
+        self.assertNotEqual(base, kernel._signature_key((x.to(torch.int32), 1024)))
+        kernel.required_threads_per_threadgroup = (128, 1, 1)
+        self.assertNotEqual(base, kernel._signature_key((x, 1024)))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Stacked PRs:
 * #3611
 * #3610
 * __->__#3603


--- --- ---

### [metal] Enable autotuning


Metal previously always used ``config_spec.default_config()``.  It now runs the
normal search for elementwise, reduction and matmul kernels, which matters most
for matmul: the default 16x16x16 tile barely uses MPP.

Benchmarking needed a Metal-specific implementation (``metal/autotune.py``).
The shared ``do_bench`` is Triton's CUDA-event timer and Triton is not installed
on macOS, so every candidate raised.  The wall-clock fallback does run, but
dispatching a Metal kernel from Python costs about 0.1ms against kernels that
take 0.2ms, so most of a single-call sample is overhead and configurations that
differ by 15% measure the same.  Each sample therefore times a batch of
back-to-back calls against one synchronization.  The batch is sized from a probe
taken after the kernel is warm, since a cold kernel's first dispatches run
several times slower and would fix the batch too small for everything after.

Candidates are made valid rather than left to fail:

  * ``num_threads`` is clamped to a divisor of its block size, which the shared
    loop strategy requires and the search does not guarantee.
  * Tile thread counts are capped so the reduction axes still fit, since tile
    strategies are built first and Metal has no lane loop to cover a shortfall.
  * A threadgroup that cannot launch is rejected before codegen.  Metal only
    refuses an oversized one when it builds the pipeline state, so otherwise
    such a config costs a full MSL compile first.

``classify_autotune_exception`` gains a catch-all.  Without one, an unrecognized
MPS error reaches ``classify_triton_exception``, which answers "raise" for any
message it does not know -- and it knows none of them -- so a single driver
error aborted the whole search.  Unrecognized errors now warn; an over-budget
threadgroup is an ordinary miss and is logged at debug.

Autotune runs are bounded by a default budget, since every candidate pays an
MSL compile.
