### PR TITLE
[triton] Add limited torch.chunk and torch.unbind support

### DIFF
--- a/docs/api/language.md
+++ b/docs/api/language.md
@@ -263,6 +263,35 @@ The `Tile` class represents a portion of an iteration space with the following k
 
 ## View Operations
 
+### PyTorch splitting operations
+
+The Triton backend supports `torch.chunk(x, 2, dim)` for two equal chunks and
+`torch.unbind(x, dim)` when the selected dimension has size two. The Tensor
+method forms (`x.chunk(...)` and `x.unbind(...)`) are also supported. Both
+operations accept positive and negative axes and return a tuple of two tensors.
+`chunk` keeps the input rank. `unbind` removes the selected axis.
+Lowerings that require a permutation of rank-compacted tile tensors are
+currently rejected. Unbinding an already trailing dimension of size two
+remains supported with flattened tiles.
+
+The axis and the size being split must be known at compile time. Use
+`hl.specialize` before the device loop when the split size needs specialization.
+Other tile dimensions can remain symbolic. Because Triton pads
+tensor dimensions to powers of two, `chunk` requires a power-of-two split size
+of at least two. Other chunk counts, uneven chunks,
+and unbinding dimensions of other sizes raise an unsupported-configuration
+error. Other backends currently reject these device operations. These
+restrictions apply only inside device loops. Host-side calls use PyTorch
+normally.
+
+For example, for an accumulator of shape `[tile_m, 128]`:
+
+```python
+left, right = torch.chunk(acc, 2, dim=-1)  # each has shape [tile_m, 64]
+grouped = acc.reshape(tile_m, 2, 64).permute(0, 2, 1)
+left, right = grouped.unbind(dim=-1)      # same two contiguous halves
+```
+
 ### subscript()
 
 ```{eval-rst}

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -76,6 +76,7 @@ from .type_info import NestedFunctionType
 from .type_info import NumericType
 from .type_info import SequenceType
 from .type_info import StackTensorType
+from .type_info import TensorAttributeType
 from .type_info import TensorType
 from .type_info import TileIndexType
 from .type_info import TypeInfo
@@ -2622,7 +2623,14 @@ class WalkDeviceAST(NodeVisitor):
         return _CheckForIndexCalls.retry_call(func, args, kwargs)
 
     def visit_Attribute(self, node: ast.Attribute) -> object:
-        return getattr(self.visit(node.value), node.attr)
+        value = self.visit(node.value)
+        # Apply the replacement here so saved bound methods use it too.
+        assert isinstance(node, ExtendedAST)
+        if isinstance(node._type_info, TensorAttributeType) and (
+            replacement := get_device_func_replacement(getattr(torch.Tensor, node.attr))
+        ):
+            return functools.partial(replacement, value)
+        return getattr(value, node.attr)
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         self.scope[node.name] = None

--- a/helion/_compiler/triton/aten_lowering.py
+++ b/helion/_compiler/triton/aten_lowering.py
@@ -19,6 +19,7 @@ from torch._inductor.utils import triton_type
 from torch.fx.node import Node
 from torch.fx.node import map_arg
 
+from ... import exc
 from ..._utils import next_power_of_2
 from ..ast_extension import expr_from_string
 from ..ast_extension import statement_from_string
@@ -94,6 +95,18 @@ def codegen_permute(ctx: LoweringContext, node: Node) -> object:
     # pyrefly: ignore [not-iterable]
     dims = [*dims]
     assert {*dims} == {*range(len(dims))}, dims
+    input_node = node.args[0]
+    assert isinstance(input_node, Node)
+    input_val = input_node.meta["val"]
+    assert isinstance(input_val, torch.Tensor)
+    physical_rank = len(
+        ctx.cg.device_function.tile_strategy.shape_dims(input_val.shape)
+    )
+    if physical_rank != len(dims):
+        raise exc.InvalidConfig(
+            "torch.permute does not support rank-compacted tile inputs. "
+            "Disable flatten_loops for the affected tile axes."
+        )
     return expr_from_string(
         f"tl.permute({{tensor}}, {dims!r})",
         tensor=tensor,
@@ -120,11 +133,52 @@ def codegen_stack(ctx: LoweringContext, node: Node) -> object:
     idx = ctx.cg.device_function.new_var("stack_idx")
     ctx.cg.add_statement(statement_from_string(f"{idx} = tl.arange(0, {padded_size})"))
 
-    # Broadcast index to target dimension shape
-    # e.g., dim=0: [:, None, None], dim=1: [None, :, None], dim=2: [None, None, :]
-    bidx = ctx.cg.device_function.new_var("broadcast_idx")
+    # Map the logical stack axis to its position after tile compaction.
+    input_node = tensors[0]
+    assert isinstance(input_node, Node)
+    input_val = input_node.meta["val"]
+    assert isinstance(input_val, torch.Tensor)
+    output_val = node.meta["val"]
+    assert isinstance(output_val, torch.Tensor)
     assert isinstance(dim, int)
-    pattern = "[" + ", ".join(["None"] * dim + [":"] + ["None"] * max(0, 2 - dim)) + "]"
+    dim = cast("int", dim)
+    logical_rank = input_val.ndim
+    assert 0 <= dim < logical_rank + 1 or -logical_rank - 1 <= dim < 0
+    if dim < 0:
+        dim += logical_rank + 1
+    tile_strategy = ctx.cg.device_function.tile_strategy
+    input_compacted = tile_strategy._compact_shape(input_val.shape)
+    output_compacted = tile_strategy._compact_shape(output_val.shape)
+    new_axes = [
+        axis
+        for axis, compacted in enumerate(output_compacted)
+        if compacted.user_indices == [dim]
+    ]
+    shifted_input = [
+        [index if index < dim else index + 1 for index in compacted.user_indices]
+        for compacted in input_compacted
+    ]
+    remaining_output = [
+        compacted.user_indices
+        for axis, compacted in enumerate(output_compacted)
+        if axis not in new_axes
+    ]
+    if len(new_axes) != 1 or remaining_output != [*shifted_input]:
+        raise exc.UnsupportedSplitConfiguration(
+            op="torch.stack",
+            requirement="a stack axis representable by one physical dimension",
+        )
+    stack_dim = new_axes[0]
+    bidx = ctx.cg.device_function.new_var("broadcast_idx")
+    pattern = (
+        "["
+        + ", ".join(
+            ["None"] * stack_dim
+            + [":"]
+            + ["None"] * (len(output_compacted) - stack_dim - 1)
+        )
+        + "]"
+    )
     ctx.cg.add_statement(statement_from_string(f"{bidx} = {idx}{pattern}"))
 
     # Expand each input tensor along the stack dimension
@@ -132,7 +186,9 @@ def codegen_stack(ctx: LoweringContext, node: Node) -> object:
     for var, tensor in zip(expanded, tensor_asts, strict=False):
         tensor_ast = cast("ast.AST", tensor)
         ctx.cg.add_statement(
-            statement_from_string(f"{var} = tl.expand_dims({{t}}, {dim})", t=tensor_ast)
+            statement_from_string(
+                f"{var} = tl.expand_dims({{t}}, {stack_dim})", t=tensor_ast
+            )
         )
 
     # Initialize result with zeros

--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -19,6 +19,7 @@ from .. import exc
 from ..autotuner.config_fragment import ConfigSpecFragment
 from ..autotuner.config_spec import BlockSizeSpec
 from ..autotuner.config_spec import NumThreadsSpec
+from ..language._decorators import get_device_func_replacement
 from ..language._decorators import is_api_func
 from ..language.stack_tensor import StackTensor
 from ..language.tile_proxy import Tile
@@ -561,6 +562,14 @@ class TensorAttributeType(TypeInfo):
         self, args: tuple[TypeInfo, ...], kwargs: dict[str, TypeInfo], origin: Origin
     ) -> TypeInfo:
         attr = self.attr()
+        if origin.is_device() and (
+            replacement := get_device_func_replacement(getattr(torch.Tensor, attr))
+        ):
+            result = CallableType(origin, replacement).propagate_call(
+                (self.tensor, *args), kwargs, origin
+            )
+            assert result is not None
+            return result
         if attr in {"dim", "ndimension"} and not (args or kwargs):
             return TypeInfo.from_example(self.tensor.fake_value.ndim, origin)
         stride_dim_kwarg = attr == "stride" and not args and set(kwargs) == {"dim"}
@@ -795,10 +804,6 @@ class CallableType(LiteralType):
             return LiteralType(origin, None)
         if self.value in (torch.nonzero, torch.Tensor.nonzero) and origin.is_device():
             raise exc.DataDependentOutputShapeNotSupported(op_desc="torch.nonzero")
-        if self.value in (torch.chunk, torch.Tensor.chunk) and origin.is_device():
-            raise exc.UnsupportedSplitOperation(op="torch.chunk")
-        if self.value in (torch.unbind, torch.Tensor.unbind) and origin.is_device():
-            raise exc.UnsupportedSplitOperation(op="torch.unbind")
         if self.value in (torch.split, torch.Tensor.split) and origin.is_device():
             raise exc.UnsupportedSplitOperation(op="torch.split")
         if (

--- a/helion/exc.py
+++ b/helion/exc.py
@@ -412,6 +412,10 @@ class InvalidConfig(BaseError):
     message = "{}"
 
 
+class UnsupportedSplitConfiguration(InvalidConfig):
+    message = "{op} in Helion device loops requires {requirement}."
+
+
 class InductorLoweringError(BaseError):
     message = "{}"
 

--- a/helion/language/view_ops.py
+++ b/helion/language/view_ops.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import cast
 
+import sympy
 import torch
 
 from .. import exc
@@ -17,6 +18,91 @@ if TYPE_CHECKING:
     from .._compiler.inductor_lowering import CodegenState
 
 __all__ = ["join", "split", "subscript"]
+
+
+def _split_dim(tensor: torch.Tensor, dim: int, op: str) -> tuple[int, int]:
+    if type(dim) is not int or not -tensor.ndim <= dim < tensor.ndim:
+        raise exc.UnsupportedSplitConfiguration(
+            op=op, requirement="a constant dim within the input rank"
+        )
+    dim %= tensor.ndim
+    size = tensor.shape[dim]
+    if isinstance(size, torch.SymInt):
+        env = CompileEnvironment.current()
+        expr = env.specialize_expr(env.shape_env.simplify(size._sympy_()))
+        block_id = env.resolve_block_id(size)
+        if not isinstance(expr, sympy.Integer) and block_id is not None:
+            block = env.block_sizes[block_id]
+            if block.reduction:
+                # A full-axis load has a block symbol even when its logical
+                # extent is constant. Do not use the extent of a tiled axis.
+                expr = env.specialize_expr(env.shape_env.simplify(block.numel))
+        if not isinstance(expr, sympy.Integer):
+            raise exc.UnsupportedSplitConfiguration(
+                op=op, requirement="a compile-time constant split dimension size"
+            )
+        size = int(expr)
+    return dim, size
+
+
+def _unbind_two(
+    tensor: torch.Tensor, dim: int, op: str
+) -> tuple[torch.Tensor, torch.Tensor]:
+    env = CompileEnvironment.current()
+    if env.backend_name != "triton":
+        raise exc.BackendUnsupported(env.backend_name, f"{op} device lowering")
+    if dim != tensor.ndim - 1:
+        order = [i for i in range(tensor.ndim) if i != dim] + [dim]
+        tensor = tensor.permute(order)
+    return split(tensor)
+
+
+@_decorators.device_func_replacement(torch.unbind)
+@_decorators.device_func_replacement(torch.Tensor.unbind)
+def _torch_unbind(
+    input: torch.Tensor,  # noqa: A002  Match PyTorch's input keyword.
+    dim: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Lower a size-two unbind to a permutation and hl.split."""
+    dim, size = _split_dim(input, dim, "torch.unbind")
+    if size != 2:
+        raise exc.UnsupportedSplitConfiguration(
+            op="torch.unbind", requirement="a split dimension of size 2"
+        )
+    shape = list(input.shape)
+    shape[dim] = size
+    return _unbind_two(input.reshape(shape), dim, "torch.unbind")
+
+
+@_decorators.device_func_replacement(torch.chunk)
+@_decorators.device_func_replacement(torch.Tensor.chunk)
+def _torch_chunk(
+    input: torch.Tensor,  # noqa: A002  Match PyTorch's input keyword.
+    chunks: int,
+    dim: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Lower two equal, contiguous chunks through a size-two unbind."""
+    if type(chunks) is not int or chunks != 2:
+        raise exc.UnsupportedSplitConfiguration(
+            op="torch.chunk", requirement="chunks=2"
+        )
+    dim, size = _split_dim(input, dim, "torch.chunk")
+    if size == 0 or size % 2:
+        raise exc.UnsupportedSplitConfiguration(
+            op="torch.chunk", requirement="a positive even split dimension size"
+        )
+    if CompileEnvironment.current().backend.pad_factory_tensors_to_power_of_2 and (
+        size & (size - 1)
+    ):
+        # Reshaping a padded axis into [2, size // 2] would split at the
+        # padded midpoint instead of the logical midpoint.
+        raise exc.UnsupportedSplitConfiguration(
+            op="torch.chunk",
+            requirement="a power-of-two split dimension size on this backend",
+        )
+    shape = list(input.shape)
+    shape[dim : dim + 1] = [2, size // 2]
+    return _unbind_two(input.reshape(shape), dim, "torch.chunk")
 
 
 @_decorators.api(tiles_as_sizes=True)

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -12,10 +12,12 @@ from helion._testing import RefEagerTestDisabled
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion._testing import skipIfNotTriton
 from helion.autotuner.base_search import PopulationBasedSearch
 from helion.autotuner.base_search import PopulationMember
 from helion.autotuner.differential_evolution import DifferentialEvolutionSearch
 from helion.autotuner.external import _FakeEnv
+from helion.autotuner.finite_search import FiniteSearch
 from helion.exc import InvalidConfig
 import helion.language as hl
 from helion.runtime.settings import _get_backend
@@ -345,73 +347,178 @@ class TestErrors(RefEagerTestDisabled, TestCase):
                 torch_nonzero_in_device_code, (torch.randn(2, 2, device=DEVICE),)
             )
 
-    def test_torch_chunk_device_error(self):
-        """Test that torch.chunk raises error in device loops and suggests hl.split()."""
-
+    @skipIfNotTriton("torch.chunk lowering is Triton-only")
+    def test_torch_chunk_unsupported_configuration(self):
         @helion.kernel(autotune_effort="none", static_shapes=True)
-        def kernel_with_chunk(q: torch.Tensor) -> torch.Tensor:
-            _, _, M, D = q.shape
-            D = hl.specialize(D)
-            M = hl.specialize(M)
-            q = q.reshape(-1, D)
-            total_rows = q.shape[0]
-            block_m = hl.register_block_size(M)
-            result = hl.zeros([total_rows, D])
-            for tile_m in hl.tile(total_rows, block_size=block_m):
-                acc = hl.zeros([tile_m, D])
+        def fn(
+            x: torch.Tensor,
+            chunks: hl.constexpr,
+            dim: hl.constexpr,
+            use_method: hl.constexpr,
+        ) -> torch.Tensor:
+            n, d = x.shape
+            out = torch.empty_like(x)
+            for tile in hl.tile(n):
+                values = hl.zeros([tile, d])
+                if use_method:
+                    a, b = values.chunk(chunks, dim=dim)
+                else:
+                    a, b = torch.chunk(values, chunks, dim=dim)
+                out[tile, :] = values + a.sum() + b.sum()
+            return out
 
-                for _tile_n in hl.tile(M, block_size=block_m):
-                    acc = torch.stack(torch.chunk(acc, 2, dim=-1), dim=-2).reshape(
-                        acc.shape
-                    )
-                    acc = acc + 0
+        cases = [
+            (64, 3, -1, "chunks=2"),
+            (64, 1, -1, "chunks=2"),
+            (64, 0, -1, "chunks=2"),
+            (64, True, -1, "chunks=2"),
+            (5, 2, -1, "positive even"),
+            (0, 2, -1, "positive even"),
+            (6, 2, -1, "power-of-two"),
+            (64, 2, 2, "constant dim"),
+            (64, 2, -3, "constant dim"),
+            (64, 2, True, "constant dim"),
+            (64, 2, 0, "compile-time constant"),
+        ]
+        for d, chunks, dim, message in cases:
+            x = torch.empty((65, d), device=DEVICE)
+            for use_method in (False, True):
+                with (
+                    self.subTest(d=d, chunks=chunks, dim=dim, use_method=use_method),
+                    self.assertRaisesRegex(
+                        helion.exc.UnsupportedSplitConfiguration, message
+                    ),
+                ):
+                    fn.bind((x, chunks, dim, use_method))
 
-                result[tile_m, :] = acc
-
-            return result
-
-        with self.assertRaisesRegex(
-            helion.exc.UnsupportedSplitOperation,
-            r"torch\.chunk is not supported in Helion device loops.*hl\.split\(\)",
-        ):
-            code_and_output(
-                kernel_with_chunk,
-                (torch.randn(1, 1, 128, 128, device=DEVICE, dtype=torch.bfloat16),),
-            )
-
-    def test_torch_unbind_device_error(self):
-        """Test that torch.unbind raises error in device loops and suggests hl.split()."""
-
+    @skipIfNotTriton("torch.unbind lowering is Triton-only")
+    def test_torch_unbind_unsupported_configuration(self):
         @helion.kernel(autotune_effort="none", static_shapes=True)
-        def kernel_with_unbind(q: torch.Tensor) -> torch.Tensor:
-            _, _, M, D = q.shape
-            D = hl.specialize(D)
-            M = hl.specialize(M)
-            q = q.reshape(-1, D)
-            total_rows = q.shape[0]
-            block_m = hl.register_block_size(M)
-            result = hl.zeros([total_rows, D])
-            for tile_m in hl.tile(total_rows, block_size=block_m):
-                acc = hl.zeros([tile_m, D])
+        def fn(
+            x: torch.Tensor, dim: hl.constexpr, use_method: hl.constexpr
+        ) -> torch.Tensor:
+            n, d = x.shape
+            out = torch.empty_like(x)
+            for tile in hl.tile(n):
+                values = hl.zeros([tile, d])
+                if use_method:
+                    a, b = values.unbind(dim=dim)
+                else:
+                    a, b = torch.unbind(values, dim=dim)
+                out[tile, :] = values + a.sum() + b.sum()
+            return out
 
-                for _tile_n in hl.tile(M, block_size=block_m):
-                    reshaped = acc.reshape(tile_m, 2, D // 2)
-                    acc0, acc1 = torch.unbind(reshaped, dim=1)
-                    acc = torch.stack((acc0, acc1), dim=1).reshape(tile_m, D)
-                    acc = acc + 0
-
-                result[tile_m, :] = acc
-
-            return result
-
-        with self.assertRaisesRegex(
-            helion.exc.UnsupportedSplitOperation,
-            r"torch\.unbind is not supported in Helion device loops.*hl\.split\(\)",
+        for d, dim, message in (
+            (3, -1, "size 2"),
+            (1, -1, "size 2"),
+            (0, -1, "size 2"),
+            (2, 2, "constant dim"),
+            (2, -3, "constant dim"),
+            (2, True, "constant dim"),
+            (2, 0, "compile-time constant"),
         ):
-            code_and_output(
-                kernel_with_unbind,
-                (torch.randn(1, 1, 128, 128, device=DEVICE, dtype=torch.bfloat16),),
-            )
+            x = torch.empty((65, d), device=DEVICE)
+            for use_method in (False, True):
+                with (
+                    self.subTest(d=d, dim=dim, use_method=use_method),
+                    self.assertRaisesRegex(
+                        helion.exc.UnsupportedSplitConfiguration, message
+                    ),
+                ):
+                    fn.bind((x, dim, use_method))
+
+    @onlyBackends(["cute"])
+    def test_torch_chunk_unbind_unsupported_backend(self):
+        @helion.kernel(autotune_effort="none", static_shapes=True)
+        def fn(
+            x: torch.Tensor, use_chunk: hl.constexpr, use_method: hl.constexpr
+        ) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                values = hl.zeros([tile, 2])
+                if use_chunk:
+                    if use_method:
+                        a, b = values.chunk(2, dim=-1)
+                    else:
+                        a, b = torch.chunk(values, 2, dim=-1)
+                else:
+                    if use_method:
+                        a, b = values.unbind(dim=-1)
+                    else:
+                        a, b = torch.unbind(values, dim=-1)
+                out[tile, :] = values + a.sum() + b.sum()
+            return out
+
+        x = torch.empty((32, 2), device=DEVICE)
+        for use_chunk in (False, True):
+            for use_method in (False, True):
+                with (
+                    self.subTest(use_chunk=use_chunk, use_method=use_method),
+                    self.assertRaisesRegex(
+                        helion.exc.BackendUnsupported, "device lowering"
+                    ),
+                ):
+                    fn.bind((x, use_chunk, use_method))
+
+    @onlyBackends(["triton"])
+    @skipIfNotTriton("torch.chunk lowering is Triton-only")
+    def test_torch_chunk_unbind_reject_flattened_multi_axis_tiles(self):
+        @helion.kernel(autotune_effort="none", static_shapes=True)
+        def chunk_fn(x: torch.Tensor) -> torch.Tensor:
+            m, n, d = x.shape
+            out = torch.empty((m, n, d // 2), device=x.device, dtype=x.dtype)
+            for tile_m, tile_n in hl.tile([m, n]):
+                left, right = torch.chunk(x[tile_m, tile_n, :], 2, dim=-1)
+                out[tile_m, tile_n, :] = left + 2 * right
+            return out
+
+        x = torch.empty((4, 8, 64), device=DEVICE)
+        with self.assertRaisesRegex(
+            helion.exc.InvalidConfig,
+            "torch.permute does not support rank-compacted tile inputs",
+        ):
+            code_and_output(chunk_fn, (x,), block_sizes=[2, 8], flatten_loops=[True])
+
+    @onlyBackends(["triton"])
+    @skipIfNotTriton("torch.chunk lowering is Triton-only")
+    def test_torch_chunk_autotune_skips_flattened_candidate(self):
+        @helion.kernel(
+            static_shapes=True,
+            autotune_effort="none",
+            configs=[
+                helion.Config(block_sizes=[2, 8], flatten_loops=[True]),
+                helion.Config(block_sizes=[2, 8], flatten_loops=[False]),
+            ],
+        )
+        def chunk_fn(x: torch.Tensor) -> torch.Tensor:
+            m, n, d = x.shape
+            out = torch.empty((m, n, d // 2), device=x.device, dtype=x.dtype)
+            for tile_m, tile_n in hl.tile([m, n]):
+                left, right = torch.chunk(x[tile_m, tile_n, :], 2, dim=-1)
+                out[tile_m, tile_n, :] = left + 2 * right
+            return out
+
+        x = torch.arange(4 * 8 * 64, device=DEVICE, dtype=torch.float32).reshape(
+            4, 8, 64
+        )
+        bound = chunk_fn.bind((x,))
+        compiled_configs: list[helion.Config] = []
+        original_compile_config = bound.compile_config
+
+        def compile_config(config, **kwargs):
+            compiled_configs.append(config)
+            return original_compile_config(config, **kwargs)
+
+        with mock.patch.object(bound, "compile_config", side_effect=compile_config):
+            search = FiniteSearch(bound, (x,), configs=chunk_fn.configs)
+            best = search.autotune()
+
+        result = bound.compile_config(best)(x)
+        expected = x[..., :32] + 2 * x[..., 32:]
+        torch.testing.assert_close(result, expected)
+        self.assertIn(chunk_fn.configs[0], compiled_configs)
+        self.assertIn(chunk_fn.configs[1], compiled_configs)
+        self.assertFalse(best.flatten_loops[0])
 
     def test_torch_split_device_error(self):
         """Test that torch.split raises error in device loops and suggests hl.split()."""

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -12,6 +12,7 @@ from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion._testing import skipIfNotTriton
 from helion._testing import skipIfRefEager
 from helion._testing import skipUnlessTensorDescriptor
 from helion._testing import xfailIfPallas
@@ -216,6 +217,208 @@ class TestViews(RefEagerTestBase, TestCase):
         if _get_backend() == "triton":
             self.assertIn("tl.split", code)
             self.assertIn("tl.join", code)
+
+    @onlyBackends(["triton"])
+    @skipIfNotTriton("torch.chunk lowering is Triton-only")
+    def test_torch_chunk_two(self):
+        @helion.kernel(autotune_effort="none")
+        def fn(
+            x: torch.Tensor, use_method: hl.constexpr
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            n, d = x.shape
+            d = hl.specialize(d)
+            lo = x.new_empty((n, d // 2))
+            hi = torch.empty_like(lo)
+            for tile in hl.tile(n):
+                values = x[tile, :]
+                if use_method:
+                    a, b = values.chunk(2, dim=-1)
+                else:
+                    a, b = torch.chunk(input=values, chunks=2, dim=1)
+                lo[tile, :] = a
+                hi[tile, :] = b
+            return lo, hi
+
+        for d in (64, 128):
+            x = torch.arange(65 * d, device=DEVICE, dtype=torch.float32).reshape(65, d)
+            expected = torch.chunk(x, 2, dim=-1)
+            for use_method in (False, True):
+                with self.subTest(d=d, use_method=use_method):
+                    code, result = code_and_output(
+                        fn, (x, use_method), block_sizes=[32]
+                    )
+                    torch.testing.assert_close(result, expected)
+                    if _get_backend() == "triton":
+                        self.assertIn("tl.split", code)
+
+    @onlyBackends(["triton"])
+    @skipIfNotTriton("torch.unbind lowering is Triton-only")
+    def test_torch_unbind_two(self):
+        @helion.kernel(autotune_effort="none")
+        def fn(
+            x: torch.Tensor, use_method: hl.constexpr
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            n, d = x.shape
+            d = hl.specialize(d)
+            lo = x.new_empty((n, d // 2))
+            hi = torch.empty_like(lo)
+            for tile in hl.tile(n):
+                values = x[tile, :].reshape(tile, 2, d // 2)
+                if use_method:
+                    permuted = values.permute(0, 2, 1)
+                    # Exercise a saved bound method as well as a direct call.
+                    unbind = permuted.unbind
+                    a, b = unbind(dim=-1)
+                else:
+                    a, b = torch.unbind(input=values, dim=1)
+                lo[tile, :] = a
+                hi[tile, :] = b
+            return lo, hi
+
+        for d in (64, 128):
+            x = torch.arange(65 * d, device=DEVICE, dtype=torch.float32).reshape(65, d)
+            expected = torch.unbind(x.reshape(65, 2, d // 2), dim=1)
+            for use_method in (False, True):
+                with self.subTest(d=d, use_method=use_method):
+                    _code, result = code_and_output(
+                        fn, (x, use_method), block_sizes=[32]
+                    )
+                    torch.testing.assert_close(result, expected)
+
+    @onlyBackends(["triton"])
+    @skipIfNotTriton("torch.chunk and torch.unbind lowering is Triton-only")
+    def test_torch_chunk_unbind_accumulator(self):
+        @helion.kernel(autotune_effort="none", static_shapes=True)
+        def fn(x: torch.Tensor, use_unbind: hl.constexpr) -> torch.Tensor:
+            n, d = x.shape
+            out = torch.empty_like(x)
+            for tile in hl.tile(n):
+                acc = hl.zeros([tile, d])
+                for _step in hl.tile(2, block_size=1):
+                    acc = acc + x[tile, :]
+                    if use_unbind:
+                        grouped = acc.reshape(tile, 2, d // 2).permute(0, 2, 1)
+                        a, b = grouped.unbind(dim=-1)
+                    else:
+                        a, b = torch.chunk(acc, 2, dim=-1)
+                    acc = torch.stack((a * 2, b * 3), dim=-2).reshape(tile, d)
+                out[tile, :] = acc
+            return out
+
+        x = torch.arange(65 * 64, device=DEVICE, dtype=torch.float32).reshape(65, 64)
+        left, right = torch.chunk(x, 2, dim=-1)
+        expected = torch.cat((left * 6, right * 12), dim=-1)
+        for use_unbind in (False, True):
+            with self.subTest(use_unbind=use_unbind):
+                _code, result = code_and_output(fn, (x, use_unbind), block_sizes=[32])
+                torch.testing.assert_close(result, expected)
+
+    @onlyBackends(["triton"])
+    @skipIfNotTriton("torch.chunk and torch.unbind lowering is Triton-only")
+    def test_torch_chunk_unbind_axes(self):
+        @helion.kernel(autotune_effort="none")
+        def fn(
+            x: torch.Tensor, leading_axis: hl.constexpr
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            n, d, k = x.shape
+            d, k = hl.specialize((d, k))
+            lo = x.new_empty((n, d // 2, k))
+            hi = torch.empty_like(lo)
+            for tile in hl.tile(n):
+                values = x[tile, :, :].reshape(tile, d, k)
+                if leading_axis:
+                    # Default dim=0 and the unbound Tensor method form.
+                    transposed = values.permute(1, 0, 2)
+                    left, right = torch.Tensor.chunk(transposed, 2)
+                    a = left.permute(1, 0, 2)
+                    b = right.permute(1, 0, 2)
+                else:
+                    a, b = values.chunk(2, dim=-2)
+                grouped = torch.stack((a, b), dim=0)
+                c, e = grouped.unbind()
+                lo[tile, :, :] = c
+                hi[tile, :, :] = e
+            return lo, hi
+
+        x = torch.arange(65 * 8 * 4, device=DEVICE, dtype=torch.float32).reshape(
+            65, 8, 4
+        )
+        expected = torch.chunk(x, 2, dim=1)
+        for leading_axis in (False, True):
+            with self.subTest(leading_axis=leading_axis):
+                _code, result = code_and_output(fn, (x, leading_axis), block_sizes=[32])
+                torch.testing.assert_close(result, expected)
+
+    @onlyBackends(["triton"])
+    @skipIfNotTriton("torch.unbind lowering is Triton-only")
+    def test_torch_unbind_stack_flattened_tiles(self):
+        @helion.kernel(autotune_effort="none", static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            m, n, _ = x.shape
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile([m, n]):
+                left, right = torch.unbind(x[tile_m, tile_n, :], dim=-1)
+                out[tile_m, tile_n, :] = torch.stack((right, left), dim=-1)
+            return out
+
+        x = torch.arange(4 * 8 * 2, device=DEVICE, dtype=torch.float32).reshape(4, 8, 2)
+        _code, result = code_and_output(
+            fn, (x,), block_sizes=[2, 8], flatten_loops=[True]
+        )
+        torch.testing.assert_close(result, x.flip(-1))
+
+    @onlyBackends(["triton"])
+    def test_torch_stack_flattened_tiles_dim_zero(self):
+        @helion.kernel(autotune_effort="none", static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.shape
+            out = torch.empty((2, m, n), device=x.device, dtype=x.dtype)
+            for tile_m, tile_n in hl.tile([m, n]):
+                values = x[tile_m, tile_n]
+                out[:, tile_m, tile_n] = torch.stack((values, values + 1), dim=0)
+            return out
+
+        x = torch.arange(4 * 8, device=DEVICE, dtype=torch.float32).reshape(4, 8)
+        _code, result = code_and_output(
+            fn, (x,), block_sizes=[2, 8], flatten_loops=[True]
+        )
+        torch.testing.assert_close(result, torch.stack((x, x + 1), dim=0))
+
+    @onlyBackends(["triton"])
+    @skipIfNotTriton("torch.chunk and torch.unbind lowering is Triton-only")
+    def test_torch_chunk_unbind_dot_accumulator(self):
+        @helion.kernel(autotune_effort="none", static_shapes=True)
+        def fn(
+            x: torch.Tensor, weight: torch.Tensor, use_unbind: hl.constexpr
+        ) -> torch.Tensor:
+            n, k = x.shape
+            d = weight.size(1)
+            out = x.new_empty((n, d), dtype=torch.float32)
+            for tile in hl.tile(n):
+                acc = hl.zeros([tile, d])
+                for tile_k in hl.tile(k, block_size=16):
+                    acc = hl.dot(x[tile, tile_k], weight[tile_k, :], acc=acc)
+                    if use_unbind:
+                        grouped = acc.reshape(tile, 2, d // 2).permute(0, 2, 1)
+                        a, b = grouped.unbind(dim=-1)
+                    else:
+                        a, b = torch.chunk(acc, 2, dim=-1)
+                    acc = torch.stack((a * 2, b * 3), dim=-2).reshape(tile, d)
+                out[tile, :] = acc
+            return out
+
+        x = torch.randn((65, 32), device=DEVICE, dtype=torch.float16)
+        weight = torch.randn((32, 64), device=DEVICE, dtype=torch.float16)
+        scale = torch.tensor([2.0] * 32 + [3.0] * 32, device=DEVICE)
+        first = x[:, :16].float() @ weight[:16, :].float()
+        second = x[:, 16:].float() @ weight[16:, :].float()
+        expected = (first * scale + second) * scale
+        for use_unbind in (False, True):
+            with self.subTest(use_unbind=use_unbind):
+                _code, result = code_and_output(
+                    fn, (x, weight, use_unbind), block_sizes=[32]
+                )
+                torch.testing.assert_close(result, expected, rtol=1e-3, atol=1e-3)
 
     def test_join_broadcast_scalar(self):
         @helion.kernel(config={"block_size": 64})


### PR DESCRIPTION
Partially addresses #901.

### Summary

Add support for two-way `torch.chunk` and size-two `torch.unbind` in Triton device loops, including Tensor method forms and saved bound methods. This allows the splitting patterns in #901 to use the PyTorch APIs instead of manually rewriting them with `hl.split`.

Both operations decompose into existing reshape/permute operations and `hl.split`, without introducing new backend primitives. Chunking separates contiguous halves, while unbinding removes the selected dimension.

Also fix `torch.stack` codegen to map the logical insertion axis to the physical axis after tile compaction. This supports round trips such as trailing size-two unbind followed by stack on flattened tiles. Permutations whose logical and physical ranks differ are explicitly rejected during codegen.

For an accumulator with shape `[tile_m, 128]`:

```python
left, right = torch.chunk(acc, 2, dim=-1)  # two [tile_m, 64] tensors

grouped = acc.reshape(tile_m, 2, 64).permute(0, 2, 1)
left, right = grouped.unbind(dim=-1)      # the same contiguous halves
```

### Limitations

- Triton only. The selected axis and its extent must be known at compile time; unrelated tile dimensions can remain symbolic. Positive and negative axes are supported.
- `chunk` requires `chunks=2` and a power-of-two split extent of at least two. `unbind` requires a split extent of exactly two. Other configurations are rejected.
- Lowerings that require permuting rank-compacted tile tensors remain unsupported. Trailing size-two unbind does not require that permutation and can be combined with supported stack operations on flattened tiles.

Host-side calls retain normal PyTorch behavior.

### Testing

Ran the targeted tests with Python 3.12.14:

```bash
HELION_BACKEND=triton python -m pytest \
    test/test_views.py test/test_errors.py \
    -k "torch_chunk or torch_unbind or torch_stack_flattened_tiles" \
    -x -vv
```

Result: 11 passed, 1 skipped, 64 deselected, 50 subtests passed in 16.45s.

This covers function and Tensor method forms, axis handling, loop-carried
and dot accumulators, flattened unbind/stack round trips, and skipping
an invalid flattened candidate during autotuning.

The CuTe-only rejection test was skipped because the selected backend
was Triton. The autotune test emitted one multiprocessing `fork()`
deprecation warning.