### PR TITLE
[AMD] Flydsl minimal reduction kernel support for one row per wavefront.

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -689,6 +689,22 @@ class Backend(abc.ABC):
         """
         return self.full_expr(shape_dims, value_expr, dtype)
 
+    def wrap_reduction_accumulator(
+        self,
+        acc_full: str,
+        *,
+        thread_count: int,
+        loop_block_size: int,
+        acc_dtype: torch.dtype,
+    ) -> str:
+        """Wrap the looped-reduction accumulator init expression, if needed.
+
+        FlyDSL's runtime scf.for carries the accumulator as an iter_arg whose init
+        type must match the per-thread vector the loop body yields, so it wraps
+        the scalar seed in ``fx.Vector.filled(...)``. Identity by default.
+        """
+        return acc_full
+
     def reshape_expr(self, expr: str, shape: str) -> str:
         raise exc.BackendUnsupported(self.name, "reshape")
 

--- a/helion/_compiler/flydsl/_codegen_modules.py
+++ b/helion/_compiler/flydsl/_codegen_modules.py
@@ -8,5 +8,6 @@ they extend.
 from __future__ import annotations
 
 from . import memory_ops  # noqa: F401
+from . import reduce_ops  # noqa: F401
 from . import tracing_ops  # noqa: F401
 from . import view_ops  # noqa: F401

--- a/helion/_compiler/flydsl/backend.py
+++ b/helion/_compiler/flydsl/backend.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 
     from ...runtime.config import Config
     from ...runtime.kernel import BoundKernel
+    from ..compile_environment import CompileEnvironment
+    from ..device_function import Argument
     from ..device_ir import GraphInfo
     from ..tile_dispatch import TileStrategyDispatch
 
@@ -30,6 +32,18 @@ if TYPE_CHECKING:
 def _flydsl_minimum_expr(a: str, b: str) -> str:
     # flydsl Vector has no ``.minimumf``; min(a,b) = -max(-a,-b).
     return f"(-((-({a})).maximumf((-({b})))))"
+
+
+def _has_user_tiled_reduction(env: CompileEnvironment) -> bool:
+    """Whether the kernel has an explicit ``hl.tile(n)`` reduction.
+
+    True when a reduction block_id lives in ``block_sizes`` (not
+    ``reduction_loops``). For these kernels every non-row block dim is a column
+    tile in the warp-per-row model (indices = offset//4 + lane), so it must be a
+    multiple of 256.
+    """
+    bs_ids = env.config_spec.block_sizes.valid_block_ids()
+    return any(info.reduction and info.block_id in bs_ids for info in env.block_sizes)
 
 
 class FlyDSLBackend(Backend):
@@ -70,6 +84,13 @@ class FlyDSLBackend(Backend):
         # and the memory-op codegen can read them directly without defaults.
         self._flydsl_num_threads: int = 64
         self._tensor_use_buffer: dict[int, bool] = {}
+        # Both reset each compile by pre_codegen. ``_needs_warp_helpers`` is set
+        # by reduction_expr when a reduction is generated, so the warp-reduce
+        # helper defs are emitted (from scalar_arg_preamble, which runs after the
+        # body) only for kernels that actually reduce -- not every kernel.
+        # ``_helpers_emitted`` then guards against emitting them more than once.
+        self._flydsl_needs_warp_helpers: bool = False
+        self._flydsl_helpers_emitted: bool = False
 
     @property
     def name(self) -> str:
@@ -115,7 +136,45 @@ class FlyDSLBackend(Backend):
         return 64
 
     def max_reduction_loop(self) -> int | None:
+        # chunk = 64 * V per pass (one 64-lane wave, V contiguous elems each);
+        # PR2 (W=1) restricts the autotuner to one-warp chunks (chunk // V == 64).
+        return 8192
+
+    @staticmethod
+    def _flydsl_looped_thread_count(config: Config, bm: int) -> int | None:
+        """thread_count for the whole-row looped reduction, else None.
+
+        PR2 is W=1 only. For bm>1 there is one warp per row, so the block has
+        64*bm threads (handled by the caller's 64*bm fallback) -> return None.
+        For bm==1 a single wavefront (64 threads) folds the row when a looped
+        reduction is active -> return 64. Returns None with no looped reduction.
+        """
+        if bm != 1:
+            return None
+        rl = config.reduction_loops
+        if not rl or rl[0] is None:
+            return None
+        # W=1: exactly one wavefront folds the whole row.
         return 64
+
+    def wrap_reduction_accumulator(
+        self,
+        acc_full: str,
+        *,
+        thread_count: int,
+        loop_block_size: int,
+        acc_dtype: torch.dtype,
+    ) -> str:
+        # flydsl's runtime scf.for carries the accumulator as an iter_arg whose
+        # init type must match the vector<Vxf32> the loop body yields. V =
+        # per-lane elements = loop chunk / thread count (identical to the
+        # redcol_vec derived in memory_ops). W=1 -> thread_count is 64.
+        # Only reached on the looped path, where thread_count is always > 0; a
+        # hard failure here is clearer than seeding V=1 and hitting a confusing
+        # downstream vector-type mismatch.
+        assert thread_count > 0, "flydsl looped reduction needs thread_count > 0"
+        vec = max(1, loop_block_size // thread_count)
+        return f"fx.Vector.filled({vec}, {acc_full}, {self.dtype_str(acc_dtype)})"
 
     @property
     def library_imports(self) -> dict[str, str]:
@@ -128,6 +187,7 @@ class FlyDSLBackend(Backend):
             "rocdl": "from flydsl.expr import rocdl",
             "gpu": "from flydsl.expr import gpu",
             "full": "from flydsl.expr.vector import full",
+            "ReductionOp": "from flydsl.expr.vector import ReductionOp",
             "helion": "import helion",
             "hl": "import helion.language as hl",
             "_default_flydsl_launcher": (
@@ -140,11 +200,15 @@ class FlyDSLBackend(Backend):
         return f"fx.block_idx.{'xyz'[dim]}"
 
     def launcher_keyword_args(self, config: Config, *, has_barrier: bool) -> list[str]:
-        # Elementwise: block = 64*bm (bm warps, one warp per row).
+        # W=1: block = 64*bm (bm warps, one warp per row). bn is pinned to 256.
         # AMD caps a workgroup at 1024 threads.
         bs = config.block_sizes
         bm = int(bs[0])
         n_threads = 64 * bm
+        # Whole-row looped reduction: threads = thread_count (W=1 -> 64).
+        _tc = self._flydsl_looped_thread_count(config, bm)
+        if _tc is not None:
+            n_threads = _tc
         if n_threads > 1024:
             raise exc.BackendUnsupported(
                 self.name, f"block too large: {n_threads} threads"
@@ -212,9 +276,16 @@ class FlyDSLBackend(Backend):
         force: bool = True,
         **kwargs: object,
     ) -> Config:
-        # Sole free knob is bm (rows/block = warps); columns are pinned to 256
-        # and bm capped at 16. FlyDSL has no precompile, so enumerate the few
-        # valid configs and FiniteSearch them in-process.
+        # W=1 search space: free knobs are bm (rows/block = warps) and, for
+        # kernels with a rollable ``:`` reduction, the reduction chunk. bn is
+        # pinned to 256 and bm capped at 16 (64*bm <= 1024) by
+        # adjust_block_size_constraints. PR2 is W=1 only: the sole looped chunk
+        # offered is the one-warp chunk (chunk // V == 64, i.e. chunk=256 at
+        # V=4) plus the persistent (None) fallback -- no V=8, no W>1 chunk
+        # growth, no constexpr_range. FlyDSL has no precompile and its JIT does
+        # not survive the subprocess benchmark workers the generic search
+        # spawns, so enumerate the few valid configs and FiniteSearch them
+        # in-process.
         from ...runtime.config import Config
 
         spec = bound_kernel.config_spec
@@ -223,20 +294,68 @@ class FlyDSLBackend(Backend):
         if not isinstance(default_bs, list) or not default_bs:
             return default
         block_sizes = [int(b) for b in default_bs]
+        ndim = len(block_sizes)
 
         row_hint = spec.block_sizes[0].size_hint if spec.block_sizes else 1
         candidates: list[Config] = []
-        seen: set[tuple[int, ...]] = set()
+        seen: set[tuple[object, ...]] = set()
+
+        rl_ids = spec.reduction_loops.valid_block_ids()
+        n_rl = len(rl_ids)
+        # W=1 chunk: one 64-lane wave x V=4 elems/thread = 256.
+        _V = 4
+        _W1_CHUNK = 64 * _V
+
+        user_tiled = _has_user_tiled_reduction(bound_kernel.env)
+        # For user-tiled reductions, pin ALL column dims to 256 in the template
+        # so every generated candidate (and the effective default) is valid.
+        if user_tiled and ndim >= 2:
+            for i in range(1, ndim):
+                block_sizes[i] = 256
+
+        # Numel of the first looped-reduction dim (used to filter OOB chunks).
+        rl_numel: int | None = None
+        if len(spec.reduction_loops):
+            rl_numel = spec.reduction_loops[0].size_hint
+
+        def _add(bs: list[int], rl: int | None) -> None:
+            # Safety: for user-tiled reductions all column dims must be multiples
+            # of 256 (one warp-pass = 64 lanes x 4 elems). Reject bad configs.
+            if user_tiled and any(b % 256 != 0 for b in bs[1:]):
+                return
+            # Safety: reject a looped chunk whose last pass OOBs the divided
+            # buffer (hardware buffer instructions fault on true OOB).
+            # NOTE: v_eff is pinned to the single V (_V = 4) used to build the
+            # candidate chunks; the fp16 V=8 follow-up (PR3) must update the
+            # candidate generation AND this OOB bound together (they are coupled).
+            if rl is not None and rl_numel is not None and rl_numel > 0:
+                v_eff = _V
+                tc = rl // v_eff
+                last_offset = ((rl_numel + rl - 1) // rl - 1) * rl
+                max_div_idx = last_offset // v_eff + tc - 1
+                n_div = (rl_numel + v_eff - 1) // v_eff
+                if max_div_idx >= n_div:
+                    return
+            key = (tuple(bs), rl)
+            if key in seen:
+                return
+            seen.add(key)
+            kw: dict[str, Any] = {"block_sizes": list(bs)}
+            if rl is not None:
+                kw["reduction_loops"] = [rl] * n_rl
+            candidates.append(Config(**kw))
+
         for bm in (1, 2, 4, 8, 16):
             if bm > max(row_hint, 1):
                 continue
             bs = list(block_sizes)
             bs[0] = bm
-            key = tuple(bs)
-            if key in seen:
-                continue
-            seen.add(key)
-            candidates.append(Config(block_sizes=list(bs)))
+            if ndim >= 2:
+                for i in range(1, ndim):
+                    bs[i] = 256
+            _add(bs, None)  # persistent
+            if rl_ids:
+                _add(bs, _W1_CHUNK)  # W=1 one-warp chunk
 
         if not candidates:
             return default
@@ -245,13 +364,39 @@ class FlyDSLBackend(Backend):
 
         # Benchmark in-process: FlyDSL's JIT/HIP-stream state does not survive
         # the precompile/benchmark subprocess workers, so disable both paths.
-        # In-place mutation of per-bind settings mirrors the base autotune().
+        # These describe a permanent flydsl capability (its JIT can NEVER use the
+        # subprocess workers), so they stay disabled for the bind -- not restored,
+        # unlike baseline_fn below. In-place mutation mirrors the base autotune().
         bound_kernel.settings.autotune_precompile = None
         bound_kernel.settings.autotune_benchmark_subprocess = False
 
+        # The default config (used as autotune baseline) may carry a
+        # reduction_loops chunk that OOBs for non-power-of-2 N; use the
+        # persistent (looped-off) config as the baseline so the accuracy check
+        # compares against a safe reference. Unlike the two settings above this is
+        # a temporary per-autotune override, so restore it in the finally so it
+        # does not leak into a later explicit compile_config on the same bind.
+        prev_baseline_fn = bound_kernel.settings.autotune_baseline_fn
+        if prev_baseline_fn is None and rl_numel is not None:
+            safe_bs = (
+                [block_sizes[0]] + ([256] * (ndim - 1))
+                if ndim >= 2
+                else [block_sizes[0]]
+            )
+            persistent_config = Config(block_sizes=safe_bs)
+            persistent_fn = bound_kernel.compile_config(
+                persistent_config, allow_print=False
+            )
+            bound_kernel.settings.autotune_baseline_fn = lambda *a, _fn=persistent_fn: (
+                _fn(*a)
+            )
+
         from ...autotuner import FiniteSearch
 
-        return FiniteSearch(bound_kernel, args, candidates).autotune()
+        try:
+            return FiniteSearch(bound_kernel, args, candidates).autotune()
+        finally:
+            bound_kernel.settings.autotune_baseline_fn = prev_baseline_fn
 
     def pre_codegen(
         self,
@@ -261,10 +406,30 @@ class FlyDSLBackend(Backend):
     ) -> None:
         from ...language import memory_ops
 
-        # Elementwise regime: block_sizes = [bm] (or [bm, 256]) -> bm rows/block,
-        # one warp (64 lanes) per row, block = 64*bm threads.
+        # Reset per-compilation state so helpers are re-emitted on each compile.
+        self._flydsl_needs_warp_helpers = False
+        self._flydsl_helpers_emitted = False
+        # W=1 regime: block_sizes = [bm] (or [bm, 256]) -> bm rows/block, one
+        # warp (64 lanes) per row, block = 64*bm threads.
         bs = config.block_sizes or [1]
         bm = int(bs[0])
+
+        # Guard: for user-tiled (explicit hl.tile(n)) reductions every column
+        # block size must be a multiple of 256 (= V*64 = one warp-pass width).
+        # The lane index formula ``offset//4 + lane`` goes OOB for any other bn.
+        # This fires for neighbor-explored configs (e.g. bn=128 from autotune)
+        # that the autotune() candidate filter cannot reject because they are
+        # generated after the candidate list is built.
+        from ..compile_environment import CompileEnvironment
+
+        _env = CompileEnvironment.current()
+        if _has_user_tiled_reduction(_env) and any(int(b) % 256 != 0 for b in bs[1:]):
+            raise exc.BackendUnsupported(
+                self.name,
+                f"explicit hl.tile(n) reduction: column block size must be a "
+                f"multiple of 256 (got block_sizes={list(bs)})",
+            )
+
         self._flydsl_num_threads = 64 * bm
 
         # Reset per-compile; every load/store tensor takes the vectorized buffer path.
@@ -322,6 +487,23 @@ class FlyDSLBackend(Backend):
         # The literal 4 is the fp16 vec width (fp16-only; fp32 needs the derived
         # width, see _flydsl_buffer_setup).
         return f"{offsets_var} = ({lid}) // 4 + fx.thread_idx.x % 64"
+
+    def range_str(self, begin: str | None, end: str, step: str | None) -> str | None:
+        # Runtime scf.for. The step may be a module-level literal variable
+        # (e.g. _REDUCTION_BLOCK_1) which scf.for materialises as an SSA value.
+        # (PR4 adds the range_constexpr register-caching path.)
+        #
+        # Invariant: flydsl reaches range_str ONLY for the whole-row rolled
+        # reduction loop (a LoopedReductionStrategy device loop); the outer grid
+        # is driven off fx.block_idx, not a range(). We therefore emit a runtime
+        # range() unconditionally, ignoring static_ranges/unroll config. This
+        # method's string-only args cannot see the loop type to assert on, so the
+        # invariant is enforced by convention today -- a range_str that keys off
+        # the loop kind lands with the second flydsl loop path (PR4).
+        args = [a for a in [begin, end] if a is not None]
+        if step and step != "1":
+            args.append(step)  # keep step as-is
+        return "range(" + ", ".join(args) + ")"
 
     def thread_in_tile_mask_expr(
         self, block_size_var: str, *, axis: int = 0
@@ -531,6 +713,100 @@ class FlyDSLBackend(Backend):
                 raise exc.BackendUnsupported(backend_name, f"op {name!r}")
 
         return FlyDSLOpOverrides()
+
+    def scalar_arg_preamble(self, arg: Argument) -> list[ast.AST]:
+        from ..ast_extension import statement_from_string
+
+        # Emit the warp-reduce helper defs once, and only for kernels that
+        # actually reduce (reduction_expr sets _needs_warp_helpers). This hook
+        # runs per scalar arg after the kernel body is generated, so the flag is
+        # already set by the time we get here; a pure-elementwise kernel leaves
+        # it False and emits nothing.
+        if self._flydsl_helpers_emitted or not self._flydsl_needs_warp_helpers:
+            return []
+        self._flydsl_helpers_emitted = True
+
+        # W=1: one warp per row -> warp shuffle covers the whole row, no smem.
+        # The 6 XOR-shuffle folds (log2 64) are unrolled here rather than emitted
+        # as a range_constexpr loop (that register-caching path lands in PR4).
+        # (The W>1 block-reduce helpers land in a follow-up PR.)
+        def _fold(step_op: str) -> str:
+            return "\n".join(
+                f"    w = {step_op.format(off=64 >> (s + 1))}" for s in range(6)
+            )
+
+        _wmax_body = _fold("w.maximumf(w.shuffle_xor({off}, 64))")
+        _wsum_body = _fold(
+            "w.addf(w.shuffle_xor({off}, 64), fastmath=arith.FastMathFlags.fast)"
+        )
+        stmts: list[ast.AST] = [
+            statement_from_string(h)
+            for h in [
+                f"def _flydsl_wmax(w):\n{_wmax_body}\n    return w",
+                f"def _flydsl_wmin(w):\n    w = -w\n{_wmax_body}\n    return -w",
+                f"def _flydsl_wsum(w):\n{_wsum_body}\n    return w",
+            ]
+        ]
+        return stmts
+
+    def reduction_combine_expr(
+        self,
+        reduction_type: str,
+        acc: str,
+        val: str,
+        dtype: torch.dtype,
+    ) -> str:
+        # Looped-reduction accumulate step. ``acc`` is a per-thread vector
+        # (wrap_reduction_accumulator seeds it as fx.Vector.filled before the
+        # loop); the freshly-loaded ``val`` goes on the LEFT so the final
+        # _flydsl_wsum/_wmax fold calls .reduce() on a vector.
+        #
+        # Both operands must share the accumulator dtype (e.g. fp16 input folded
+        # into an fp32 acc), so cast the freshly-loaded value first.
+        val = self.cast_expr(val, self.dtype_str(dtype))
+        # ``maximumf``/``minimumf`` require both operands to be the SAME vector
+        # shape. Re-broadcast acc to ``val``'s shape with ``Vector.filled_like(
+        # val, 0) + acc`` -- a shape-only zero vector plus acc -- NOT
+        # ``(val) - (val)``: a masked tail reduction feeds ``val = +/-inf``
+        # (identity from _mask_to), and ``inf - inf`` is NaN. This is a no-op when
+        # acc already matches val's shape. ``sum`` uses ``+`` directly (it
+        # promotes either way; the masked tail feeds a finite 0 identity).
+        if reduction_type == "sum":
+            return f"({val}) + ({acc})"
+        acc_bc = f"(fx.Vector.filled_like({val}, 0) + ({acc}))"
+        if reduction_type == "max":
+            return f"({val}).maximumf({acc_bc})"
+        if reduction_type == "min":
+            # flydsl Vector has no ``.minimumf``; use min(a,b) = -max(-a,-b).
+            return f"(-((-({val})).maximumf((-({acc_bc})))))"
+        raise exc.BackendUnsupported(self.name, f"reduction combine {reduction_type!r}")
+
+    def reduction_expr(
+        self,
+        input_name: str,
+        reduction_type: str,
+        dim: int,
+        *,
+        block_size_var: str | None = None,
+        threads_in_group: int | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> str:
+        # W=1: one warp per row -> warp shuffle covers the whole row, no smem.
+        # (The W>1 cross-warp block reduce lands in a follow-up PR.)
+        # The _flydsl_w{sum,max,min} helper defs these calls reference are emitted
+        # by scalar_arg_preamble (which runs after this body is generated); flag
+        # that they are needed so they are emitted only for reducing kernels.
+        if reduction_type not in ("sum", "max", "min"):
+            raise exc.BackendUnsupported(self.name, f"reduction {reduction_type!r}")
+        self._flydsl_needs_warp_helpers = True
+        # fast-math is applied to ``sum`` only, on purpose: float add is not
+        # associative and the shuffle fold reorders it, so ``fast`` authorizes
+        # that reordering; max/min are order-independent and need no flag.
+        if reduction_type == "sum":
+            return f"_flydsl_wsum({input_name}.reduce(ReductionOp.ADD, fastmath=arith.FastMathFlags.fast))"
+        if reduction_type == "max":
+            return f"_flydsl_wmax({input_name}.reduce(ReductionOp.MAX))"
+        return f"_flydsl_wmin({input_name}.reduce(ReductionOp.MIN))"
 
     def reshape_expr(self, expr: str, shape: str) -> str:
         return expr

--- a/helion/_compiler/flydsl/memory_ops.py
+++ b/helion/_compiler/flydsl/memory_ops.py
@@ -289,6 +289,41 @@ def _(state: CodegenState) -> None:
     tensor_name = state.device_function.tensor_arg(tensor).name
     use_buffer = backend._tensor_use_buffer.get(id(tensor), False)
 
+    if use_buffer and tensor.ndim == 1:
+        # Rank-1 scalar store (e.g. inv_rms[tile_m] = per-row reduced scalar):
+        # one element per row, not a vectorized column store. Slicing a rank-1
+        # memref with a 2-tuple fails the flydsl profile check, so store the
+        # scalar directly at element ``idx_expr`` of the buffer. All 64 lanes
+        # hold the same reduced value and index, so the write is idempotent.
+        row_block_id: int | None = None
+        for idx in subscript:
+            if isinstance(idx, torch.SymInt):
+                bid = env.get_block_id(idx)
+                if bid is not None:
+                    row_block_id = bid
+                    break
+        # PR2 supports only per-row reduced-scalar rank-1 stores
+        # (inv_rms[tile_m], out[tile_m]), whose subscript always carries the row
+        # tile's block id. A constant-index rank-1 store (e.g. out[0] = ...) is a
+        # scope limitation, not yet supported -- fail clearly rather than silently
+        # defaulting to block 0 and storing at the wrong offset.
+        assert row_block_id is not None, (
+            "flydsl rank-1 store supports only tiled per-row scalar stores; "
+            f"no tile block id in subscript {subscript!r}"
+        )
+        idx_expr = state.codegen.index_var(row_block_id)
+        buf = state.codegen.lift(
+            expr_from_string(f"fx.rocdl.make_buffer_tensor({tensor_name})"),
+            prefix="flydsl_buf",
+            dce=True,
+        )
+        state.add_statement(
+            statement_from_string(
+                f"fx.memref_store({{value}}, {buf.id}, {idx_expr})", value=value
+            )
+        )
+        return None
+
     if use_buffer:
         _info = _flydsl_buffer_setup(env, state, tensor, tensor_name, subscript)
         setup = _info["setup"]

--- a/helion/_compiler/flydsl/reduce_ops.py
+++ b/helion/_compiler/flydsl/reduce_ops.py
@@ -1,0 +1,39 @@
+"""FlyDSL-backend codegen for ops defined in ``helion.language.reduce_ops``.
+
+Backend-specific codegen bodies live here (not in the backend-neutral language
+module).  Importing this module runs the ``@_decorators.codegen(op, "flydsl")``
+registrations; ``_codegen_modules`` imports it so registration keeps the same
+eager timing as before.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ... import exc
+from ...language import _decorators
+from ...language.reduce_ops import _reduce
+
+if TYPE_CHECKING:
+    import ast
+
+    from ..inductor_lowering import CodegenState
+
+
+@_decorators.codegen(_reduce, "flydsl")
+def _(state: CodegenState) -> ast.AST | list[ast.AST]:
+    # ``hl.reduce`` (the explicit user-combine primitive) is not yet supported on
+    # flydsl. The whole-row reductions the flydsl kernels actually use --
+    # ``torch.sum`` / ``mean`` / ``amax`` / ``amin`` etc. -- lower through the
+    # reduction *strategy* path (see FlyDSLBackend.reduction_expr), which folds
+    # each thread's per-lane vector to a scalar before the cross-lane warp
+    # shuffle. This ``_reduce`` codegen would instead shuffle the per-thread
+    # vector directly and store a vector into a scalar slot, which crashes the
+    # AMDGPU backend ("cannot scalarize buffer.store operand"). Reject it cleanly
+    # until the vectorized per-lane fold is implemented; the standard PyTorch
+    # reductions work today and are the documented path.
+    raise exc.BackendUnsupported(
+        "flydsl",
+        "hl.reduce (use torch.sum/mean/amax/amin, which lower through the "
+        "supported reduction path)",
+    )

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -1846,6 +1846,12 @@ class LoopedReductionStrategy(ReductionStrategy):
             acc_full = backend.reduction_acc_init_expr(
                 shape_dims, constant_repr(default), acc_dtype
             )
+            acc_full = backend.wrap_reduction_accumulator(
+                acc_full,
+                thread_count=self._thread_count,
+                loop_block_size=self._loop_block_size,
+                acc_dtype=acc_dtype,
+            )
             device_loop.outer_prefix.append(
                 statement_from_string(f"{acc} = {acc_full}")
             )

--- a/test/test_flydsl_reduction.py
+++ b/test/test_flydsl_reduction.py
@@ -1,0 +1,214 @@
+"""Unit tests for the flydsl backend's W=1 whole-row reduction.
+
+Covers single-wavefront (W=1) reductions on top of the minimal elementwise
+backend: the reduction loop lowers to a runtime ``range()`` (scf.for), warp
+shuffle folds (sum/max/min), whole-row (``:``) and explicit ``hl.tile(n)``
+reductions, column-tail masking, fp32, multi-row blocks (bm>1), the persistent
+(non-looped) fallback, and autotuning over the reduction knobs.
+
+Cross-wavefront (W>1), fp16 V=8, and constexpr register-caching land in
+follow-up PRs.
+
+flydsl is AMD/ROCm-only and experimental, so the whole module is skipped when
+it is not importable.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import TestCase
+from helion._testing import code_and_output
+from helion._testing import onlyBackends
+import helion.language as hl
+
+pytest.importorskip("flydsl")
+
+
+@helion.kernel(backend="flydsl")
+def rms_norm_fwd(
+    x: torch.Tensor, weight: torch.Tensor, eps: float = 1e-5
+) -> tuple[torch.Tensor, torch.Tensor]:
+    m, n = x.size()
+    out = torch.empty_like(x)
+    inv_rms = torch.empty([m], dtype=torch.float32, device=x.device)
+    for tile_m in hl.tile(m):
+        x_tile = x[tile_m, :].to(torch.float32)
+        x_squared = x_tile * x_tile
+        mean_x_squared = torch.mean(x_squared, dim=-1)
+        inv_rms_tile = torch.rsqrt(mean_x_squared + eps)
+        normalized = x_tile * inv_rms_tile[:, None]
+        out[tile_m, :] = (normalized * weight[:].to(torch.float32)).to(out.dtype)
+        inv_rms[tile_m] = inv_rms_tile
+    return out, inv_rms.reshape(-1, 1)
+
+
+@helion.kernel(backend="flydsl")
+def softmax_decomposed(x: torch.Tensor) -> torch.Tensor:
+    n, _m = x.size()
+    out = torch.empty_like(x)
+    for tile_n in hl.tile(n):
+        values = x[tile_n, :]
+        amax = torch.amax(values, dim=1, keepdim=True)
+        exp = torch.exp(values - amax)
+        sum_exp = torch.sum(exp, dim=1, keepdim=True)
+        out[tile_n, :] = exp / sum_exp
+    return out
+
+
+@helion.kernel(backend="flydsl")
+def tiled_sum(x: torch.Tensor) -> torch.Tensor:
+    # Explicit inner-tile reduction (hl.tile(n)) rather than whole-row ``:``.
+    m, n = x.size()
+    out = torch.empty([m], dtype=torch.float32, device=x.device)
+    for tile_m in hl.tile(m):
+        acc = hl.zeros([tile_m], dtype=torch.float32)
+        for tile_n in hl.tile(n):
+            acc += x[tile_m, tile_n].to(torch.float32).sum(-1)
+        out[tile_m] = acc
+    return out
+
+
+@helion.kernel(backend="flydsl")
+def row_min(x: torch.Tensor) -> torch.Tensor:
+    # Whole-row min reduction (exercises the reduction-strategy ``min`` fold).
+    m, _n = x.size()
+    out = torch.empty([m], dtype=x.dtype, device=x.device)
+    for tile_m in hl.tile(m):
+        out[tile_m] = torch.amin(x[tile_m, :], dim=-1)
+    return out
+
+
+def _add_combine(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:  # noqa: FURB118
+    # A named combine fn is exactly what the hl.reduce primitive takes.
+    return a + b
+
+
+@helion.kernel(backend="flydsl")
+def row_hl_reduce(x: torch.Tensor) -> torch.Tensor:
+    # Explicit hl.reduce primitive (NOT the torch.* reduction path).
+    m, _n = x.size()
+    out = torch.empty([m], dtype=torch.float32, device=x.device)
+    for tile_m in hl.tile(m):
+        out[tile_m] = hl.reduce(_add_combine, x[tile_m, :].to(torch.float32), dim=-1)
+    return out
+
+
+def ref_rms(x: torch.Tensor, w: torch.Tensor, eps: float = 1e-5) -> torch.Tensor:
+    h = x.float()
+    v = h.pow(2).mean(-1, keepdim=True)
+    return (w * (h * torch.rsqrt(v + eps))).to(x.dtype)
+
+
+def ref_softmax(x: torch.Tensor) -> torch.Tensor:
+    return torch.softmax(x.float(), dim=-1).to(x.dtype)
+
+
+def _tol(dt: torch.dtype) -> dict[str, float]:
+    return (
+        {"rtol": 1e-2, "atol": 1e-2}
+        if dt == torch.float16
+        else {"rtol": 1e-4, "atol": 1e-4}
+    )
+
+
+@onlyBackends(["flydsl"])
+class TestFlydslReduction(TestCase):
+    def _rms(self, m: int, n: int, dt: torch.dtype, **cfg: object) -> str:
+        x = torch.randn(m, n, device=DEVICE, dtype=dt)
+        w = torch.randn(n, device=DEVICE, dtype=dt)
+        code, (out, _) = code_and_output(rms_norm_fwd, (x, w, 1e-5), **cfg)
+        torch.testing.assert_close(out.float(), ref_rms(x, w).float(), **_tol(dt))
+        return code
+
+    def _softmax(self, m: int, n: int, dt: torch.dtype, **cfg: object) -> str:
+        x = torch.randn(m, n, device=DEVICE, dtype=dt)
+        code, out = code_and_output(softmax_decomposed, (x,), **cfg)
+        torch.testing.assert_close(out.float(), ref_softmax(x).float(), **_tol(dt))
+        return code
+
+    def test_reduction_lowers_to_runtime_scf_for(self) -> None:
+        # The reduction loop must be a runtime range() (scf.for), not the
+        # compile-time-unrolled range_constexpr.
+        code = self._rms(8, 1024, torch.float16, block_sizes=[1], reduction_loops=[64])
+        self.assertIn("range(0, 1024", code)
+        self.assertNotIn("range_constexpr(0, 1024", code)
+
+    def test_w1_single_warp_thread_count(self) -> None:
+        # A 64-lane chunk (chunk // V == 64) keeps one warp per row: W=1.
+        code = self._rms(8, 4096, torch.float16, block_sizes=[1], reduction_loops=[256])
+        self.assertIn("_num_threads=64", code)
+
+    def test_persistent_reduction(self) -> None:
+        self._rms(8, 256, torch.float16, block_sizes=[1], reduction_loops=[None])
+
+    def test_multi_row_block(self) -> None:
+        for bm in (2, 4):
+            self._rms(16, 512, torch.float16, block_sizes=[bm], reduction_loops=[256])
+
+    def test_softmax_w1(self) -> None:
+        # Whole-row softmax with a 64-lane chunk (W=1).
+        self._softmax(8, 512, torch.float16, block_sizes=[1], reduction_loops=[256])
+
+    def test_min_reduction(self) -> None:
+        # Whole-row min fold via the reduction-strategy path (sum/max covered too).
+        x = torch.randn(8, 4096, device=DEVICE, dtype=torch.float16)
+        _, out = code_and_output(row_min, (x,), block_sizes=[1], reduction_loops=[256])
+        torch.testing.assert_close(out.float(), x.float().amin(-1))
+
+    def test_hl_reduce_unsupported(self) -> None:
+        # The explicit hl.reduce primitive is not yet supported on flydsl (its
+        # per-thread vector is shuffled directly and stored to a scalar slot,
+        # which crashes the AMDGPU backend). It must raise cleanly, not crash.
+        # torch.sum/mean/amax/amin are the supported reduction path.
+        x = torch.randn(8, 256, device=DEVICE, dtype=torch.float32)
+        with self.assertRaises(helion.exc.BackendUnsupported):
+            code_and_output(row_hl_reduce, (x,), block_sizes=[1])
+
+    def test_explicit_tile_reduction(self) -> None:
+        # Explicit hl.tile(n) reduction (N a multiple of the inner tile).
+        x = torch.randn(8, 1024, device=DEVICE, dtype=torch.float16)
+        _, out = code_and_output(tiled_sum, (x,), block_sizes=[1, 256])
+        torch.testing.assert_close(out, x.float().sum(-1), rtol=1e-2, atol=1e-1)
+
+    def test_explicit_tile_reduction_tail(self) -> None:
+        # Explicit hl.tile(n) reduction with a tail (N % inner-tile != 0): the
+        # per-element column mask on the load must drop out-of-range columns so
+        # the reduction does not sum neighbour-row data.
+        for n in (300, 700, 1000):
+            x = torch.randn(8, n, device=DEVICE, dtype=torch.float32)
+            _, out = code_and_output(tiled_sum, (x,), block_sizes=[1, 256])
+            torch.testing.assert_close(out, x.float().sum(-1), rtol=1e-3, atol=1e-3)
+
+    def test_autotune_selects_valid_config(self) -> None:
+        # The flydsl autotune enumerates (block_sizes, reduction_loops) and
+        # FiniteSearch-picks a valid, correct config.
+        x = torch.randn(8, 4096, device=DEVICE, dtype=torch.float16)
+        w = torch.randn(4096, device=DEVICE, dtype=torch.float16)
+        bk = rms_norm_fwd.bind((x, w, 1e-5))
+        cfg = bk.autotune((x, w, 1e-5), force=True)
+        self.assertIn("block_sizes", cfg.config)
+        out, _ = bk.compile_config(cfg)(x, w, 1e-5)
+        torch.testing.assert_close(
+            out.float(), ref_rms(x, w).float(), rtol=1e-2, atol=1e-2
+        )
+
+    def test_autotune_explicit_tile_reduction(self) -> None:
+        # autotune() on a kernel with an explicit hl.tile(n) inner reduction
+        # returns a valid, correct config (per-element tail masking + guarded
+        # stores make it safe).
+        x = torch.randn(8, 500, device=DEVICE, dtype=torch.float32)
+        bk = tiled_sum.bind((x,))
+        cfg = bk.autotune((x,), force=True)
+        self.assertIn("block_sizes", cfg.config)
+        out = bk.compile_config(cfg)(x)
+        torch.testing.assert_close(out, x.float().sum(-1), rtol=1e-3, atol=1e-3)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
This PR introduces support for reduction kernels to FlyDSL backend.
The support is only for reduction in a single wavefront across the column dimension and it only supports torch reduction ops; it does not support hl.reduce yet.
