### PR TITLE
[xpu][feat] Avoid implicit CUDA device fallbacks for autodiff

### DIFF
--- a/helion/_compiler/_inductor/template_buffer.py
+++ b/helion/_compiler/_inductor/template_buffer.py
@@ -524,7 +524,11 @@ class HelionTemplateBuffer(TemplateBuffer):
     ) -> tuple[HelionTemplateBuffer, tuple[TensorBox, ...]]:
         """Build a HelionTemplateBuffer and return ``(buf, outputs)``."""
         inputs = list(realized_inputs.values())
-        dev = inputs[0].get_device() if inputs else torch.device("cuda")
+        # With no realized inputs there is no device to read off an IRNode, so
+        # fall back to the device the kernel was actually compiled for rather
+        # than assuming CUDA.
+        bound_kernel = cast("BoundKernel", buffer_kwargs["bound_kernel"])
+        dev = inputs[0].get_device() if inputs else bound_kernel.env.device
 
         mutated_nodes = [
             realized_inputs[n] for n in mutated_input_names if n in realized_inputs

--- a/helion/_compiler/_inductor/template_buffer.py
+++ b/helion/_compiler/_inductor/template_buffer.py
@@ -525,8 +525,7 @@ class HelionTemplateBuffer(TemplateBuffer):
         """Build a HelionTemplateBuffer and return ``(buf, outputs)``."""
         inputs = list(realized_inputs.values())
         # With no realized inputs there is no device to read off an IRNode, so
-        # fall back to the device the kernel was actually compiled for rather
-        # than assuming CUDA.
+        # fall back to the device the kernel was actually compiled for.
         bound_kernel = cast("BoundKernel", buffer_kwargs["bound_kernel"])
         dev = inputs[0].get_device() if inputs else bound_kernel.env.device
 

--- a/helion/autotuner/external.py
+++ b/helion/autotuner/external.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import torch
 
+from helion import exc
 from helion.autotuner.base_search import _AutotunableKernel
 from helion.autotuner.config_spec import ConfigSpec
 from helion.runtime.config import Config
@@ -79,6 +80,29 @@ class _FakeEnv:
     process_group_name: str | None = None
 
 
+def _infer_autotune_device(args: Sequence[Any]) -> torch.device:
+    """Pick the accelerator device to autotune on from the sample args.
+
+    Prefers a tensor argument that already lives on the current accelerator;
+    otherwise falls back to the current accelerator itself.  Never assumes
+    CUDA -- an external kernel may be tuned on ROCm, XPU or MPS.
+    """
+    accelerator = torch.accelerator.current_accelerator()
+    if accelerator is None:
+        raise exc.InvalidAPIUsage(
+            "no accelerator is available to autotune on; pass an explicit "
+            "`device=` to the autotuner"
+        )
+    return next(
+        (
+            arg.device
+            for arg in args
+            if isinstance(arg, torch.Tensor) and arg.device.type == accelerator.type
+        ),
+        accelerator,
+    )
+
+
 class _ExternalKernelAdapter(_AutotunableKernel):
     """Adapter making user-provided callables satisfy the ``_AutotunableKernel`` protocol.
 
@@ -102,17 +126,7 @@ class _ExternalKernelAdapter(_AutotunableKernel):
         self._compile_fn = compile_fn
         self._compile_cache: dict[Config, Callable[..., Any]] = {}
 
-        self._env = _FakeEnv(
-            device
-            or next(
-                (
-                    arg.device
-                    for arg in args
-                    if isinstance(arg, torch.Tensor) and arg.is_cuda
-                ),
-                torch.device("cuda"),
-            )
-        )
+        self._env = _FakeEnv(device or _infer_autotune_device(args))
         self._settings = Settings(**settings_kwargs)
         if baseline_fn is not None:
             self._settings.autotune_baseline_fn = baseline_fn

--- a/helion/autotuner/external.py
+++ b/helion/autotuner/external.py
@@ -84,8 +84,7 @@ def _infer_autotune_device(args: Sequence[Any]) -> torch.device:
     """Pick the accelerator device to autotune on from the sample args.
 
     Prefers a tensor argument that already lives on the current accelerator;
-    otherwise falls back to the current accelerator itself.  Never assumes
-    CUDA -- an external kernel may be tuned on ROCm, XPU or MPS.
+    otherwise falls back to the current accelerator itself.
     """
     accelerator = torch.accelerator.current_accelerator()
     if accelerator is None:

--- a/helion/experimental/autodiff.py
+++ b/helion/experimental/autodiff.py
@@ -79,6 +79,7 @@ class GraphAnalyzer:
     def __init__(
         self,
         forward_graph: torch.fx.Graph,
+        device: torch.device,
         scalar_values: dict[str, object] | None = None,
         return_order: tuple[str, ...] | None = None,
         all_graphs: list | None = None,
@@ -86,6 +87,10 @@ class GraphAnalyzer:
         kernel_input_names: list[str] | None = None,
     ) -> None:
         self.forward_graph = forward_graph
+        # Device the kernel is compiled for.  Used whenever a synthesized
+        # helper tensor (unit carry, dummy ys, materialized ``aten.full``)
+        # cannot recover a device from a node's ``meta["val"]``.
+        self.device = device
         self.scalar_values = scalar_values or {}
         # Aligns compute-graph outputs with grad_outs (return-order).
         self.return_order = return_order
@@ -1079,7 +1084,7 @@ class GraphAnalyzer:
             device = (
                 anchor_fake.device
                 if isinstance(anchor_fake, torch.Tensor)
-                else torch.device("cuda")
+                else self.device
             )
             unit = compute_graph.call_function(
                 torch.ops.aten.zeros.default,
@@ -1404,9 +1409,7 @@ class GraphAnalyzer:
                 else:
                     resolved.append(s)
             fake = n.meta.get("val")
-            dev = (
-                fake.device if isinstance(fake, torch.Tensor) else torch.device("cuda")
-            )
+            dev = fake.device if isinstance(fake, torch.Tensor) else self.device
             fn = cg.call_function(
                 torch.ops.aten.full.default,
                 (resolved, fill_value),
@@ -1737,7 +1740,7 @@ class GraphAnalyzer:
         # empty (no stores, or xs not needed for recomputation), the backward
         # scan_op call does bw_xs[0].shape[0] to get scan_length and raises
         # IndexError.  The dummy ensures bw_xs is non-empty.
-        dummy_device: object = torch.device("cuda")
+        dummy_device: object = self.device
         if carry_phs_in_cg:
             anchor_fake = carry_phs_in_cg[0].meta.get("val")
             if isinstance(anchor_fake, torch.Tensor):
@@ -5549,6 +5552,7 @@ def backward(
                 )
         analyzer = GraphAnalyzer(
             fwd_graph,
+            bound.env.device,
             scalar_values=scalar_values,
             return_order=return_order,
             all_graphs=list(graphs),

--- a/helion/experimental/autodiff.py
+++ b/helion/experimental/autodiff.py
@@ -87,9 +87,6 @@ class GraphAnalyzer:
         kernel_input_names: list[str] | None = None,
     ) -> None:
         self.forward_graph = forward_graph
-        # Device the kernel is compiled for.  Used whenever a synthesized
-        # helper tensor (unit carry, dummy ys, materialized ``aten.full``)
-        # cannot recover a device from a node's ``meta["val"]``.
         self.device = device
         self.scalar_values = scalar_values or {}
         # Aligns compute-graph outputs with grad_outs (return-order).

--- a/test/test_autodiff.py
+++ b/test/test_autodiff.py
@@ -15,7 +15,6 @@ from helion._testing import TestCase
 from helion._testing import skipIfMTIA
 from helion._testing import skipIfNotTriton
 from helion._testing import skipIfRocm
-from helion._testing import skipIfXPU
 from helion.autotuner.effort_profile import _PROFILES
 from helion.autotuner.effort_profile import AutotuneEffortProfile
 from helion.autotuner.effort_profile import DifferentialEvolutionConfig
@@ -35,7 +34,6 @@ for _utf8_locale in ("C.UTF-8", "en_US.UTF-8", "C.utf8", "en_US.utf8"):
 
 @skipIfMTIA("autodiff not tested on MTIA")
 @skipIfNotTriton("autodiff not tested on non Triton backends")
-@skipIfXPU("autodiff scan-path backward aborts in torch scan-HOP autograd on XPU")
 class TestAutodiff(RefEagerTestDisabled, TestCase):
     def _check_backward(
         self,

--- a/test/test_autodiff.py
+++ b/test/test_autodiff.py
@@ -6,6 +6,7 @@ import os
 import unittest
 from unittest.mock import patch
 
+import pytest
 import torch
 
 import helion
@@ -1337,6 +1338,8 @@ class TestAutodiff(RefEagerTestDisabled, TestCase):
             atol=1e-2,
         )
 
+    # XPU native compilation of the backward kernel can exceed the CI 60s limit.
+    @pytest.mark.timeout(180)
     def test_example_attention_non_divisible_seqlen(self):
         # Non-block-divisible sequence length: the scan zero-pads the key dim
         # and must re-apply the forward's OOB mask, else the softmax is


### PR DESCRIPTION
## Summary
This PR does the following to enable the XPU tests for autodiff:

- Make the hardcoded CUDA fallback to be device-agnostic for autodiff feature
- Use the bound kernel device to infer the correct device.
- Enable XPU tests for autodiff
