### PR TITLE
[pallas] disable flaky test_route_forward_then_local_consume

### DIFF
--- a/test/test_remote_copy.py
+++ b/test/test_remote_copy.py
@@ -1486,6 +1486,7 @@ class TestRemoteCopyJaxRuntime(TestCase):
             result[:, 1], _expected_pipeline_destination(world_size)
         )
 
+    @unittest.skip("flaky due to an in-place symmetric HBM remote-copy race")
     @skipIfPallasInterpret("remote HBM buffers require TPU DMA lowering")
     def test_route_forward_then_local_consume(self) -> None:
         import jax


### PR DESCRIPTION
Peers use the same HBM region as an outgoing source and incoming destination, which is racy: an incoming DMA can overwrite data that is still being read.

A simple solution would be to use VMEM as a bounce buffer, sync with a barrier, then do the peer transfer. But that limits the transfer size to very small chunks that fit in VMEM; a better solution, although more complex, would be to either split the big transfer into smaller chunks in VMEM, or use additional HBM for the bounce buffer.

Example of the race in CI:

```
FAILED test/test_remote_copy.py::TestRemoteCopyJaxRuntime::test_route_forward_then_local_consume - AssertionError:
Arrays are not equal

Mismatched elements: 32 / 16384 (0.195%)
First 5 mismatches are at indices:
 [1, 0, 2, 7, 32]: 5024.0 (ACTUAL), 13216.0 (DESIRED)
 [1, 0, 2, 7, 33]: 5025.0 (ACTUAL), 13217.0 (DESIRED)
 [1, 0, 2, 7, 34]: 5026.0 (ACTUAL), 13218.0 (DESIRED)
 [1, 0, 2, 7, 35]: 5027.0 (ACTUAL), 13219.0 (DESIRED)
 [1, 0, 2, 7, 36]: 5028.0 (ACTUAL), 13220.0 (DESIRED)
Max absolute difference among violations: 8192.
Max relative difference among violations: 0.61985475
 ACTUAL: array([[[[[0.0000e+00, 1.0000e+00, 2.0000e+00, ..., 1.2500e+02,
           1.2600e+02, 1.2700e+02],
          [1.2800e+02, 1.2900e+02, 1.3000e+02, ..., 2.5300e+02,...
 DESIRED: array([[[[[0.0000e+00, 1.0000e+00, 2.0000e+00, ..., 1.2500e+02,
           1.2600e+02, 1.2700e+02],
          [1.2800e+02, 1.2900e+02, 1.3000e+02, ..., 2.5300e+02,...
================== 1 failed, 13 passed, 2 warnings in 10.06s ===================
```

Given that the solution isn't trivial and I'm not too familiar with this code, I'm punting on fixing the problem and just disabling the flaky test from CI.